### PR TITLE
Ri-7024: close the add key panel if open, after load sample data is executed

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/no-keys-found/NoKeysFound.tsx
+++ b/redisinsight/ui/src/pages/browser/components/no-keys-found/NoKeysFound.tsx
@@ -53,6 +53,8 @@ const NoKeysFound = (props: Props) => {
         count: SCAN_TREE_COUNT_DEFAULT,
       }),
     )
+
+    onAddKeyPanel(false)
   }
 
   return (


### PR DESCRIPTION
**Testing steps**:
- add db instance with no keys
- open the form to add a key manually
- load the sample data while the form is still open
- loaded data is displayed

**Expected**: The add key form should close when sample data is loaded 

**Before**: The add key form is open after load sample data is clicked and displayed
