### PR TITLE
RI-6868 - storing the connections per database - POC for feedback

### DIFF
--- a/redisinsight/api/config/ormconfig.ts
+++ b/redisinsight/api/config/ormconfig.ts
@@ -22,6 +22,7 @@ import { CloudCapiKeyEntity } from 'src/modules/cloud/capi-key/entity/cloud-capi
 import { RdiEntity } from 'src/modules/rdi/entities/rdi.entity';
 import { AiQueryMessageEntity } from 'src/modules/ai/query/entities/ai-query.message.entity';
 import { CloudSessionEntity } from 'src/modules/cloud/session/entities/cloud.session.entity';
+import { MicrosoftAuthEntity } from 'src/modules/auth/microsoft-auth/entities/microsoft-auth.entity';
 import migrations from '../migration';
 import * as config from '../src/utils/config';
 
@@ -54,6 +55,7 @@ const ormConfig = {
     RdiEntity,
     AiQueryMessageEntity,
     CloudSessionEntity,
+    MicrosoftAuthEntity,
   ],
   migrations,
 };

--- a/redisinsight/api/migration/1739636593872-MicrosoftAzureAuth.ts
+++ b/redisinsight/api/migration/1739636593872-MicrosoftAzureAuth.ts
@@ -4,7 +4,18 @@ export class MicrosoftAzureAuth1739636593872 implements MigrationInterface {
     name = 'MicrosoftAzureAuth1739636593872'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "microsoft_auth_session" ("id" varchar PRIMARY KEY NOT NULL, "data" varchar, "encryption" varchar)`);
+        await queryRunner.query(`
+            CREATE TABLE "microsoft_auth_session" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "token_cache" text,
+                "username" varchar,
+                "account_id" varchar,
+                "tenant_id" varchar,
+                "display_name" varchar,
+                "last_updated" bigint,
+                "encryption" varchar
+            )
+        `);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/redisinsight/api/src/app.module.ts
+++ b/redisinsight/api/src/app.module.ts
@@ -37,6 +37,7 @@ import XFrameOptionsMiddleware from './middleware/x-frame-options.middleware';
 import { routes } from './app.routes';
 import { RedisConnectionMiddleware, redisConnectionControllers } from './middleware/redis-connection';
 import { AzureModule } from './modules/azure/azure.module'
+import { MicrosoftAuthModule } from './modules/auth/microsoft-auth/microsoft-azure-auth.module';
 
 const SERVER_CONFIG = config.get('server') as Config['server'];
 const PATH_CONFIG = config.get('dir_path') as Config['dir_path'];
@@ -75,6 +76,7 @@ const STATICS_CONFIG = config.get('statics') as Config['statics'];
     }),
     InitModule.register([AutodiscoveryModule, AnalyticsModule]),
     AzureModule,
+    MicrosoftAuthModule,
   ],
   controllers: [],
   providers: [],

--- a/redisinsight/api/src/middleware/redis-connection/redis-connection.middleware.ts
+++ b/redisinsight/api/src/middleware/redis-connection/redis-connection.middleware.ts
@@ -4,19 +4,37 @@ import {
   Logger,
   NestMiddleware,
   NotFoundException,
+  OnModuleInit,
 } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 import { NextFunction, Request, Response } from 'express';
 import ERROR_MESSAGES from 'src/constants/error-messages';
+import { RedisErrorCodes } from 'src/constants';
 import { DatabaseService } from 'src/modules/database/database.service';
+import { plainToClass } from 'class-transformer';
 import { sessionMetadataFromRequest } from 'src/common/decorators';
+import { Database } from 'src/modules/database/models/database';
+import { MicrosoftAuthService } from 'src/modules/auth/microsoft-auth/microsoft-azure-auth.service';
 
 @Injectable()
-export class RedisConnectionMiddleware implements NestMiddleware {
+export class RedisConnectionMiddleware implements NestMiddleware, OnModuleInit {
   private logger = new Logger('RedisConnectionMiddleware');
+  private microsoftAuthService: MicrosoftAuthService;
 
   constructor(
     private databaseService: DatabaseService,
+    private moduleRef: ModuleRef,
   ) {}
+
+  async onModuleInit() {
+    try {
+      // Get MicrosoftAuthService dynamically to avoid circular dependencies
+      // TODO: Review after PR!
+      this.microsoftAuthService = this.moduleRef.get(MicrosoftAuthService, { strict: false });
+    } catch (error) {
+      this.logger.error('RedisConnectionMiddleware - Failed to get MicrosoftAuthService');
+    }
+  }
 
   async use(req: Request, res: Response, next: NextFunction): Promise<any> {
     const { instanceIdFromReq } = RedisConnectionMiddleware.getConnectionConfigFromReq(req);
@@ -29,6 +47,30 @@ export class RedisConnectionMiddleware implements NestMiddleware {
     const existDatabaseInstance = await this.databaseService.exists(sessionMetadata, instanceIdFromReq);
     if (!existDatabaseInstance) {
       throw new NotFoundException(ERROR_MESSAGES.INVALID_DATABASE_INSTANCE_ID);
+    }
+
+    // Get the database to check if it's an Azure database
+    try {
+      const database = await this.databaseService.get(sessionMetadata, instanceIdFromReq);
+
+      const isAzureDatabase = ['AZURE_CACHE', 'AZURE'].includes(database?.provider) ||
+                              (database?.cloudDetails &&
+                               database?.cloudDetails.hasOwnProperty('provider') &&
+                               ['AZURE_CACHE', 'AZURE'].includes(database?.cloudDetails['provider']));
+
+      // Only associate Microsoft auth account with Azure databases
+      if (isAzureDatabase && this.microsoftAuthService) {
+        try {
+          this.logger.log(`RedisConnectionMiddleware - Associating Microsoft account with Azure database ${instanceIdFromReq}`);
+          await this.microsoftAuthService.associateAccountWithDatabase(instanceIdFromReq);
+        } catch (error) {
+          this.logger.warn(`RedisConnectionMiddleware - Failed to associate Microsoft account with database ${instanceIdFromReq}: ${error.message}`);
+          // Don't fail the connection process if Microsoft auth association fails
+        }
+      }
+    } catch (dbError) {
+      this.logger.error(`RedisConnectionMiddleware - Failed to retrieve database info: ${dbError.message}`);
+      // Continue anyway - don't fail the connection
     }
 
     next();

--- a/redisinsight/api/src/modules/auth/microsoft-auth/entities/microsoft-auth.entity.ts
+++ b/redisinsight/api/src/modules/auth/microsoft-auth/entities/microsoft-auth.entity.ts
@@ -1,0 +1,36 @@
+import { Expose } from 'class-transformer';
+import { Column, Entity } from 'typeorm';
+
+@Entity('microsoft_auth_session')
+export class MicrosoftAuthEntity {
+  @Column({ nullable: false, primary: true })
+  @Expose()
+  id: string;
+
+  @Column({ name: 'token_cache', nullable: true, type: 'text' })
+  @Expose()
+  tokenCache: string;
+
+  @Column({ nullable: true })
+  @Expose()
+  username: string;
+
+  @Column({ name: 'account_id', nullable: true })
+  @Expose()
+  accountId: string;
+
+  @Column({ name: 'tenant_id', nullable: true })
+  @Expose()
+  tenantId: string;
+
+  @Column({ name: 'display_name', nullable: true })
+  @Expose()
+  displayName: string;
+
+  @Column({ name: 'last_updated', nullable: true, type: 'bigint' })
+  @Expose()
+  lastUpdated: number;
+
+  @Column({ nullable: true })
+  encryption: string;
+}

--- a/redisinsight/api/src/modules/auth/microsoft-auth/microsoft-auth-storage.module.ts
+++ b/redisinsight/api/src/modules/auth/microsoft-auth/microsoft-auth-storage.module.ts
@@ -1,0 +1,16 @@
+import { Global, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MicrosoftAuthEntity } from './entities/microsoft-auth.entity';
+import { MicrosoftAuthRepository } from './repositories/microsoft-auth.repository';
+import { EncryptionModule } from 'src/modules/encryption/encryption.module';
+
+@Global()
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([MicrosoftAuthEntity]),
+    EncryptionModule,
+  ],
+  providers: [MicrosoftAuthRepository],
+  exports: [MicrosoftAuthRepository],
+})
+export class MicrosoftAuthStorageModule {}

--- a/redisinsight/api/src/modules/auth/microsoft-auth/microsoft-azure-auth.module.ts
+++ b/redisinsight/api/src/modules/auth/microsoft-auth/microsoft-azure-auth.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
 import { MicrosoftAuthService } from './microsoft-azure-auth.service';
 import { MicrosoftAzureAuthController } from './microsoft-azure-auth.controller';
+import { CloudSessionModule } from 'src/modules/cloud/session/cloud-session.module';
+import { MicrosoftAuthStorageModule } from './microsoft-auth-storage.module';
 
 @Module({
-    imports: [],
+    imports: [
+        CloudSessionModule.register(),
+        MicrosoftAuthStorageModule,
+    ],
     providers: [
         MicrosoftAuthService,
     ],

--- a/redisinsight/api/src/modules/auth/microsoft-auth/microsoft-azure-auth.service.ts
+++ b/redisinsight/api/src/modules/auth/microsoft-auth/microsoft-azure-auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { SessionMetadata } from 'src/common/models';
 import { DEFAULT_TOKEN_MANAGER_CONFIG, EntraIdCredentialsProviderFactory, PKCEParams } from '@redis/entraid/dist/lib/entra-id-credentials-provider-factory';
 import config from 'src/utils/config';
@@ -6,6 +6,12 @@ import { EntraidCredentialsProvider } from '@redis/entraid/dist/lib/entraid-cred
 import { CloudAuthStatus } from 'src/modules/cloud/auth/models/cloud-auth-response';
 import { AuthenticationResult } from '@azure/msal-common/node';
 import { Token } from '@redis/client/dist/lib/authx/token';
+import { AccountInfo, PublicClientApplication } from '@azure/msal-node';
+import { MSALIdentityProvider } from '@redis/entraid/dist/lib/msal-identity-provider';
+import { TokenManager } from '@redis/client/dist/lib/authx/token-manager';
+import { MicrosoftAuthRepository } from './repositories/microsoft-auth.repository';
+import { MicrosoftAuthSessionData } from './models/microsoft-auth-session.model';
+import { SQLitePersistencePlugin } from './sqlite-persistence-plugin';
 
 const { idp: { microsoft: idpConfig } } = config.get('cloud');
 
@@ -41,28 +47,232 @@ interface EntraIdAuthProvider {
 }
 
 @Injectable()
-export class MicrosoftAuthService {
+export class MicrosoftAuthService implements OnModuleInit {
     private readonly logger = new Logger('MicrosoftAuthService');
 
     private authRequests: Map<string, any> = new Map();
     private inProgressRequests: Map<string, any> = new Map();
     private activeCredentialsProvider: EntraidCredentialsProvider | null = null;
     private entraIdProvider: EntraIdAuthProvider;
+    private msalClient: PublicClientApplication;
+    private scopes: string[];
 
-    constructor() {
-        this.entraIdProvider = EntraIdCredentialsProviderFactory.createForAuthorizationCodeWithPKCE({
+    private persistencePlugin: SQLitePersistencePlugin;
+
+    constructor(
+        private readonly msAuthRepository: MicrosoftAuthRepository,
+    ) {
+        this.scopes = [
+            'offline_access',
+            'openid',
+            'email',
+            'profile',
+            'https://management.azure.com/user_impersonation'
+        ];
+
+        this.persistencePlugin = new SQLitePersistencePlugin(this.msAuthRepository);
+        this.msalClient = new PublicClientApplication({
+            auth: {
+                clientId: idpConfig.clientId,
+                authority: idpConfig.authority
+            },
+            cache: {
+                cachePlugin: this.persistencePlugin
+            }
+        });
+
+        const provider = EntraIdCredentialsProviderFactory.createForAuthorizationCodeWithPKCE({
             clientId: idpConfig.clientId,
             redirectUri: idpConfig.redirectUri,
-            tokenManagerConfig: DEFAULT_TOKEN_MANAGER_CONFIG,
+            tokenManagerConfig: {
+                ...DEFAULT_TOKEN_MANAGER_CONFIG,
+                expirationRefreshRatio: 0.00000001
+            },
             authorityConfig: { type: 'custom', authorityUrl: idpConfig.authority },
-            scopes: [
-                'offline_access',
-                'openid',
-                'email',
-                'profile',
-                'https://management.azure.com/user_impersonation'
-            ],
+            scopes: this.scopes,
         });
+
+        this.entraIdProvider = {
+            ...provider,
+            createCredentialsProvider: (pkceParams) => {
+                const idp = new MSALIdentityProvider(
+                    async () => {
+                        const authResult = await this.msalClient.acquireTokenByCode({
+                            code: pkceParams.code,
+                            codeVerifier: pkceParams.verifier,
+                            scopes: this.scopes,
+                            redirectUri: idpConfig.redirectUri,
+
+                        });
+
+                        this.updateAccountInfo(authResult.account);
+
+                        return authResult;
+                    }
+                );
+
+                const tm = new TokenManager(idp, DEFAULT_TOKEN_MANAGER_CONFIG);
+                return new EntraidCredentialsProvider(tm, idp, {});
+            }
+        };
+    }
+
+    async onModuleInit() {
+        this.logger.log('Microsoft Auth Service initializing...');
+        // This will most likely need to be updated to an actual rest api call, similar to how the cloud service checks auth.
+        try {
+            try {
+                const authData = await this.msAuthRepository.get();
+                if (!authData) {
+                    this.logger.log('[Init] No valid database entry found, creating an empty one');
+
+                    await this.msAuthRepository.save({
+                        id: SQLitePersistencePlugin.DEFAULT_ID,
+                        tokenCache: null,
+                        username: null,
+                        accountId: null,
+                        tenantId: null,
+                        displayName: null,
+                        lastUpdated: Date.now()
+                    });
+
+                    this.logger.log('[Init] Empty database entry created for future use');
+                }
+            } catch (repoError) {
+                this.logger.error('Error checking/initializing auth repository:', repoError);
+            }
+
+            const restored = await this.restoreActiveAccount();
+
+            if (restored) {
+                const token = await this.getAccessToken();
+                if (token) {
+                    try {
+                        // TODO: Remove this test method call. this is used for quick validation of the token during dev. It should NOT be used in prod
+                        const subscriptions = await this.getSubscriptions();
+                        this.logger.log(`[Init] Successfully retrieved ${subscriptions.length} subscriptions`);
+
+                        subscriptions?.forEach((sub, index) => {
+                            this.logger.log(`[Init] Subscription #${index + 1}: ${sub.displayName || 'Unnamed'} (${sub.subscriptionId})`);
+                        });
+                    } catch (subscriptionError) {
+                        this.logger.error('[Init] Error retrieving subscriptions:', subscriptionError);
+                    }
+                } else {
+                    this.logger.warn('[Init] Access token could not be retrieved during initialization');
+                }
+            } else {
+                this.logger.log('[Init] No Microsoft account to restore during initialization');
+            }
+        } catch (error) {
+            this.logger.error('[Init] Error during Microsoft Auth Service initialization:', error);
+        }
+
+        this.logger.log('Microsoft Auth Service initialized');
+    }
+
+    /**
+     * Update account information in our storage
+     * @param account The account information from MSAL
+     * @private
+     */
+    private async updateAccountInfo(account: AccountInfo): Promise<void> {
+        try {
+            let existingData: MicrosoftAuthSessionData | null = null;
+            try {
+                existingData = await this.msAuthRepository.get();
+            } catch (getError) {
+                this.logger.warn(`[Account] Failed to get existing account data: ${getError.message}. Will create new entry.`);
+            }
+
+            // Update or create auth data
+            const updatedData: Partial<MicrosoftAuthSessionData> = {
+                id: SQLitePersistencePlugin.DEFAULT_ID,
+                // TODO: update with the dbId at some point - the request is to keep details per DB.
+                username: account.username,
+                accountId: account.homeAccountId,
+                tenantId: account.tenantId,
+                displayName: account.name,
+                lastUpdated: Date.now(),
+                // Preserve token cache if it exists
+                tokenCache: existingData?.tokenCache || null
+            };
+
+            try {
+                await this.msAuthRepository.save(updatedData);
+                this.logger.log(`[Account] Updated account info in database: ${account.username}`);
+            } catch (saveError) {
+                this.logger.error(`[Account] Failed to save account info: ${saveError.message}`);
+
+                // Try once more after ensuring table exists again
+                try {
+                    await this.msAuthRepository.save(updatedData);
+                    this.logger.log(`[Account] Retry successful - Updated account info in database: ${account.username}`);
+                } catch (retryError) {
+                    this.logger.error(`[Account] Retry failed - Could not save account info: ${retryError.message}`);
+                    throw retryError;
+                }
+            }
+        } catch (error) {
+            this.logger.error(`[Account] Error updating account info:`, error);
+        }
+    }
+
+    /**
+     * Restore active account and credentials provider from the database
+     * @private
+     */
+    private async restoreActiveAccount(): Promise<boolean> {
+        try {
+            this.logger.log(`[Token Restoration] Starting account restoration`);
+
+            // Get accounts from the token cache
+            // The token cache should already be loaded from the database by the persistence plugin
+            const accounts = await this.msalClient.getTokenCache().getAllAccounts();
+
+            if (accounts.length === 0) {
+                this.logger.warn('[Token Restoration] No accounts found in token cache');
+                return false;
+            }
+
+            this.logger.log(`[Token Restoration] Found ${accounts.length} accounts in token cache`);
+
+            // Log details of all found accounts (for debugging)
+            accounts.forEach((acc, index) => {
+                this.logger.log(`[Token Restoration] Account #${index + 1}: Username: ${acc.username}, ID: ${acc.homeAccountId}, Tenant: ${acc.tenantId}`);
+            });
+
+            // Use the first account for now
+            // (in future we could store a preferred account ID in the database)
+            const selectedAccount = accounts[0];
+
+            if (selectedAccount) {
+                // Recreate credentials provider with the selected account
+                this.logger.log(`[Token Restoration] Recreating credentials provider with account: ${selectedAccount.username}`);
+                this.recreateCredentialsProvider(selectedAccount);
+
+                // Test if the token is valid
+                try {
+                    this.logger.log(`[Token Restoration] Testing token acquisition`);
+                    const authResult = await this.msalClient.acquireTokenSilent({
+                        account: selectedAccount,
+                        scopes: this.scopes,
+                        forceRefresh: false
+                    });
+
+                    this.logger.log(`[Token Restoration] Token acquired successfully, expires: ${new Date(authResult.expiresOn).toISOString()}`);
+                    return true;
+                } catch (tokenError) {
+                    this.logger.warn(`[Token Restoration] Token acquisition test failed, but continuing with account restoration`, tokenError);
+                    return true; // Still return true as we have an account, even if token acquisition failed
+                }
+            }
+
+            return false;
+        } catch (error) {
+            this.logger.error('[Token Restoration] Error restoring active account:', error);
+            return false;
+        }
     }
 
     async getAuthorizationUrl(
@@ -85,7 +295,6 @@ export class MicrosoftAuthService {
 
         this.authRequests.clear();
         this.authRequests.set(options?.state, authRequest);
-
         return authUrl;
     }
 
@@ -113,11 +322,11 @@ export class MicrosoftAuthService {
             );
 
             const [credentials] = await this.activeCredentialsProvider.subscribe({
-                onNext: (token) => {
-                    console.log('Token acquired:', token);
+                onNext: async (token) => {
+                    this.logger.log('Token acquired', token);
                 },
                 onError: (error) => {
-                    console.error('Token acquisition failed:', error);
+                    this.logger.error('Token acquisition failed:', error);
                 }
             });
 
@@ -165,32 +374,159 @@ export class MicrosoftAuthService {
 
     async getSession(): Promise<AuthenticationResult | null> {
         try {
+            this.logger.log(`[Session] Attempting to get session`);
+
+            // If no active provider, try to restore it
             if (!this.activeCredentialsProvider) {
-                this.logger.warn('No active credentials provider available');
-                return null;
+                this.logger.log(`[Session] No active credentials provider, attempting to restore account`);
+                const restored = await this.restoreActiveAccount();
+                if (!restored) {
+                    this.logger.warn(`[Session] Could not restore active account`);
+                    return null;
+                }
+                this.logger.log(`[Session] Successfully restored active account`);
+            } else {
+                this.logger.log(`[Session] Using existing credentials provider`);
             }
 
             // Get the latest credentials from the provider
+            this.logger.log(`[Session] Requesting current token from credentials provider`);
             const credentials: Token<AuthenticationResult> | null = await this.activeCredentialsProvider.tokenManager.getCurrentToken();
 
-            if (!credentials) {
-                this.logger.warn('No credentials available from provider');
+            if (credentials) {
+                this.logger.log(`[Session] Credentials successfully obtained from token manager, expires: ${new Date(credentials.value.expiresOn).toISOString()}`);
+                return credentials.value;
+            }
+
+            // If token manager returned null, try direct MSAL client approach as fallback
+            this.logger.log(`[Session] No credentials from token manager, falling back to direct MSAL client approach`);
+
+            // Get accounts from MSAL
+            const accounts = await this.msalClient.getTokenCache().getAllAccounts();
+            if (accounts.length === 0) {
+                this.logger.warn(`[Session] No accounts found in token cache during fallback`);
                 return null;
             }
 
-            return credentials.value;
+            // TODO: update to use the correct account. This is for POC level testing only
+            const selectedAccount = accounts[0];
+            this.logger.log(`[Session] Using account for fallback token acquisition: ${selectedAccount.username}`);
+
+            try {
+                const authResult = await this.msalClient.acquireTokenSilent({
+                    account: selectedAccount,
+                    scopes: this.scopes,
+                    forceRefresh: false
+                });
+
+                if (authResult) {
+                    this.logger.log(`[Session] Fallback token acquisition successful, expires: ${new Date(authResult.expiresOn).toISOString()}`);
+
+                    // Update our credentials provider with the fresh account
+                    this.recreateCredentialsProvider(selectedAccount);
+
+                    return authResult;
+                }
+            } catch (tokenError) {
+                this.logger.error(`[Session] Fallback token acquisition failed:`, tokenError);
+            }
+
+            this.logger.warn(`[Session] No credentials available after fallback attempts`);
+            return null;
         } catch (e) {
-            this.logger.error('Failed to get Microsoft session', e);
+            this.logger.error(`[Session] Failed to get Microsoft session`, e);
             return null;
         }
     }
 
     async getAccessToken(): Promise<string | null> {
         try {
+            this.logger.log(`[Token] Attempting to get access token`);
             const session = await this.getSession();
-            return session?.accessToken || null;
+
+            if (session?.accessToken) {
+                // Log token details (not the actual token for security)
+                const tokenLength = session.accessToken.length;
+                const tokenPrefix = session.accessToken.substring(0, 5);
+                const tokenSuffix = session.accessToken.substring(tokenLength - 5);
+                this.logger.log(`[Token] Access token retrieved, length: ${tokenLength}, prefix: ${tokenPrefix}..., suffix: ...${tokenSuffix}`);
+                this.logger.log(`[Token] Token expires on: ${new Date(session.expiresOn).toISOString()}`);
+                return session.accessToken;
+            } else {
+                this.logger.warn(`[Token] No access token available in session`);
+                return null;
+            }
         } catch (e) {
-            this.logger.error('Failed to get access token', e);
+            this.logger.error(`[Token] Failed to get access token`, e);
+            return null;
+        }
+    }
+
+    /**
+     * Recreate the credentials provider for the given account
+     * @param account MSAL account
+     * @private
+     */
+    private recreateCredentialsProvider(account: AccountInfo): void {
+        // Create a new credentials provider using the saved account
+        const idp = new MSALIdentityProvider(
+            async () => {
+                return this.msalClient.acquireTokenSilent({
+                    account,
+                    scopes: this.scopes,
+                    forceRefresh: false
+                });
+            }
+        );
+
+        const tm = new TokenManager(idp, DEFAULT_TOKEN_MANAGER_CONFIG);
+        this.activeCredentialsProvider = new EntraidCredentialsProvider(tm, idp, {});
+    }
+
+
+    /**
+     * Tests the access token by attempting to retrieve Azure subscriptions
+     * @returns An array of subscription objects or null if unsuccessful
+     */
+    async getSubscriptions(): Promise<any[] | null> {
+        try {
+            this.logger.log('[Subscriptions] Attempting to retrieve Azure subscriptions');
+
+            // Get the access token
+            const token = await this.getAccessToken();
+            if (!token) {
+                this.logger.warn('[Subscriptions] No access token available to retrieve subscriptions');
+                return null;
+            }
+
+            // Make a request to the Azure Management API
+            const response = await fetch('https://management.azure.com/subscriptions?api-version=2020-01-01', {
+                method: 'GET',
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                this.logger.error(`[Subscriptions] Failed to retrieve subscriptions: ${response.status} ${response.statusText}`);
+                this.logger.error(`[Subscriptions] Error details: ${errorText}`);
+                return null;
+            }
+
+            const data = await response.json();
+            if (data && Array.isArray(data.value)) {
+                this.logger.log(`[Subscriptions] Successfully retrieved ${data.value.length} subscriptions`);
+                console.log(data.value);
+                return data.value;
+            } else {
+                this.logger.warn('[Subscriptions] Received unexpected response format from Azure API');
+                this.logger.log(`[Subscriptions] Response: ${JSON.stringify(data)}`);
+                return null;
+            }
+        } catch (error) {
+            this.logger.error('[Subscriptions] Error retrieving subscriptions:', error);
             return null;
         }
     }

--- a/redisinsight/api/src/modules/auth/microsoft-auth/models/microsoft-auth-session.model.ts
+++ b/redisinsight/api/src/modules/auth/microsoft-auth/models/microsoft-auth-session.model.ts
@@ -1,18 +1,48 @@
-import { Expose, Type } from 'class-transformer';
+import { Expose } from 'class-transformer';
 
-export class MicrosoftAuthSession {
-    @Expose()
-    username: string;
-
-    @Expose()
-    password: string;
-}
-
+/**
+ * Data model for Microsoft Authentication session
+ */
 export class MicrosoftAuthSessionData {
-    @Expose()
-    id: string;
+  /**
+   * Primary key
+   */
+  @Expose()
+  id: string;
 
-    @Expose()
-    @Type(() => MicrosoftAuthSession)
-    data: MicrosoftAuthSession;
-} 
+  /**
+   * The serialized MSAL token cache
+   */
+  @Expose()
+  tokenCache?: string;
+
+  /**
+   * Username of the authenticated user
+   */
+  @Expose()
+  username?: string;
+
+  /**
+   * Account ID from Microsoft
+   */
+  @Expose()
+  accountId?: string;
+
+  /**
+   * Tenant ID from Microsoft
+   */
+  @Expose()
+  tenantId?: string;
+
+  /**
+   * Display name of the user
+   */
+  @Expose()
+  displayName?: string;
+
+  /**
+   * Last updated timestamp
+   */
+  @Expose()
+  lastUpdated?: number;
+}

--- a/redisinsight/api/src/modules/auth/microsoft-auth/repositories/microsoft-auth.repository.ts
+++ b/redisinsight/api/src/modules/auth/microsoft-auth/repositories/microsoft-auth.repository.ts
@@ -1,0 +1,72 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { classToClass } from 'src/utils';
+import { EncryptionService } from 'src/modules/encryption/encryption.service';
+import { ModelEncryptor } from 'src/modules/encryption/model.encryptor';
+import { plainToClass } from 'class-transformer';
+import { Logger, Injectable } from '@nestjs/common';
+import { MicrosoftAuthEntity } from '../entities/microsoft-auth.entity';
+import { MicrosoftAuthSessionData } from '../models/microsoft-auth-session.model';
+
+// Default ID for single Microsoft auth record
+const DEFAULT_AUTH_ID = 'default';
+
+@Injectable()
+export class MicrosoftAuthRepository {
+  private readonly modelEncryptor: ModelEncryptor;
+  private readonly logger = new Logger('MicrosoftAuthRepository');
+
+  constructor(
+    @InjectRepository(MicrosoftAuthEntity)
+    private readonly repository: Repository<MicrosoftAuthEntity>,
+    private readonly encryptionService: EncryptionService,
+  ) {
+    this.modelEncryptor = new ModelEncryptor(this.encryptionService, [
+      'tokenCache',
+      'username',
+      'accountId',
+      'tenantId',
+      'displayName'
+    ]);
+  }
+
+  async get(id: string = DEFAULT_AUTH_ID): Promise<MicrosoftAuthSessionData | null> {
+    try {
+      const entity = await this.repository.findOneBy({ id });
+
+      if (!entity) {
+        return null;
+      }
+
+      const decrypted = await this.modelEncryptor.decryptEntity(entity, false);
+      return classToClass(MicrosoftAuthSessionData, decrypted);
+    } catch (error) {
+      this.logger.error(`Error getting Microsoft auth data: ${error.message}`, error.stack);
+      return null;
+    }
+  }
+
+  async save(authData: Partial<MicrosoftAuthSessionData>): Promise<void> {
+    try {
+      const id = authData.id || DEFAULT_AUTH_ID;
+
+      const entity = await this.modelEncryptor.encryptEntity(
+        plainToClass(MicrosoftAuthEntity, { ...authData, id }),
+      );
+
+      await this.repository.upsert(entity, ['id']);
+    } catch (error) {
+      this.logger.error(`Error saving Microsoft auth data: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      await this.repository.delete(id);
+    } catch (error) {
+      this.logger.error(`Error deleting Microsoft auth data: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+}

--- a/redisinsight/api/src/modules/auth/microsoft-auth/sqlite-persistence-plugin.ts
+++ b/redisinsight/api/src/modules/auth/microsoft-auth/sqlite-persistence-plugin.ts
@@ -1,0 +1,70 @@
+import { Logger } from '@nestjs/common';
+import { ICachePlugin } from '@azure/msal-node';
+import { MicrosoftAuthRepository } from './repositories/microsoft-auth.repository';
+import { MicrosoftAuthSessionData } from './models/microsoft-auth-session.model';
+
+/**
+ * SQLite-based cache plugin for MSAL token persistence
+ * Uses the MicrosoftAuthRepository to store token cache data in the database
+ */
+export class SQLitePersistencePlugin implements ICachePlugin {
+    private readonly logger = new Logger('SQLitePersistencePlugin');
+    public static readonly DEFAULT_ID = 'default';
+
+    constructor(
+        private readonly msAuthRepository: MicrosoftAuthRepository,
+    ) {}
+
+    async beforeCacheAccess(cacheContext: any): Promise<void> {
+        try {
+            this.logger.log(`Loading token cache from database...`);
+            const authData = await this.msAuthRepository.get();
+
+            if (authData?.tokenCache) {
+                const serializedCache = authData.tokenCache;
+                this.logger.log(`Token cache found in database, size: ${serializedCache.length} bytes`);
+
+                cacheContext.tokenCache.deserialize(serializedCache);
+            } else {
+                this.logger.log(`No token cache found in database`);
+            }
+        } catch (error) {
+            this.logger.error(`Error reading token cache from database:`, error);
+        }
+    }
+
+    async afterCacheAccess(cacheContext: any): Promise<void> {
+        if (cacheContext.cacheHasChanged) {
+            try {
+                this.logger.log(`Token cache has changed, persisting to database...`);
+
+                const serializedCache = cacheContext.tokenCache.serialize();
+                let existingData = null;
+
+                try {
+                    existingData = await this.msAuthRepository.get();
+                } catch (getError) {
+                    this.logger.warn(`Failed to get existing token data: ${getError.message}. Will create new entry.`);
+                }
+
+                await this.msAuthRepository.save({
+                    id: SQLitePersistencePlugin.DEFAULT_ID,
+                    // TODO: update with the dbId at some point - the request is to keep details per DB.
+                    tokenCache: serializedCache,
+                    lastUpdated: Date.now(),
+                    ...existingData ? {
+                        username: existingData.username,
+                        accountId: existingData.accountId,
+                        tenantId: existingData.tenantId,
+                        displayName: existingData.displayName
+                    } : {}
+                });
+
+                this.logger.log(`Token cache successfully saved to database, size: ${serializedCache.length} bytes`);
+
+            } catch (error) {
+                this.logger.error(`Error saving token cache to database:`, error);
+            }
+        }
+    }
+}

--- a/redisinsight/api/src/modules/cloud/session/cloud-session.module.ts
+++ b/redisinsight/api/src/modules/cloud/session/cloud-session.module.ts
@@ -17,7 +17,7 @@ export class CloudSessionModule {
           useClass: cloudSessionRepository,
         },
       ],
-      exports: [CloudSessionService],
+      exports: [CloudSessionService, CloudSessionRepository],
     };
   }
 }

--- a/redisinsight/api/src/modules/database/database.module.ts
+++ b/redisinsight/api/src/modules/database/database.module.ts
@@ -16,6 +16,7 @@ import { StackDatabasesRepository } from 'src/modules/database/repositories/stac
 import { DatabaseClientFactory } from 'src/modules/database/providers/database.client.factory';
 import { DatabaseInfoProvider } from './providers/database-info.provider';
 import { ConnectionMiddleware } from './middleware/connection.middleware';
+import { MicrosoftAuthModule } from 'src/modules/auth/microsoft-auth/microsoft-azure-auth.module';
 
 const SERVER_CONFIG = config.get('server') as Config['server'];
 
@@ -28,6 +29,9 @@ export class DatabaseModule {
   ) {
     return {
       module: DatabaseModule,
+      imports: [
+        MicrosoftAuthModule,
+      ],
       controllers: [
         DatabaseController,
         DatabaseInfoController,

--- a/redisinsight/desktop/preload.ts
+++ b/redisinsight/desktop/preload.ts
@@ -25,6 +25,9 @@ contextBridge.exposeInMainWorld('app', {
   microsoftAuthCallback: ((connected: any) => {
     ipcRenderer.on(IpcOnEvent.microsoftAuthCallback, connected)
   }),
+  microsoftAuthEditCallback: ((connected: any) => {
+    ipcRenderer.on(IpcOnEvent.microsoftAuthEditCallback, connected)
+  }),
   deepLinkAction: ((parsedDeepLink: any) => {
     ipcRenderer.on(IpcOnEvent.deepLinkAction, parsedDeepLink)
   }),

--- a/redisinsight/desktop/src/lib/auth/service.auth.strategy.ts
+++ b/redisinsight/desktop/src/lib/auth/service.auth.strategy.ts
@@ -1,4 +1,5 @@
 import log from 'electron-log'
+import { LocalConstantsProvider } from 'apiSrc/modules/constants/providers/local.constants.provider'
 import { AuthStrategy } from './auth.interface'
 import { CloudAuthService } from '../../../../api/dist/src/modules/cloud/auth/cloud-auth.service'
 import { CloudAuthModule } from '../../../../api/dist/src/modules/cloud/auth/cloud-auth.module'
@@ -18,11 +19,13 @@ export class ServiceAuthStrategy implements AuthStrategy {
 
   private beApp: any
 
-  private constructor() { }
+  private constructor(
+    private readonly constantsProvider: LocalConstantsProvider,
+  ) { }
 
   public static getInstance(beApp?: any): ServiceAuthStrategy {
     if (!ServiceAuthStrategy.instance) {
-      ServiceAuthStrategy.instance = new ServiceAuthStrategy()
+      ServiceAuthStrategy.instance = new ServiceAuthStrategy(new LocalConstantsProvider())
     }
     if (beApp) {
       ServiceAuthStrategy.instance.beApp = beApp
@@ -62,11 +65,7 @@ export class ServiceAuthStrategy implements AuthStrategy {
     this.lastAuthType = options.authOptions?.strategy
     log.info('[Service Auth] Getting auth URL', options.authOptions?.strategy === AuthProviderType.Microsoft, options)
 
-    // Create a default session metadata if not provided
-    const sessionMetadata = options.sessionMetadata || {
-      sessionId: 'default',
-      userId: 'default'
-    }
+    const sessionMetadata = options.sessionMetadata || this.constantsProvider.getSystemSessionMetadata()
 
     const url = await this.getAuthService().getAuthorizationUrl(sessionMetadata, options.authOptions)
     log.info('[Service Auth] Auth URL obtained')

--- a/redisinsight/desktop/src/lib/auth/service.auth.strategy.ts
+++ b/redisinsight/desktop/src/lib/auth/service.auth.strategy.ts
@@ -61,7 +61,14 @@ export class ServiceAuthStrategy implements AuthStrategy {
   async getAuthUrl(options: any): Promise<{ url: string }> {
     this.lastAuthType = options.authOptions?.strategy
     log.info('[Service Auth] Getting auth URL', options.authOptions?.strategy === AuthProviderType.Microsoft, options)
-    const url = await this.getAuthService().getAuthorizationUrl(options.sessionMetadata, options.authOptions)
+
+    // Create a default session metadata if not provided
+    const sessionMetadata = options.sessionMetadata || {
+      sessionId: 'default',
+      userId: 'default'
+    }
+
+    const url = await this.getAuthService().getAuthorizationUrl(sessionMetadata, options.authOptions)
     log.info('[Service Auth] Auth URL obtained')
     return { url }
   }

--- a/redisinsight/desktop/src/lib/auth/service.auth.strategy.ts
+++ b/redisinsight/desktop/src/lib/auth/service.auth.strategy.ts
@@ -74,14 +74,21 @@ export class ServiceAuthStrategy implements AuthStrategy {
   }
 
   async handleCallback(query: any): Promise<any> {
-    log.info('[Service Auth] Handling callback')
     if (this.getAuthService().isRequestInProgress(query)) {
-      log.info('[Service Auth] Request already in progress, skipping')
-      return { status: 'succeed' }
+      return {
+        status: 'succeed',
+        action: query.action,
+        databaseId: query.databaseId,
+        options: query
+      }
     }
     const result = await this.getAuthService().handleCallback(query)
-    log.info('[Service Auth] Callback handled', result)
-    return result
+    return {
+      ...result,
+      action: query.action,
+      databaseId: query.databaseId,
+      options: query
+    }
   }
 
   async shutdown(): Promise<void> {

--- a/redisinsight/ui/src/components/subscriptions-list/styles.module.scss
+++ b/redisinsight/ui/src/components/subscriptions-list/styles.module.scss
@@ -196,4 +196,8 @@
   margin-bottom: 24px;
   display: flex;
   flex-direction: column;
+
+  .euiFlexGroup--gutterLarge {
+    margin: 0 !important;
+  }
 }

--- a/redisinsight/ui/src/constants/api.ts
+++ b/redisinsight/ui/src/constants/api.ts
@@ -25,6 +25,8 @@ enum ApiEndpoints {
 
   MICROSOFT_AZURE_CLOUD_SUBSCRIPTIONS = 'azure/autodiscovery/subscriptions',
   MICROSOFT_AZURE_CLOUD_DATABASES = 'azure/autodiscovery/databases',
+  MICROSOFT_AUTH_SESSION = 'auth/microsoft/session',
+  MICROSOFT_AUTH_LOGOUT = 'auth/microsoft/logout',
 
   SENTINEL_GET_DATABASES = 'redis-sentinel/get-databases',
   SENTINEL_DATABASES = 'redis-sentinel/databases',

--- a/redisinsight/ui/src/electron/components/ConfigMicrosoftAuth/ConfigMicrosoftAuth.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigMicrosoftAuth/ConfigMicrosoftAuth.tsx
@@ -7,6 +7,7 @@ import { CloudAuthStatus } from 'uiSrc/electron/constants/cloudAuth'
 import { INFINITE_MESSAGES, InfiniteMessagesIds } from 'uiSrc/components/notifications/components'
 import { addErrorNotification, addInfiniteNotification, removeInfiniteNotification } from 'uiSrc/slices/app/notifications'
 import { createAxiosError } from 'uiSrc/utils'
+import { loadMicrosoftAuthSessionSuccess } from 'uiSrc/slices/instances/microsoftAuthSession'
 
 export interface MicrosoftAuthResponse {
   status: CloudAuthStatus
@@ -15,6 +16,8 @@ export interface MicrosoftAuthResponse {
   error?: {
     message: string
   }
+  action?: string
+  databaseId?: string
 }
 
 const ConfigMicrosoftAuth = () => {
@@ -23,22 +26,17 @@ const ConfigMicrosoftAuth = () => {
   const history = useHistory()
 
   useEffect(() => {
-    window.app?.microsoftAuthCallback?.(microsoftAuthCallback)
+    window.app?.microsoftAuthCallback?.((e: any, response: MicrosoftAuthResponse) =>
+      handleMicrosoftAuthCallback(e, response, 'autodiscovery'))
+    window.app?.microsoftAuthEditCallback?.((e: any, response: MicrosoftAuthResponse) =>
+      handleMicrosoftAuthCallback(e, response, 'edit'))
   }, [])
 
   const closeInfinityNotification = () => {
     dispatch(removeInfiniteNotification(InfiniteMessagesIds.oAuthProgress))
   }
 
-  const onAuthSuccess = () => {
-    // TODO: Update for the complete flow in follow up PR
-    // dispatch(fetchSubscriptionsAzure())
-    closeInfinityNotification()
-    history.push(Pages.azureSubscriptions)
-  }
-
-  const microsoftAuthCallback = (_e: any, response: MicrosoftAuthResponse) => {
-    // Handle Microsoft auth callback
+  const handleMicrosoftAuthCallback = (_e: any, response: MicrosoftAuthResponse, action: 'autodiscovery' | 'edit') => {
     if (response.status === CloudAuthStatus.Succeed) {
       if (isAuthInProgress.current) {
         return
@@ -46,13 +44,37 @@ const ConfigMicrosoftAuth = () => {
       isAuthInProgress.current = true
       if (response.username && response.password) {
         dispatch(addInfiniteNotification(INFINITE_MESSAGES.AUTHENTICATING()))
-        onAuthSuccess()
+        closeInfinityNotification()
+
+        // Update the microsoft_auth_session table for both autodiscovery and edit cases
+        if (action === 'edit' && response.databaseId) {
+          const sessionData = {
+            id: response.databaseId,
+            username: response.username,
+            displayName: response.username, // Using username as display name if not provided
+            lastUpdated: Date.now(),
+            // Add any additional fields from the response if available
+            ...(response.action && { action: response.action })
+          }
+
+          // Dispatch action to update the session
+          dispatch(loadMicrosoftAuthSessionSuccess({
+            databaseId: response.databaseId,
+            data: {
+              ...sessionData,
+              authenticated: true
+            }
+          }))
+        }
+
+        if (action === 'autodiscovery') {
+          history.push(Pages.azureSubscriptions)
+        }
       }
     } else if (response.status === CloudAuthStatus.Failed) {
       dispatch(addErrorNotification(createAxiosError({
         message: response.error?.message || 'Microsoft authentication failed',
       })))
-
       isAuthInProgress.current = false
     }
   }

--- a/redisinsight/ui/src/electron/constants/ipcEvent.ts
+++ b/redisinsight/ui/src/electron/constants/ipcEvent.ts
@@ -7,6 +7,7 @@ enum IpcInvokeEvent {
   themeChange = 'theme:change',
   appRestart = 'app:restart',
   microsoftAuth = 'microsoft-auth',
+  microsoftAuthEdit = 'microsoft-auth-edit',
 }
 
 enum IpcOnEvent {
@@ -15,6 +16,7 @@ enum IpcOnEvent {
   deepLinkAction = 'deep-link:action',
   appUpdateAvailable = 'app:update:available',
   microsoftAuthCallback = 'microsoft:auth:callback',
+  microsoftAuthEditCallback = 'microsoft:auth-edit:callback',
 }
 
 export {

--- a/redisinsight/ui/src/electron/utils/ipcAuth.ts
+++ b/redisinsight/ui/src/electron/utils/ipcAuth.ts
@@ -1,4 +1,4 @@
-import { OAuthStrategy } from 'uiSrc/slices/interfaces'
+import { OAuthStrategy, OAuthSocialAction } from 'uiSrc/slices/interfaces'
 import { IpcInvokeEvent } from '../constants'
 
 export const ipcAuth = async (strategy: OAuthStrategy, action: string, data?: {}) => {
@@ -9,8 +9,11 @@ export const ipcAuth = async (strategy: OAuthStrategy, action: string, data?: {}
 }
 
 export const ipcAuthMicrosoft = async (strategy: OAuthStrategy, action: string, data?: {}) => {
+  const event = action === OAuthSocialAction.EditDatabase
+    ? IpcInvokeEvent.microsoftAuthEdit
+    : IpcInvokeEvent.microsoftAuth
   await window.app?.ipc?.invoke?.(
-    IpcInvokeEvent.microsoftAuth,
+    event,
     { strategy, action, data }
   )
 }

--- a/redisinsight/ui/src/hooks/useMicrosoftAuth.ts
+++ b/redisinsight/ui/src/hooks/useMicrosoftAuth.ts
@@ -1,0 +1,161 @@
+import { useState, useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useHistory } from 'react-router-dom'
+import { OAuthSocialAction, OAuthStrategy } from 'uiSrc/slices/interfaces'
+import { ipcAuthMicrosoft } from 'uiSrc/electron/utils/ipcAuth'
+import { setSSOFlow } from 'uiSrc/slices/instances/cloud'
+import { signIn } from 'uiSrc/slices/oauth/cloud'
+import { resetDataAzure } from 'uiSrc/slices/instances/microsoftAzure'
+import {
+  fetchMicrosoftAuthSession,
+  resetMicrosoftAuthSession,
+  MicrosoftAuthSession
+} from 'uiSrc/slices/instances/microsoftAuthSession'
+import { AppDispatch, RootState } from 'uiSrc/slices/store'
+import { Pages, ApiEndpoints } from 'uiSrc/constants'
+import { apiService } from 'uiSrc/services'
+
+export interface AuthenticationStatus {
+  isAuthenticated: boolean;
+  userEmail: string | null;
+  displayName: string | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const useMicrosoftAuth = (databaseId?: string): [
+  AuthenticationStatus,
+  () => void, // signIn
+  () => Promise<void>, // signOut
+  () => Promise<void> // retry
+] => {
+  const dispatch = useDispatch<AppDispatch>()
+  const history = useHistory()
+
+  const sessionData = useSelector((state: RootState) => (
+    databaseId ? (state.connections.microsoftAuthSession?.data || {})[databaseId] : null
+  ))
+
+  const [status, setStatus] = useState<AuthenticationStatus>({
+    isAuthenticated: false,
+    userEmail: null,
+    displayName: null,
+    isLoading: true,
+    error: null
+  })
+
+  const checkAuthenticationStatus = async () => {
+    try {
+      setStatus((prev) => ({ ...prev, isLoading: true, error: null }))
+
+      if (!databaseId) {
+        setStatus((prev) => ({
+          ...prev,
+          isAuthenticated: false,
+          userEmail: null,
+          displayName: null,
+          isLoading: false
+        }))
+        return
+      }
+
+      // Use our Redux action to fetch the session
+      // The Promise returned by dispatch is the action result, not what the thunk returned
+      const actionResult = await dispatch(fetchMicrosoftAuthSession(databaseId))
+      // The actual session data is attached to the action result by Redux Thunk
+      const result = actionResult?.payload?.data as MicrosoftAuthSession
+
+      // Update local state based on the result
+      if (result && result.authenticated) {
+        setStatus({
+          isAuthenticated: true,
+          userEmail: result.username,
+          displayName: result.displayName,
+          isLoading: false,
+          error: null
+        })
+      } else {
+        setStatus({
+          isAuthenticated: false,
+          userEmail: null,
+          displayName: null,
+          isLoading: false,
+          error: result?.error || null
+        })
+      }
+    } catch (error) {
+      console.error(`Microsoft auth fetch error for database ${databaseId}:`, error)
+      setStatus((prev) => ({
+        ...prev,
+        isAuthenticated: false,
+        isLoading: false,
+        error: error instanceof Error ? error.message : 'Unknown error occurred'
+      }))
+    }
+  }
+
+  useEffect(() => {
+    checkAuthenticationStatus()
+  }, [databaseId])
+
+  useEffect(() => {
+    if (sessionData) {
+      setStatus({
+        isAuthenticated: sessionData.authenticated || false,
+        userEmail: sessionData.username || null,
+        displayName: sessionData.displayName || null,
+        isLoading: false,
+        error: sessionData.error || null
+      })
+    }
+  }, [sessionData])
+
+  const handleSignIn = () => {
+    if (databaseId) {
+      // For database editing, used in direct Microsoft auth without autodiscovery
+      ipcAuthMicrosoft(OAuthStrategy.Microsoft, OAuthSocialAction.EditDatabase, {
+        databaseId,
+        action: OAuthSocialAction.EditDatabase
+      })
+    } else {
+      // For autodiscovery, use the existing flow
+      dispatch(setSSOFlow(OAuthSocialAction.SignIn))
+      dispatch(signIn())
+      ipcAuthMicrosoft(OAuthStrategy.Microsoft, OAuthSocialAction.SignIn)
+    }
+  }
+
+  const handleSignOut = async () => {
+    try {
+      if (databaseId) {
+        await apiService.post(`${ApiEndpoints.MICROSOFT_AUTH_LOGOUT}/${databaseId}`)
+        dispatch(resetMicrosoftAuthSession({ databaseId }))
+      }
+
+      dispatch(resetDataAzure())
+
+      setStatus((prev) => ({
+        ...prev,
+        isAuthenticated: false,
+        userEmail: null,
+        displayName: null
+      }))
+
+      history.push(Pages.home)
+    } catch (error) {
+      setStatus((prev) => ({
+        ...prev,
+        isAuthenticated: false,
+        userEmail: null,
+        displayName: null
+      }))
+      history.push(Pages.home)
+    }
+  }
+
+  const retry = async () => {
+    await checkAuthenticationStatus()
+  }
+
+  return [status, handleSignIn, handleSignOut, retry]
+}

--- a/redisinsight/ui/src/pages/home/components/form/styles.module.scss
+++ b/redisinsight/ui/src/pages/home/components/form/styles.module.scss
@@ -1,0 +1,20 @@
+.typeBtn {
+    position: relative;
+    width: 100%;
+    height: 32px !important;
+    padding: 0;
+
+    border-color: var(--separatorColorLight) !important;
+    color: var(--buttonSecondaryTextColor) !important;
+    box-shadow: none !important;
+
+    font-weight: normal !important;
+
+    .btnIcon {
+        margin-right: 8px;
+    }
+}
+
+:global(.euiFlexGroup--gutterLarge) {
+    margin: 0 !important;
+}

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/AddConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/AddConnection.tsx
@@ -41,6 +41,7 @@ const AddConnection = (props: Props) => {
             formik={formik}
             onHostNamePaste={onHostNamePaste}
             showFields={{ host: true, alias: true, port: true, timeout: true }}
+            provider={formik.values.provider}
           />
           <Divider colorVariable="separatorColor" variant="fullWidth" className="form__divider" />
           <DbIndex

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
@@ -54,6 +54,7 @@ const EditConnection = (props: Props) => {
             }}
             autoFocus={!isCloneMode && isEditMode}
             onHostNamePaste={onHostNamePaste}
+            provider={formik.values.provider}
           />
           {isCloneMode && (
             <>

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditSentinelConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditSentinelConnection.tsx
@@ -51,6 +51,7 @@ const EditSentinelConnection = (props: Props) => {
         formik={formik}
         showFields={{ host: true, port: true, alias: false, timeout: false }}
         onHostNamePaste={onHostNamePaste}
+        provider={formik.values.provider}
       />
       <Divider colorVariable="separatorColor" variant="fullWidth" className="form__divider" />
       <DbIndex
@@ -94,6 +95,7 @@ const EditSentinelConnection = (props: Props) => {
         formik={formik}
         showFields={{ host: false, port: true, alias: false, timeout: false }}
         onHostNamePaste={onHostNamePaste}
+        provider={formik.values.provider}
       />
     </>
   )

--- a/redisinsight/ui/src/pages/home/components/sentinel-connection/sentinel-connection-form/SentinelConnectionForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/sentinel-connection/sentinel-connection-form/SentinelConnectionForm.tsx
@@ -1,8 +1,6 @@
 import {
   EuiButton,
   EuiForm,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiToolTip,
   keys,
   EuiSpacer,
@@ -159,6 +157,7 @@ const SentinelConnectionForm = (props: Props) => {
             formik={formik}
             showFields={{ host: true, port: true, alias: false, timeout: false }}
             onHostNamePaste={onHostNamePaste}
+            provider={formik.values.provider}
           />
           <EuiSpacer />
           <TlsDetails

--- a/redisinsight/ui/src/pages/home/interfaces/form.ts
+++ b/redisinsight/ui/src/pages/home/interfaces/form.ts
@@ -1,8 +1,8 @@
 import { Instance } from 'uiSrc/slices/interfaces'
 import { ADD_NEW_CA_CERT, NO_CA_CERT } from 'uiSrc/pages/home/constants'
 
-export interface DbConnectionInfo extends Instance {
-  id?: string
+export interface DbConnectionInfo extends Omit<Instance, 'id' | 'port' | 'password' | 'timeout'> {
+  id: string
   port: string
   tlsClientAuthRequired?: boolean
   certificates?: { id: number; name: string }[]
@@ -33,6 +33,7 @@ export interface DbConnectionInfo extends Instance {
   sshPassword?: string | true
   sshPrivateKey?: string | true
   sshPassphrase?: string | true
+  microsoftAccount?: string
 }
 
 export interface ISubmitButton {

--- a/redisinsight/ui/src/slices/instances/microsoftAuthSession.ts
+++ b/redisinsight/ui/src/slices/instances/microsoftAuthSession.ts
@@ -1,0 +1,118 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+import { ApiEndpoints } from 'uiSrc/constants'
+import { apiService } from 'uiSrc/services'
+import { getApiErrorMessage, getAxiosError, isStatusSuccessful } from 'uiSrc/utils'
+import { addErrorNotification } from '../app/notifications'
+import { AppDispatch, RootState } from '../store'
+import { EnhancedAxiosError } from '../interfaces'
+
+export interface MicrosoftAuthSession {
+  username: string | null;
+  displayName: string | null;
+  authenticated: boolean;
+  idTokenClaims?: Record<string, any> | null;
+  expiresOn?: Date | null;
+  error?: string;
+}
+
+export interface MicrosoftAuthSessionsState {
+  loading: boolean;
+  error: string;
+  data: Record<string, MicrosoftAuthSession>;
+}
+
+export const initialState: MicrosoftAuthSessionsState = {
+  loading: false,
+  error: '',
+  data: {},
+}
+
+export const microsoftAuthSessionSlice = createSlice({
+  name: 'microsoftAuthSession',
+  initialState,
+  reducers: {
+    loadMicrosoftAuthSession: (state) => {
+      state.loading = true
+      state.error = ''
+    },
+    loadMicrosoftAuthSessionSuccess: (state, { payload }) => {
+      state.loading = false
+      // Store the session data indexed by the database ID
+      state.data = {
+        ...state.data,
+        [payload.databaseId]: payload.data
+      }
+    },
+    loadMicrosoftAuthSessionFailure: (state, { payload }) => {
+      state.loading = false
+      state.error = payload
+    },
+    resetMicrosoftAuthSession: (state, { payload }) => {
+      // Remove the session data for a specific database ID
+      if (payload.databaseId && state.data[payload.databaseId]) {
+        const newData = { ...state.data }
+        delete newData[payload.databaseId]
+        state.data = newData
+      }
+    },
+    resetAllMicrosoftAuthSessions: (state) => {
+      state.data = {}
+    },
+  },
+})
+
+export const {
+  loadMicrosoftAuthSession,
+  loadMicrosoftAuthSessionSuccess,
+  loadMicrosoftAuthSessionFailure,
+  resetMicrosoftAuthSession,
+  resetAllMicrosoftAuthSessions,
+} = microsoftAuthSessionSlice.actions
+
+export const microsoftAuthSessionSelector = (state: RootState) => state.connections.microsoftAuthSession
+export const selectMicrosoftAuthSessionByDatabaseId = (databaseId: string) =>
+  (state: RootState) => state.connections.microsoftAuthSession.data[databaseId]
+
+export default microsoftAuthSessionSlice.reducer
+
+export function fetchMicrosoftAuthSession(databaseId: string) {
+  return async (dispatch: AppDispatch) => {
+    dispatch(loadMicrosoftAuthSession())
+
+    try {
+      // Construct the API URL with the database ID
+      const endpoint = `${ApiEndpoints.MICROSOFT_AUTH_SESSION}/${databaseId}`
+      const { data, status } = await apiService.get(endpoint)
+
+      if (isStatusSuccessful(status)) {
+        dispatch(
+          loadMicrosoftAuthSessionSuccess({
+            databaseId,
+            data,
+          })
+        )
+        return data
+      }
+
+      return {
+        authenticated: false,
+        username: null,
+        displayName: null,
+        error: `Invalid response status: ${status}`
+      }
+    } catch (error) {
+      const errorMessage = getApiErrorMessage(error as EnhancedAxiosError)
+      const err = getAxiosError(error as EnhancedAxiosError)
+
+      dispatch(loadMicrosoftAuthSessionFailure(errorMessage))
+      dispatch(addErrorNotification(err))
+      return {
+        authenticated: false,
+        username: null,
+        displayName: null,
+        error: errorMessage
+      }
+    }
+  }
+}

--- a/redisinsight/ui/src/slices/interfaces/cloud.ts
+++ b/redisinsight/ui/src/slices/interfaces/cloud.ts
@@ -100,7 +100,8 @@ export enum OAuthSocialSource {
 export enum OAuthSocialAction {
   Create = 'create',
   Import = 'import',
-  SignIn = 'signIn'
+  SignIn = 'signIn',
+  EditDatabase = 'editDatabase'
 }
 
 export enum OAuthStrategy {

--- a/redisinsight/ui/src/slices/store.ts
+++ b/redisinsight/ui/src/slices/store.ts
@@ -8,6 +8,8 @@ import clientCertsReducer from './instances/clientCerts'
 import clusterReducer from './instances/cluster'
 import cloudReducer from './instances/cloud'
 import sentinelReducer from './instances/sentinel'
+import azureReducer from './instances/microsoftAzure'
+import microsoftAuthSessionReducer from './instances/microsoftAuthSession'
 import keysReducer from './browser/keys'
 import stringReducer from './browser/string'
 import zsetReducer from './browser/zset'
@@ -54,7 +56,6 @@ import rdiDryRunJobReducer from './rdi/dryRun'
 import rdiTestConnectionsReducer from './rdi/testConnections'
 import rdiStatisticsReducer from './rdi/statistics'
 import aiAssistantReducer from './panels/aiAssistant'
-import azureReducer from './instances/microsoftAzure'
 
 const riConfig = getConfig()
 
@@ -82,6 +83,7 @@ export const rootReducer = combineReducers({
     cloud: cloudReducer,
     sentinel: sentinelReducer,
     azure: azureReducer,
+    microsoftAuthSession: microsoftAuthSessionReducer,
   }),
   browser: combineReducers({
     keys: keysReducer,

--- a/redisinsight/ui/src/types/index.d.ts
+++ b/redisinsight/ui/src/types/index.d.ts
@@ -42,6 +42,7 @@ export interface WindowApp {
   sendWindowId: any
   cloudOauthCallback: any
   microsoftAuthCallback: any
+  microsoftAuthEditCallback: any
   deepLinkAction: any
   updateAvailable: any
   ipc: IPCHandler

--- a/redisinsight/ui/src/utils/test-utils.tsx
+++ b/redisinsight/ui/src/utils/test-utils.tsx
@@ -94,6 +94,7 @@ const initialStateDefault: RootState = {
     cloud: cloneDeep(initialStateCloud),
     sentinel: cloneDeep(initialStateSentinel),
     azure: cloneDeep(initialStateAzure),
+    microsoftAuthSession: { loading: false, error: '', data: {} },
   },
   browser: {
     keys: cloneDeep(initialStateKeys),


### PR DESCRIPTION
This is a follow up of https://github.com/RedisInsight/RedisInsight/pull/4373 and https://github.com/RedisInsight/RedisInsight/pull/4410

The main changes are:

-  The auth flow is changed to use a custom CredentialsProvider that uses node-msal more direct
- There is an SQLitePersistencePlugin added to the way we are using node-msal. This way we can cache the received credentials encrypted in our own sql lite db, then restore the connection after.

I am still testing out different expiration scenarios with the tokens, but so far it seems to work well and I'd like to gather some feedback before continuing down that path (fixing all todos left, removing the logs left for showing the flow, etc) 