### PR TITLE
[RI-7074] revert anchorClassName prop usage for RiTooltip

### DIFF
--- a/redisinsight/ui/src/components/base/shared/WindowControlGroup.tsx
+++ b/redisinsight/ui/src/components/base/shared/WindowControlGroup.tsx
@@ -22,7 +22,11 @@ export const WindowControlGroup = ({
 }: Props) => (
   <Row gap="m" justify="end">
     <FlexItem>
-      <RiTooltip content={hideContent} position="top">
+      <RiTooltip
+        content={hideContent}
+        position="top"
+        anchorClassName="flex-row"
+      >
         <IconButton
           size="S"
           icon={MinusIcon}
@@ -34,7 +38,11 @@ export const WindowControlGroup = ({
       </RiTooltip>
     </FlexItem>
     <FlexItem>
-      <RiTooltip content={closeContent} position="top">
+      <RiTooltip
+        content={closeContent}
+        position="top"
+        anchorClassName="flex-row"
+      >
         <IconButton
           size="S"
           icon={CancelSlimIcon}

--- a/redisinsight/ui/src/components/base/tooltip/RITooltip.tsx
+++ b/redisinsight/ui/src/components/base/tooltip/RITooltip.tsx
@@ -8,6 +8,7 @@ export interface RiTooltipProps
   title?: React.ReactNode
   position?: TooltipProps['placement']
   delay?: TooltipProps['openDelayDuration']
+  anchorClassName?: string
 }
 
 export const RiTooltip = ({
@@ -16,6 +17,7 @@ export const RiTooltip = ({
   content,
   position,
   delay,
+  anchorClassName,
   ...props
 }: RiTooltipProps) => (
   <TooltipProvider>
@@ -25,7 +27,7 @@ export const RiTooltip = ({
       placement={position}
       openDelayDuration={delay}
     >
-      <span>{children}</span>
+      <span className={anchorClassName}>{children}</span>
     </Tooltip>
   </TooltipProvider>
 )

--- a/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
@@ -17,7 +17,6 @@ import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import { PrimaryButton } from 'uiSrc/components/base/forms/buttons'
 import { InfoIcon } from 'uiSrc/components/base/icons'
 import { Title } from 'uiSrc/components/base/text/Title'
-import { CallOut } from 'uiSrc/components/base/display/call-out/CallOut'
 import { Text } from 'uiSrc/components/base/text'
 import { SwitchInput } from 'uiSrc/components/base/inputs'
 import { Link } from 'uiSrc/components/base/link/Link'
@@ -330,6 +329,7 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
         <FlexItem>
           <RiTooltip
             position="top"
+            anchorClassName="euiToolTip__btn-disabled"
             content={
               submitIsDisabled() ? (
                 <span>

--- a/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.tsx
+++ b/redisinsight/ui/src/components/database-list-modules/DatabaseListModules.tsx
@@ -142,7 +142,12 @@ const DatabaseListModules = React.memo((props: Props) => {
       !inCircle ? (
         Module(moduleName, abbreviation, icon, content)
       ) : (
-        <RiTooltip position="bottom" content={Content[i]} key={moduleName}>
+        <RiTooltip
+          position="bottom"
+          content={Content[i]}
+          anchorClassName={styles.anchorModuleTooltip}
+          key={moduleName}
+        >
           <>{Module(moduleName, abbreviation, icon, content)}</>
         </RiTooltip>
       ),

--- a/redisinsight/ui/src/components/database-list-options/DatabaseListOptions.tsx
+++ b/redisinsight/ui/src/components/database-list-options/DatabaseListOptions.tsx
@@ -96,6 +96,7 @@ const DatabaseListOptions = ({ options }: Props) => {
               : contentProp
           }
           position="top"
+          anchorClassName={styles.tooltip}
         >
           {icon ? (
             <IconButton

--- a/redisinsight/ui/src/components/formated-date/FormatedDate.tsx
+++ b/redisinsight/ui/src/components/formated-date/FormatedDate.tsx
@@ -4,6 +4,7 @@ import { DATETIME_FORMATTER_DEFAULT, TimezoneOption } from 'uiSrc/constants'
 import { userSettingsConfigSelector } from 'uiSrc/slices/user/user-settings'
 import { formatTimestamp } from 'uiSrc/utils'
 import { RiTooltip } from 'uiSrc/components'
+import styles from './styles.module.scss'
 
 export interface Props {
   date: Date | string | number
@@ -19,7 +20,7 @@ const FormatedDate = ({ date }: Props) => {
   const formatedDate = formatTimestamp(date, dateFormat, timezone)
 
   return (
-    <RiTooltip content={formatedDate}>
+    <RiTooltip anchorClassName={styles.text} content={formatedDate}>
       <span>{formatedDate}</span>
     </RiTooltip>
   )

--- a/redisinsight/ui/src/components/full-screen/FullScreen.tsx
+++ b/redisinsight/ui/src/components/full-screen/FullScreen.tsx
@@ -19,6 +19,7 @@ const FullScreen = ({
   <RiTooltip
     content={isFullScreen ? 'Exit Full Screen' : 'Full Screen'}
     position="left"
+    anchorClassName={anchorClassName}
   >
     <IconButton
       icon={isFullScreen ? ShrinkIcon : ExtendIcon}

--- a/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
+++ b/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
@@ -165,6 +165,7 @@ const InlineItemEditor = (props: Props) => {
 
   const ApplyBtn = (
     <RiTooltip
+      anchorClassName={styles.tooltip}
       position="bottom"
       title={
         (isDisabled && disabledTooltipText?.title) ||

--- a/redisinsight/ui/src/components/instance-header/InstanceHeader.tsx
+++ b/redisinsight/ui/src/components/instance-header/InstanceHeader.tsx
@@ -266,6 +266,7 @@ const InstanceHeader = ({ onChangeDbIndex }: Props) => {
                   <FlexItem style={{ paddingLeft: 6 }}>
                     <RiTooltip
                       position="right"
+                      anchorClassName={styles.tooltipAnchor}
                       className={styles.tooltip}
                       content={
                         <ShortInstanceInfo

--- a/redisinsight/ui/src/components/monitor/MonitorHeader/MonitorHeader.tsx
+++ b/redisinsight/ui/src/components/monitor/MonitorHeader/MonitorHeader.tsx
@@ -100,6 +100,7 @@ const MonitorHeader = ({ handleRunMonitor }: Props) => {
                     ? 'Pause'
                     : 'Resume'
               }
+              anchorClassName="inline-flex"
             >
               <IconButton
                 icon={
@@ -119,6 +120,9 @@ const MonitorHeader = ({ handleRunMonitor }: Props) => {
               content={
                 !isStarted || !items.length ? '' : 'Clear Profiler Window'
               }
+              anchorClassName={cx('inline-flex', {
+                transparent: !isStarted || !items.length,
+              })}
             >
               <IconButton
                 icon={DeleteIcon}

--- a/redisinsight/ui/src/components/multi-search/MultiSearch.tsx
+++ b/redisinsight/ui/src/components/multi-search/MultiSearch.tsx
@@ -302,6 +302,7 @@ const MultiSearch = (props: Props) => {
           {disableSubmit && (
             <RiTooltip
               position="top"
+              anchorClassName={styles.anchorSubmitBtn}
               content="Please choose index in order to preform the search"
             >
               {SubmitBtn()}

--- a/redisinsight/ui/src/components/oauth/shared/oauth-form/components/oauth-sso-form/OAuthSsoForm.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-form/components/oauth-sso-form/OAuthSsoForm.tsx
@@ -61,6 +61,7 @@ const OAuthSsoForm = ({ onBack, onSubmit }: Props) => {
   }) => (
     <RiTooltip
       position="top"
+      anchorClassName="euiToolTip__btn-disabled"
       data-testid="btn-submit-tooltip"
       content={
         disabled ? (

--- a/redisinsight/ui/src/components/oauth/shared/oauth-recommended-settings/OAuthRecommendedSettings.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-recommended-settings/OAuthRecommendedSettings.tsx
@@ -35,6 +35,7 @@ const OAuthRecommendedSettings = (props: Props) => {
             </>
           }
           position="top"
+          anchorClassName={styles.recommendedSettingsToolTip}
         >
           <EuiIcon type="iInCircle" size="s" />
         </RiTooltip>

--- a/redisinsight/ui/src/components/oauth/shared/oauth-social-buttons/OAuthSocialButtons.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-social-buttons/OAuthSocialButtons.tsx
@@ -60,6 +60,7 @@ const OAuthSocialButtons = (props: Props) => {
         <RiTooltip
           key={label}
           position="top"
+          anchorClassName={!agreement ? 'euiToolTip__btn-disabled' : ''}
           content={agreement ? null : 'Acknowledge the agreement'}
           data-testid={`${label}-tooltip`}
         >

--- a/redisinsight/ui/src/components/query/query-card/QueryCardHeader/QueryCardHeader.tsx
+++ b/redisinsight/ui/src/components/query/query-card/QueryCardHeader/QueryCardHeader.tsx
@@ -251,7 +251,11 @@ const QueryCardHeader = (props: Props) => {
       disabled: false,
       inputDisplay: (
         <div className={styles.changeViewWrapper}>
-          <RiTooltip content={truncateText(text, 500)} position="left">
+          <RiTooltip
+            content={truncateText(text, 500)}
+            position="left"
+            anchorClassName={styles.changeViewWrapper}
+          >
             <EuiIcon
               className={styles.iconDropdownOption}
               type={theme === Theme.Dark ? iconDark : iconLight}
@@ -390,6 +394,7 @@ const QueryCardHeader = (props: Props) => {
                   title="Processing Time"
                   content={getExecutionTimeString(executionTime)}
                   position="left"
+                  anchorClassName={styles.executionTime}
                   data-testid="execution-time-tooltip"
                 >
                   <>
@@ -481,7 +486,11 @@ const QueryCardHeader = (props: Props) => {
             </FlexItem>
             {!isFullScreen && (
               <FlexItem className={cx(styles.buttonIcon, styles.playIcon)}>
-                <RiTooltip content="Run again" position="left">
+                <RiTooltip
+                  content="Run again"
+                  position="left"
+                  anchorClassName={cx(styles.buttonIcon, styles.playIcon)}
+                >
                   <IconButton
                     disabled={emptyCommand}
                     icon={PlayIcon}
@@ -506,6 +515,7 @@ const QueryCardHeader = (props: Props) => {
               {(isRawMode(mode) || isGroupResults(resultsMode)) && (
                 <RiTooltip
                   className={styles.tooltip}
+                  anchorClassName={styles.buttonIcon}
                   content={
                     <>
                       {isGroupMode(resultsMode) && (

--- a/redisinsight/ui/src/components/query/query-card/QueryCardTooltip/QueryCardTooltip.tsx
+++ b/redisinsight/ui/src/components/query/query-card/QueryCardTooltip/QueryCardTooltip.tsx
@@ -72,6 +72,7 @@ const QueryCardTooltip = (props: Props) => {
   return (
     <RiTooltip
       className={styles.tooltip}
+      anchorClassName={styles.tooltipAnchor}
       content={<>{contentItems}</>}
       position="bottom"
     >

--- a/redisinsight/ui/src/components/recommendation/badge-icon/BadgeIcon.tsx
+++ b/redisinsight/ui/src/components/recommendation/badge-icon/BadgeIcon.tsx
@@ -16,7 +16,7 @@ const BadgeIcon = ({ id, icon, name }: Props) => (
     data-testid={`recommendation-badge-${id}`}
   >
     <div data-testid={id} className={styles.badgeWrapper}>
-      <RiTooltip content={name} position="top">
+      <RiTooltip content={name} position="top" anchorClassName="flex-row">
         {icon}
       </RiTooltip>
     </div>

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/expert-chat/components/expert-chat-header/ExpertChatHeader.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/expert-chat/components/expert-chat-header/ExpertChatHeader.tsx
@@ -63,7 +63,10 @@ const ExpertChatHeader = (props: Props) => {
   return (
     <div className={styles.header}>
       {connectedInstanceName ? (
-        <RiTooltip content={connectedInstanceName}>
+        <RiTooltip
+          content={connectedInstanceName}
+          anchorClassName={styles.dbName}
+        >
           <Text size="xs" className="truncateText">
             {connectedInstanceName}
           </Text>
@@ -78,6 +81,7 @@ const ExpertChatHeader = (props: Props) => {
               ? undefined
               : 'Open relevant tutorials to learn more'
           }
+          anchorClassName={styles.headerBtnAnchor}
           position="bottom"
         >
           <EuiPopover

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/InternalLink/InternalLink.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/InternalLink/InternalLink.tsx
@@ -45,7 +45,7 @@ const InternalLink = (props: Props) => {
   }
 
   const content = (
-    <RiTooltip content={toolTip}>
+    <RiTooltip content={toolTip} anchorClassName={styles.content}>
       <span className={styles.content}>
         <div className={styles.title}>{children || label}</div>
         {!!summary && (

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/UploadTutorialForm/UploadTutorialForm.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/UploadTutorialForm/UploadTutorialForm.tsx
@@ -115,6 +115,7 @@ const UploadTutorialForm = (props: Props) => {
               </SecondaryButton>
               <RiTooltip
                 position="top"
+                anchorClassName="euiToolTip__btn-disabled"
                 title={
                   isSubmitDisabled
                     ? validationErrors.REQUIRED_TITLE(

--- a/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/LiveTimeRecommendations.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/LiveTimeRecommendations.tsx
@@ -145,6 +145,7 @@ const LiveTimeRecommendations = () => {
         <RiTooltip
           position="bottom"
           className={styles.tooltip}
+          anchorClassName={styles.tooltipAnchor}
           content={
             <>
               Tips will help you improve your database.

--- a/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/components/recommendation/Recommendation.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/components/recommendation/Recommendation.tsx
@@ -89,7 +89,11 @@ const RecommendationTitle = ({
             className={styles.redisStackLink}
             data-testid={`${id}-redis-stack-link`}
           >
-            <RiTooltip content="Redis Stack" position="top">
+            <RiTooltip
+              content="Redis Stack"
+              position="top"
+              anchorClassName="flex-row"
+            >
               <EuiIcon
                 type={
                   theme === Theme.Dark ? RediStackDarkMin : RediStackLightMin
@@ -248,6 +252,7 @@ const Recommendation = ({
             title="Snooze tip"
             content="This tip will be removed from the list and displayed again when relevant."
             position="top"
+            anchorClassName="flex-row"
           >
             <IconButton
               icon={SnoozeIcon}
@@ -267,6 +272,7 @@ const Recommendation = ({
                 : 'This tip will be removed from the list and not displayed again.'
             }`}
             position="top"
+            anchorClassName="flex-row"
           >
             <IconButton
               icon={hide ? HideIcon : ShowIcon}

--- a/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
+++ b/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
@@ -79,6 +79,7 @@ const TableResult = React.memo((props: Props) => {
                 position="bottom"
                 title={title}
                 className="text-multiline-ellipsis"
+                anchorClassName={cx('tooltip')}
                 content={formatLongName(value.toString())}
               >
                 <div className="copy-btn-wrapper">

--- a/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases-result/RedisCloudDatabasesResultPage.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases-result/RedisCloudDatabasesResultPage.tsx
@@ -82,6 +82,7 @@ const RedisCloudDatabasesResultPage = () => {
               position="bottom"
               title="Database"
               className={styles.tooltipColumnName}
+              anchorClassName="truncateText"
               content={formatLongName(name)}
             >
               <Text>{cellContent}</Text>
@@ -113,6 +114,7 @@ const RedisCloudDatabasesResultPage = () => {
               position="bottom"
               title="Subscription"
               className={styles.tooltipColumnName}
+              anchorClassName="truncateText"
               content={formatLongName(name)}
             >
               <Text>{cellContent}</Text>
@@ -152,7 +154,7 @@ const RedisCloudDatabasesResultPage = () => {
         return (
           <div className="public_endpoint">
             <Text className="copyPublicEndpointText">{text}</Text>
-            <RiTooltip position="right" content="Copy">
+            <RiTooltip position="right" content="Copy" anchorClassName="copyPublicEndpointTooltip">
               <IconButton
                 icon={CopyIcon}
                 aria-label="Copy public endpoint"
@@ -205,7 +207,7 @@ const RedisCloudDatabasesResultPage = () => {
             {statusAdded === AddRedisDatabaseStatus.Success ? (
               <Text>{messageAdded}</Text>
             ) : (
-              <RiTooltip position="left" title="Error" content={messageAdded}>
+              <RiTooltip position="left" title="Error" content={messageAdded} anchorClassName="truncateText">
                 <Row align="center" gap="s">
                   <FlexItem>
                     <EuiIcon type="alert" color="danger" />

--- a/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases/RedisCloudDatabases/RedisCloudDatabases.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases/RedisCloudDatabases/RedisCloudDatabases.tsx
@@ -167,6 +167,7 @@ const RedisCloudDatabasesPage = ({
   const SubmitButton = ({ isDisabled }: { isDisabled: boolean }) => (
     <RiTooltip
       position="top"
+      anchorClassName="euiToolTip__btn-disabled"
       title={
         isDisabled ? validationErrors.SELECT_AT_LEAST_ONE('database') : null
       }

--- a/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases/RedisCloudDatabasesPage.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-databases/RedisCloudDatabasesPage.tsx
@@ -140,6 +140,7 @@ const RedisCloudDatabasesPage = () => {
               position="bottom"
               title="Database"
               className={styles.tooltipColumnName}
+              anchorClassName="truncateText"
               content={formatLongName(name)}
             >
               <Text>{cellContent}</Text>
@@ -178,6 +179,7 @@ const RedisCloudDatabasesPage = () => {
               position="bottom"
               title="Subscription"
               className={styles.tooltipColumnName}
+              anchorClassName="truncateText"
               content={formatLongName(name)}
             >
               <Text>{cellContent}</Text>
@@ -217,7 +219,7 @@ const RedisCloudDatabasesPage = () => {
         return (
           <div className="public_endpoint">
             <Text className="copyPublicEndpointText">{text}</Text>
-            <RiTooltip position="right" content="Copy">
+            <RiTooltip position="right" content="Copy" anchorClassName="copyPublicEndpointTooltip">
               <IconButton
                 icon={CopyIcon}
                 aria-label="Copy public endpoint"

--- a/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-subscriptions/RedisCloudSubscriptions/RedisCloudSubscriptions.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-cloud/redis-cloud-subscriptions/RedisCloudSubscriptions/RedisCloudSubscriptions.tsx
@@ -178,6 +178,7 @@ const RedisCloudSubscriptions = ({
   const SubmitButton = ({ isDisabled }: { isDisabled: boolean }) => (
     <RiTooltip
       position="top"
+      anchorClassName="euiToolTip__btn-disabled"
       title={
         isDisabled ? validationErrors.SELECT_AT_LEAST_ONE('subscription') : null
       }

--- a/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases-result/SentinelDatabasesResultPage.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases-result/SentinelDatabasesResultPage.tsx
@@ -190,7 +190,11 @@ const SentinelDatabasesResultPage = () => {
         return (
           <div className="host_port">
             <Text className="copyHostPortText">{text}</Text>
-            <RiTooltip position="right" content="Copy">
+            <RiTooltip
+              position="right"
+              content="Copy"
+              anchorClassName="copyPublicEndpointTooltip"
+            >
               <IconButton
                 icon={CopyIcon}
                 aria-label="Copy public endpoint"
@@ -326,12 +330,9 @@ const SentinelDatabasesResultPage = () => {
           <div role="presentation">
             <RiTooltip
               position="top"
+              anchorClassName="euiToolTip__btn-disabled"
               title={isDisabled ? validationErrors.REQUIRED_TITLE(1) : null}
-              content={
-                isDisabled ? (
-                  <span>Database Alias</span>
-                ) : null
-              }
+              content={isDisabled ? <span>Database Alias</span> : null}
             >
               <PrimaryButton
                 size="s"

--- a/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases/SentinelDatabasesPage.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases/SentinelDatabasesPage.tsx
@@ -157,7 +157,11 @@ const SentinelDatabasesPage = () => {
         return (
           <div className="host_port">
             <Text className="copyHostPortText">{text}</Text>
-            <RiTooltip position="right" content="Copy">
+            <RiTooltip
+              position="right"
+              content="Copy"
+              anchorClassName="copyPublicEndpointTooltip"
+            >
               <IconButton
                 icon={CopyIcon}
                 aria-label="Copy public endpoint"
@@ -243,6 +247,7 @@ const SentinelDatabasesPage = () => {
               onChangedInput={handleChangedInput}
               append={
                 <RiTooltip
+                  anchorClassName="inputAppendIcon"
                   position="left"
                   content="Select the Redis logical database to work with in Browser and Workbench."
                 >

--- a/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases/components/SentinelDatabases/SentinelDatabases.tsx
+++ b/redisinsight/ui/src/pages/autodiscover-sentinel/sentinel-databases/components/SentinelDatabases/SentinelDatabases.tsx
@@ -175,6 +175,7 @@ const SentinelDatabases = ({
     return (
       <RiTooltip
         position="top"
+        anchorClassName="euiToolTip__btn-disabled"
         title={title}
         content={
           isSubmitDisabled() ? (

--- a/redisinsight/ui/src/pages/browser/components/add-items-actions/AddItemsActions.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-items-actions/AddItemsActions.tsx
@@ -53,6 +53,7 @@ const AddItemsActions = (props: Props) => {
               <RiTooltip
                 content={length === 1 ? 'Clear' : 'Remove'}
                 position="left"
+                anchorClassName={anchorClassName}
               >
                 <IconButton
                   icon={DeleteIcon}
@@ -66,14 +67,17 @@ const AddItemsActions = (props: Props) => {
           )}
           {index === length - 1 && (
             <div>
-              <RiTooltip content="Add" position="left">
+              <RiTooltip
+                content="Add"
+                position="left"
+                anchorClassName={anchorClassName}
+              >
                 <IconButton
                   icon={PlusInCircleIcon}
                   disabled={loading || addItemIsDisabled}
                   aria-label="Add new item"
                   onClick={addItem}
                   data-testid={dataTestId || 'add-new-item'}
-                  className={anchorClassName}
                 />
               </RiTooltip>
             </div>

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKey.tsx
@@ -132,11 +132,15 @@ const AddKey = (props: Props) => {
           <FlexItem grow style={{ marginBottom: '36px' }}>
             <Title size="M">New Key</Title>
             {!arePanelsCollapsed && (
-              <RiTooltip content="Close" position="left">
+              <RiTooltip
+                content="Close"
+                position="left"
+                anchorClassName={styles.closeKeyTooltip}
+              >
                 <IconButton
                   icon={CancelSlimIcon}
                   aria-label="Close key"
-                  className={cx(styles.closeBtn, styles.closeKeyTooltip)}
+                  className={styles.closeBtn}
                   onClick={() => closeKey()}
                 />
               </RiTooltip>

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActions.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkActions.tsx
@@ -115,7 +115,11 @@ const BulkActions = (props: Props) => {
             />
           )}
           {(!arePanelsCollapsed || isFullScreen) && (
-            <RiTooltip content="Close" position="left">
+            <RiTooltip
+              content="Close"
+              position="left"
+              anchorClassName={styles.anchorTooltip}
+            >
               <IconButton
                 icon={CancelSlimIcon}
                 aria-label="Close panel"

--- a/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummary/BulkDeleteSummary.tsx
+++ b/redisinsight/ui/src/pages/browser/components/bulk-actions/BulkDelete/BulkDeleteSummary/BulkDeleteSummary.tsx
@@ -45,6 +45,7 @@ const BulkDeleteSummary = () => {
             <span>{title}</span>
             <RiTooltip
               position="right"
+              anchorClassName={styles.tooltipAnchor}
               content="Expected amount is estimated based on
               the number of keys scanned and the scan percentage.
               The final number may be different."

--- a/redisinsight/ui/src/pages/browser/components/create-redisearch-index/CreateRedisearchIndexWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/components/create-redisearch-index/CreateRedisearchIndexWrapper.tsx
@@ -31,7 +31,11 @@ const CreateRedisearchIndexWrapper = ({
             New Index
           </Title>
           {!arePanelsCollapsed && (
-            <RiTooltip content="Close" position="left">
+            <RiTooltip
+              content="Close"
+              position="left"
+              anchorClassName={styles.closeRightPanel}
+            >
               <IconButton
                 icon={CancelSlimIcon}
                 aria-label="Close panel"

--- a/redisinsight/ui/src/pages/browser/components/key-row-name/KeyRowName.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-row-name/KeyRowName.tsx
@@ -44,6 +44,7 @@ const KeyRowName = (props: Props) => {
           <RiTooltip
             title="Key Name"
             className={styles.tooltip}
+            anchorClassName="truncateText"
             position="bottom"
             content={nameTooltipContent}
           >

--- a/redisinsight/ui/src/pages/browser/components/key-row-size/KeyRowSize.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-row-size/KeyRowSize.tsx
@@ -58,6 +58,7 @@ const KeyRowSize = (props: Props) => {
           <RiTooltip
             title="Key Size"
             className={styles.tooltip}
+            anchorClassName="truncateText"
             position="right"
             content={<>{formatBytes(size, 3)}</>}
           >

--- a/redisinsight/ui/src/pages/browser/components/key-row-ttl/KeyRowTTL.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-row-ttl/KeyRowTTL.tsx
@@ -61,6 +61,7 @@ const KeyRowTTL = (props: Props) => {
         <RiTooltip
           title="Time to Live"
           className={styles.tooltip}
+          anchorClassName="truncateText"
           position="right"
           content={
             <>

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -404,6 +404,7 @@ const KeysHeader = (props: Props) => {
                         <RiTooltip
                           content="Hide the key size to avoid performance issues when working with large keys."
                           position="top"
+                          anchorClassName="flex-row"
                         >
                           <EuiIcon
                             className={styles.infoIcon}

--- a/redisinsight/ui/src/pages/browser/components/popover-delete/PopoverDelete.tsx
+++ b/redisinsight/ui/src/pages/browser/components/popover-delete/PopoverDelete.tsx
@@ -87,6 +87,7 @@ const PopoverDelete = (props: Props) => {
   const deleteButtonWithTooltip = (
     <RiTooltip
       content={TEXT_DISABLED_ACTION_WITH_TRUNCATED_DATA}
+      anchorClassName={styles.editBtnAnchor}
       data-testid={testid ? `${testid}-tooltip` : 'remove-tooltip'}
     >
       {deleteButton}

--- a/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/Node.tsx
+++ b/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/Node.tsx
@@ -111,7 +111,11 @@ const Node = ({
   }
 
   const Folder = () => (
-    <RiTooltip content={tooltipContent} position="bottom" anchorClassName={styles.anchorTooltipNode}>
+    <RiTooltip
+      content={tooltipContent}
+      position="bottom"
+      anchorClassName={styles.anchorTooltipNode}
+    >
       <>
         <div className={styles.nodeName}>
           <EuiIcon

--- a/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/Node.tsx
+++ b/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/Node.tsx
@@ -13,7 +13,6 @@ import KeyRowType from 'uiSrc/pages/browser/components/key-row-type'
 import { RedisResponseBuffer } from 'uiSrc/slices/interfaces'
 import { appContextDbConfig } from 'uiSrc/slices/app/context'
 import { RiTooltip } from 'uiSrc/components'
-import { Col, Row } from 'uiSrc/components/base/layout/flex'
 import { DeleteKeyPopover } from '../../../delete-key-popover/DeleteKeyPopover'
 import { TreeData } from '../../interfaces'
 import styles from './styles.module.scss'
@@ -112,12 +111,8 @@ const Node = ({
   }
 
   const Folder = () => (
-    <RiTooltip
-      content={tooltipContent}
-      position="bottom"
-      style={{ width: '100%' }}
-    >
-      <Row responsive align="center" grow className={styles.anchorTooltipNode}>
+    <RiTooltip content={tooltipContent} position="bottom" anchorClassName={styles.anchorTooltipNode}>
+      <>
         <div className={styles.nodeName}>
           <EuiIcon
             type={isOpen ? 'arrowDown' : 'arrowRight'}
@@ -146,7 +141,7 @@ const Node = ({
             {keyCount ?? ''}
           </div>
         </div>
-      </Row>
+      </>
     </RiTooltip>
   )
 
@@ -184,9 +179,7 @@ const Node = ({
   )
 
   const Node = (
-    <Row
-      justify="between"
-      align="center"
+    <div
       className={cx(styles.nodeContent, 'rowKey', {
         [styles.nodeContentOpen]: isOpen && !isLeaf,
       })}
@@ -199,11 +192,11 @@ const Node = ({
     >
       {!isLeaf && <Folder />}
       {isLeaf && <Leaf />}
-    </Row>
+    </div>
   )
 
   const tooltipContent = (
-    <Col gap="m">
+    <>
       <div className={styles.folderTooltipHeader}>
         <span
           className={styles.folderPattern}
@@ -217,7 +210,7 @@ const Node = ({
         )}
       </div>
       <span>{`${keyCount} key(s) (${Math.round(keyApproximate * 100) / 100}%)`}</span>
-    </Col>
+    </>
   )
 
   return (

--- a/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/styles.module.scss
@@ -1,6 +1,9 @@
 .anchorTooltipNode {
+  width: 100%;
   height: 42px;
+  display: flex !important;
   position: relative;
+  align-items: center;
 }
 
 .nodeContainer {
@@ -16,9 +19,12 @@
 }
 
 .nodeContent {
+  display: flex;
+  justify-content: space-between;
   cursor: pointer;
   padding: 8px 16px;
   color: var(--euiTextSubduedColor) !important;
+  align-items: center;
   font:
     normal normal normal 13px/28px Graphik,
     sans-serif !important;

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.tsx
@@ -72,6 +72,7 @@ const KeyDetailsHeaderFormatter = (props: Props) => {
                 : typeSelected
             }
             position="top"
+            anchorClassName="flex-row"
           >
             <>
               {width >= MIDDLE_SCREEN_RESOLUTION ? (

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-name/KeyDetailsHeaderName.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-name/KeyDetailsHeaderName.tsx
@@ -165,8 +165,9 @@ const KeyDetailsHeaderName = ({ onEditKey }: Props) => {
               title="Key Name"
               position="left"
               content={tooltipContent}
+              anchorClassName={styles.toolTipAnchorKey}
             >
-              <span className={styles.toolTipAnchorKey}>
+              <>
                 <InlineItemEditor
                   onApply={() => applyEditKey()}
                   isDisabled={!keyIsEditable}
@@ -199,10 +200,14 @@ const KeyDetailsHeaderName = ({ onEditKey }: Props) => {
                   />
                 </InlineItemEditor>
                 <p className={styles.keyHiddenText}>{key}</p>
-              </span>
+              </>
             </RiTooltip>
             {keyIsHovering && (
-              <RiTooltip position="right" content="Copy">
+              <RiTooltip
+                position="right"
+                content="Copy"
+                anchorClassName={styles.copyKey}
+              >
                 <IconButton
                   icon={CopyIcon}
                   id={COPY_KEY_NAME_ICON}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/hash-details-table/HashDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/hash-details-table/HashDetailsTable.tsx
@@ -585,6 +585,7 @@ const HashDetailsTable = (props: Props) => {
                 <RiTooltip
                   title="Time to Live"
                   className={styles.tooltip}
+                  anchorClassName="truncateText"
                   position="right"
                   content={truncateNumberToDuration(expire || 0)}
                 >

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/key-details-actions/add-items-action/AddItemsAction.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/key-details-actions/add-items-action/AddItemsAction.tsx
@@ -20,6 +20,9 @@ const AddItemsAction = ({ width, title, openAddItemPanel }: Props) => (
   <RiTooltip
     content={width > MIDDLE_SCREEN_RESOLUTION ? '' : title}
     position="left"
+    anchorClassName={cx(styles.actionBtn, {
+      [styles.withText]: width > MIDDLE_SCREEN_RESOLUTION,
+    })}
   >
     <span
       className={cx(styles.actionBtn, {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/key-details-actions/remove-items-action/RemoveItemsAction.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/key-details-actions/remove-items-action/RemoveItemsAction.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { RiTooltip } from 'uiSrc/components'
 import { IconButton } from 'uiSrc/components/base/forms/buttons'
 import { MinusInCircleIcon } from 'uiSrc/components/base/icons'
+import styles from './styles.module.scss'
 
 export interface Props {
   title: string
@@ -10,7 +11,7 @@ export interface Props {
 }
 
 const RemoveItemsAction = ({ title, openRemoveItemPanel }: Props) => (
-  <RiTooltip content={title} position="left">
+  <RiTooltip content={title} position="left" anchorClassName={styles.actionBtn}>
     <IconButton
       icon={MinusInCircleIcon}
       aria-label={title}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/key-details-actions/stream-items-action/StreamItemsAction.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/key-details-actions/stream-items-action/StreamItemsAction.tsx
@@ -20,6 +20,9 @@ const StreamItemsAction = ({ width, title, openAddItemPanel }: Props) => (
   <RiTooltip
     content={width > MIDDLE_SCREEN_RESOLUTION ? '' : title}
     position="left"
+    anchorClassName={cx(styles.actionBtn, {
+      [styles.withText]: width > MIDDLE_SCREEN_RESOLUTION,
+    })}
   >
     <span
       className={cx(styles.actionBtn, {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/list-details-table/ListDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/list-details-table/ListDetailsTable.tsx
@@ -272,6 +272,7 @@ const ListDetailsTable = () => {
               <RiTooltip
                 title="Index"
                 className={styles.tooltip}
+                anchorClassName="truncateText"
                 position="bottom"
                 content={tooltipContent}
               >

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/no-key-selected/NoKeySelected.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/no-key-selected/NoKeySelected.tsx
@@ -44,17 +44,19 @@ export const NoKeySelected = (props: Props) => {
 
   return (
     <>
-      <div className={styles.closeRightPanel}>
-        <RiTooltip content="Close" position="left">
-          <IconButton
-            icon={CancelSlimIcon}
-            aria-label="Close panel"
-            className={styles.closeBtn}
-            onClick={handleClosePanel}
-            data-testid="close-right-panel-btn"
-          />
-        </RiTooltip>
-      </div>
+      <RiTooltip
+        content="Close"
+        position="left"
+        anchorClassName={styles.closeRightPanel}
+      >
+        <IconButton
+          icon={CancelSlimIcon}
+          aria-label="Close panel"
+          className={styles.closeBtn}
+          onClick={handleClosePanel}
+          data-testid="close-right-panel-btn"
+        />
+      </RiTooltip>
 
       <div className={styles.placeholder}>
         <Text textAlign="center" color="subdued" size="s">

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/StreamEntryFields/StreamEntryFields.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/StreamEntryFields/StreamEntryFields.tsx
@@ -122,6 +122,7 @@ const StreamEntryFields = (props: Props) => {
             onFocus={() => setIsEntryIdFocused(true)}
             append={
               <RiTooltip
+                anchorClassName="inputAppendIcon"
                 className={styles.entryIdTooltip}
                 position="left"
                 title="Enter Valid ID or *"

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-group/AddStreamGroup.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-group/AddStreamGroup.tsx
@@ -128,6 +128,7 @@ const AddStreamGroup = (props: Props) => {
                       onFocus={() => setIsIdFocused(true)}
                       append={
                         <RiTooltip
+                          anchorClassName="inputAppendIcon"
                           className={styles.entryIdTooltip}
                           position="left"
                           title="Enter Valid ID, 0 or $"

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/consumers-view/ConsumersViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/consumers-view/ConsumersViewWrapper.tsx
@@ -135,6 +135,7 @@ const ConsumersViewWrapper = (props: Props) => {
             >
               <RiTooltip
                 className={styles.tooltipName}
+                anchorClassName="truncateText"
                 position="bottom"
                 content={tooltipContent}
               >

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/groups-view/GroupsViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/groups-view/GroupsViewWrapper.tsx
@@ -227,6 +227,7 @@ const GroupsViewWrapper = (props: Props) => {
             >
               <RiTooltip
                 className={styles.tooltipName}
+                anchorClassName="truncateText"
                 position="bottom"
                 content={tooltipContent}
               >
@@ -285,6 +286,7 @@ const GroupsViewWrapper = (props: Props) => {
                 <RiTooltip
                   title={`${pending} Pending Messages`}
                   className={styles.tooltip}
+                  anchorClassName="truncateText"
                   position="bottom"
                   content={tooltipContent}
                 >
@@ -373,6 +375,7 @@ const GroupsViewWrapper = (props: Props) => {
                 onFocus={() => setIsIdFocused(true)}
                 append={
                   <RiTooltip
+                    anchorClassName="inputAppendIcon"
                     position="left"
                     title="Enter Valid ID, 0 or $"
                     content={lastDeliveredIDTooltipText}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessageClaimPopover/MessageClaimPopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessageClaimPopover/MessageClaimPopover.tsx
@@ -187,6 +187,7 @@ const MessageClaimPopover = (props: Props) => {
     <RiTooltip
       content="There is no consumer to claim the message."
       position="top"
+      anchorClassName="flex-row"
       data-testid="claim-pending-message-tooltip"
     >
       {button}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/stream-data-view/StreamDataViewWrapper.tsx
@@ -300,6 +300,7 @@ const StreamDataViewWrapper = (props: Props) => {
               tooltipContent={tooltipContent}
               expanded={expanded}
               truncateLength={650}
+              anchorClassName="streamItem line-clamp-2"
             />
           </div>
         </Text>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/string-details/string-details-value/StringDetailsValue.tsx
@@ -247,6 +247,7 @@ const StringDetailsValue = (props: Props) => {
     return (
       <RiTooltip
         title={!isValid ? noEditableText : undefined}
+        anchorClassName={styles.tooltipAnchor}
         className={styles.tooltip}
         position="left"
         data-testid="string-value-tooltip"

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/text-details-wrapper/TextDetailsWrapper.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/text-details-wrapper/TextDetailsWrapper.tsx
@@ -20,7 +20,11 @@ const TextDetailsWrapper = ({
 
   return (
     <div className={styles.container} data-testid={getDataTestid('details')}>
-      <RiTooltip content="Close" position="left">
+      <RiTooltip
+        content="Close"
+        position="left"
+        anchorClassName={styles.closeRightPanel}
+      >
         <IconButton
           icon={CancelSlimIcon}
           aria-label="Close key"

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/zset-details-table/ZSetDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/zset-details-table/ZSetDetailsTable.tsx
@@ -404,6 +404,7 @@ const ZSetDetailsTable = (props: Props) => {
                 <RiTooltip
                   title="Score"
                   className={styles.tooltip}
+                  anchorClassName="truncateText"
                   position="bottom"
                   content={tooltipContent}
                 >

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-input/EditableInput.tsx
@@ -61,6 +61,7 @@ const EditableInput = (props: Props) => {
         {isHovering && (
           <RiTooltip
             content={editToolTipContent}
+            anchorClassName={styles.editBtnAnchor}
             data-testid={`${testIdPrefix}_edit-tooltip-${field}`}
           >
             <IconButton

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-textarea/EditableTextArea.tsx
@@ -103,6 +103,7 @@ const EditableTextArea = (props: Props) => {
         {isHovering && (
           <RiTooltip
             content={editToolTipContent}
+            anchorClassName={styles.editBtnAnchor}
             data-testid={`${testIdPrefix}_edit-tooltip-${field}`}
           >
             <IconButton

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/formatted-value/FormattedValue.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/formatted-value/FormattedValue.tsx
@@ -29,6 +29,7 @@ const FormattedValue = ({
     <RiTooltip
       title={title}
       content={tooltipContent}
+      anchorClassName="truncateText"
       position={position}
       {...rest}
     >

--- a/redisinsight/ui/src/pages/cluster-details/components/cluster-details-header/ClusterDetailsHeader.tsx
+++ b/redisinsight/ui/src/pages/cluster-details/components/cluster-details-header/ClusterDetailsHeader.tsx
@@ -56,6 +56,7 @@ const ClusterDetailsHeader = () => {
         ) : (
           <RiTooltip
             className={styles.tooltip}
+            anchorClassName="truncateText"
             position="bottom"
             content={<>{formatLongName(username || DEFAULT_USERNAME)}</>}
           >

--- a/redisinsight/ui/src/pages/database-analysis/components/header/Header.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/header/Header.tsx
@@ -168,6 +168,7 @@ const Header = (props: Props) => {
             <FlexItem style={{ paddingLeft: 6 }}>
               <RiTooltip
                 position="bottom"
+                anchorClassName={styles.tooltipAnchor}
                 className={styles.tooltip}
                 title="Database Analysis"
                 data-testid="db-new-reports-tooltip"

--- a/redisinsight/ui/src/pages/database-analysis/components/recommendations-view/Recommendations.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/recommendations-view/Recommendations.tsx
@@ -103,7 +103,7 @@ const Recommendations = () => {
               className={styles.redisStackLink}
               data-testid={`${id}-redis-stack-link`}
             >
-              <RiTooltip content="Redis Stack" position="top">
+              <RiTooltip content="Redis Stack" position="top" anchorClassName="flex-row">
                 <EuiIcon
                   type={
                     theme === Theme.Dark ? RediStackDarkMin : RediStackLightMin

--- a/redisinsight/ui/src/pages/database-analysis/components/top-keys/Table.tsx
+++ b/redisinsight/ui/src/pages/database-analysis/components/top-keys/Table.tsx
@@ -163,6 +163,7 @@ const TopKeysTable = ({
           <span data-testid={`ttl-${name}`}>
             <RiTooltip
               title="Time to Live"
+              anchorClassName="truncateText"
               position="bottom"
               content={
                 <>

--- a/redisinsight/ui/src/pages/home/components/add-database-screen/AddDatabaseScreen.tsx
+++ b/redisinsight/ui/src/pages/home/components/add-database-screen/AddDatabaseScreen.tsx
@@ -123,6 +123,7 @@ const AddDatabaseScreen = (props: Props) => {
           <FlexItem>
             <RiTooltip
               position="top"
+              anchorClassName="euiToolTip__btn-disabled"
               content={
                 isInvalid ? (
                   <span>
@@ -158,6 +159,7 @@ const AddDatabaseScreen = (props: Props) => {
               <FlexItem>
                 <RiTooltip
                   position="top"
+                  anchorClassName="euiToolTip__btn-disabled"
                   content={
                     isInvalid ? (
                       <span>

--- a/redisinsight/ui/src/pages/home/components/cloud-connection/cloud-connection-form/CloudConnectionForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/cloud-connection/cloud-connection-form/CloudConnectionForm.tsx
@@ -132,6 +132,7 @@ const CloudConnectionForm = (props: Props) => {
   const SubmitButton = ({ onClick, submitIsDisabled }: ISubmitButton) => (
     <RiTooltip
       position="top"
+      anchorClassName="euiToolTip__btn-disabled"
       title={
         submitIsDisabled
           ? validationErrors.REQUIRED_TITLE(Object.values(errors).length)

--- a/redisinsight/ui/src/pages/home/components/cluster-connection/cluster-connection-form/ClusterConnectionForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/cluster-connection/cluster-connection-form/ClusterConnectionForm.tsx
@@ -132,6 +132,7 @@ const ClusterConnectionForm = (props: Props) => {
         </div>
       }
       className="homePage_tooltip"
+      anchorClassName="inputAppendIcon"
       position="right"
       content={
         <ul className="homePage_toolTipUl">
@@ -168,6 +169,7 @@ const ClusterConnectionForm = (props: Props) => {
   const SubmitButton = ({ onClick, submitIsDisabled }: ISubmitButton) => (
     <RiTooltip
       position="top"
+      anchorClassName="euiToolTip__btn-disabled"
       title={
         submitIsDisabled
           ? validationErrors.REQUIRED_TITLE(Object.values(errors).length)

--- a/redisinsight/ui/src/pages/home/components/database-list-component/DatabasesListWrapper.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-list-component/DatabasesListWrapper.tsx
@@ -456,7 +456,11 @@ const DatabasesListWrapper = (props: Props) => {
           return (
             <div className="host_port" data-testid="host-port">
               <Text className="copyHostPortText">{text}</Text>
-              <RiTooltip position="right" content="Copy">
+              <RiTooltip
+                position="right"
+                content="Copy"
+                anchorClassName="copyHostPortTooltip"
+              >
                 <IconButton
                   icon={CopyIcon}
                   aria-label="Copy host:port"

--- a/redisinsight/ui/src/pages/home/components/db-status/DbStatus.tsx
+++ b/redisinsight/ui/src/pages/home/components/db-status/DbStatus.tsx
@@ -78,9 +78,10 @@ const DbStatus = (props: Props) => {
       }
       position="right"
       className={styles.tooltip}
+      anchorClassName={cx(styles.statusAnchor, styles.warning)}
     >
       <div
-        className={cx(styles.statusAnchor, styles.status, styles.warning)}
+        className={cx(styles.status, styles.warning)}
         data-testid={`database-status-${type}-${id}`}
       >
         !
@@ -103,9 +104,13 @@ const DbStatus = (props: Props) => {
 
   if (isNew) {
     return (
-      <RiTooltip content="New" position="top">
+      <RiTooltip
+        content="New"
+        position="top"
+        anchorClassName={cx(styles.statusAnchor)}
+      >
         <div
-          className={cx(styles.statusAnchor, styles.status, styles.new)}
+          className={cx(styles.status, styles.new)}
           data-testid={`database-status-new-${id}`}
         />
       </RiTooltip>

--- a/redisinsight/ui/src/pages/home/components/form/DatabaseForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/DatabaseForm.tsx
@@ -58,6 +58,7 @@ const DatabaseForm = (props: Props) => {
         </div>
       }
       className="homePage_tooltip"
+      anchorClassName="inputAppendIcon"
       position="right"
       content={
         <ul className="homePage_toolTipUl">

--- a/redisinsight/ui/src/pages/home/components/form/DbInfo.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/DbInfo.tsx
@@ -48,6 +48,7 @@ const DbInfo = (props: Props) => {
     <RiTooltip
       title="Host:port"
       position="left"
+      anchorClassName={styles.anchorEndpoints}
       content={
         <ul className={styles.endpointsList}>
           {nodes?.map(({ host: eHost, port: ePort }) => (

--- a/redisinsight/ui/src/pages/home/components/form/sentinel/SentinelHostPort.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/sentinel/SentinelHostPort.tsx
@@ -23,7 +23,11 @@ const SentinelHostPort = (props: Props) => {
       Sentinel Host & Port:
       <div className={styles.hostPort}>
         <ColorText>{`${host}:${port}`}</ColorText>
-        <RiTooltip position="right" content="Copy">
+        <RiTooltip
+          position="right"
+          content="Copy"
+          anchorClassName="copyHostPortTooltip"
+        >
           <IconButton
             icon={CopyIcon}
             aria-label="Copy host:port"

--- a/redisinsight/ui/src/pages/home/components/import-database/ImportDatabase.tsx
+++ b/redisinsight/ui/src/pages/home/components/import-database/ImportDatabase.tsx
@@ -143,6 +143,7 @@ const ImportDatabase = (props: Props) => {
         </SecondaryButton>
         <RiTooltip
           position="top"
+          anchorClassName="euiToolTip__btn-disabled"
           content={isSubmitDisabled ? 'Upload a file' : undefined}
         >
           <PrimaryButton

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/components/FooterActions.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/components/FooterActions.tsx
@@ -41,6 +41,7 @@ const FooterActions = (props: Props) => {
   }: ISubmitButton) => (
     <RiTooltip
       position="top"
+      anchorClassName="euiToolTip__btn-disabled"
       title={
         submitIsDisabled
           ? validationErrors.REQUIRED_TITLE(Object.keys(errors).length)
@@ -67,6 +68,7 @@ const FooterActions = (props: Props) => {
       <FlexItem className="btn-back">
         <RiTooltip
           position="top"
+          anchorClassName="euiToolTip__btn-disabled"
           title={
             submitIsDisable()
               ? validationErrors.REQUIRED_TITLE(Object.keys(errors).length)

--- a/redisinsight/ui/src/pages/home/components/sentinel-connection/sentinel-connection-form/SentinelConnectionForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/sentinel-connection/sentinel-connection-form/SentinelConnectionForm.tsx
@@ -83,6 +83,7 @@ const SentinelConnectionForm = (props: Props) => {
   const SubmitButton = ({ onClick, submitIsDisabled }: ISubmitButton) => (
     <RiTooltip
       position="top"
+      anchorClassName="euiToolTip__btn-disabled"
       title={
         submitIsDisabled
           ? validationErrors.REQUIRED_TITLE(Object.keys(errors).length)

--- a/redisinsight/ui/src/pages/pub-sub/components/subscription-panel/SubscriptionPanel.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/subscription-panel/SubscriptionPanel.tsx
@@ -132,7 +132,10 @@ const SubscriptionPanel = () => {
           </FlexItem>
           {!!messages.length && (
             <FlexItem style={{ marginLeft: 8 }}>
-              <RiTooltip content="Clear Messages">
+              <RiTooltip
+                content="Clear Messages"
+                anchorClassName={cx('inline-flex')}
+              >
                 <IconButton
                   icon={DeleteIcon}
                   onClick={onClickClear}

--- a/redisinsight/ui/src/pages/pub-sub/components/subscription-panel/components/patternsInfo/PatternsInfo.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/subscription-panel/components/patternsInfo/PatternsInfo.tsx
@@ -22,14 +22,15 @@ const PatternsInfo = ({ channels }: PatternsInfoProps) => {
         Patterns:&nbsp;{getChannelsCount()}{' '}
       </Text>
       <RiTooltip
+        anchorClassName={styles.appendIcon}
         position="right"
         title={
-          <span className={styles.appendIcon}>
+          <>
             {channels
               ?.trim()
               .split(' ')
               .map((ch) => <p key={`${ch}`}>{ch}</p>)}
-          </span>
+          </>
         }
       >
         <EuiIcon

--- a/redisinsight/ui/src/pages/rdi/home/connection-form/components/ValidationTooltip.tsx
+++ b/redisinsight/ui/src/pages/rdi/home/connection-form/components/ValidationTooltip.tsx
@@ -24,6 +24,7 @@ const ValidationTooltip = ({ isValid, errors, children }: Props) => {
     <RiTooltip
       data-testid="connection-form-validation-tooltip"
       position="top"
+      anchorClassName="euiToolTip__btn-disabled"
       title={
         !isValid
           ? validationErrors.REQUIRED_TITLE(Object.keys(errors).length)

--- a/redisinsight/ui/src/pages/rdi/home/instance-list/RdiInstancesListWrapper.tsx
+++ b/redisinsight/ui/src/pages/rdi/home/instance-list/RdiInstancesListWrapper.tsx
@@ -178,7 +178,11 @@ const RdiInstancesListWrapper = ({
       render: (name: string, { id }) => (
         <div className="url" data-testid="url">
           <Text className="copyUrlText">{name}</Text>
-          <RiTooltip position="right" content="Copy">
+          <RiTooltip
+            position="right"
+            content="Copy"
+            anchorClassName="copyUrlTooltip"
+          >
             <IconButton
               size="L"
               icon={CopyIcon}

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/reset-pipeline-button/ResetPipelineButton.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/reset-pipeline-button/ResetPipelineButton.tsx
@@ -4,6 +4,7 @@ import { RiResetIcon } from 'uiSrc/components/base/icons'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import { SecondaryButton } from 'uiSrc/components/base/forms/buttons'
 import { RiTooltip } from 'uiSrc/components'
+import styles from '../styles.module.scss'
 
 export interface PipelineButtonProps {
   onClick: () => void
@@ -32,6 +33,7 @@ const ResetPipelineButton = ({
         </>
       ) : null
     }
+    anchorClassName={disabled || loading ? styles.disabled : styles.tooltip}
   >
     <SecondaryButton
       aria-label="Reset pipeline button"

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/start-pipeline-button/StartPipelineButton.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/start-pipeline-button/StartPipelineButton.tsx
@@ -4,13 +4,17 @@ import { SecondaryButton } from 'uiSrc/components/base/forms/buttons'
 import { PlayFilledIcon } from 'uiSrc/components/base/icons'
 import { RiTooltip } from 'uiSrc/components'
 import { PipelineButtonProps } from '../reset-pipeline-button/ResetPipelineButton'
+import styles from '../styles.module.scss'
 
 const StartPipelineButton = ({
   onClick,
   disabled,
   loading,
 }: PipelineButtonProps) => (
-  <RiTooltip content="Start the pipeline to resume processing new data arrivals.">
+  <RiTooltip
+    content="Start the pipeline to resume processing new data arrivals."
+    anchorClassName={disabled ? styles.disabled : styles.tooltip}
+  >
     <SecondaryButton
       aria-label="Start running pipeline"
       size="s"

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/stop-pipeline-button/StopPipelineButton.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/stop-pipeline-button/StopPipelineButton.tsx
@@ -4,13 +4,17 @@ import { SecondaryButton } from 'uiSrc/components/base/forms/buttons'
 import { RiStopIcon } from 'uiSrc/components/base/icons'
 import { RiTooltip } from 'uiSrc/components'
 import { PipelineButtonProps } from '../reset-pipeline-button/ResetPipelineButton'
+import styles from '../styles.module.scss'
 
 const StopPipelineButton = ({
   onClick,
   disabled,
   loading,
 }: PipelineButtonProps) => (
-  <RiTooltip content="Stop the pipeline to prevent processing of new data arrivals.">
+  <RiTooltip
+    content="Stop the pipeline to prevent processing of new data arrivals."
+    anchorClassName={disabled ? styles.disabled : undefined}
+  >
     <SecondaryButton
       aria-label="Stop running pipeline"
       size="s"

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/current-pipeline-status/CurrentPipelineStatus.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/current-pipeline-status/CurrentPipelineStatus.tsx
@@ -45,7 +45,10 @@ const CurrentPipelineStatus = ({
       {headerLoading ? (
         <Loader size="m" style={{ marginLeft: '8px' }} />
       ) : (
-        <RiTooltip content={errorTooltipContent}>
+        <RiTooltip
+          content={errorTooltipContent}
+          anchorClassName={statusError && styles.tooltip}
+        >
           <div className={styles.stateBadge} data-testid="pipeline-state-badge">
             <EuiIcon type={stateInfo.icon} />
             <span>{stateInfo.label}</span>

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/pipeline-actions/PipelineActions.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/pipeline-actions/PipelineActions.tsx
@@ -175,6 +175,7 @@ const PipelineActions = ({ collectorStatus, pipelineStatus }: Props) => {
               : 'Please fix the validation errors before deploying'
           }
           position="left"
+          anchorClassName="flex-row"
         >
           <DeployPipelineButton
             loading={deployLoading}

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-tree/JobsTree.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-tree/JobsTree.tsx
@@ -179,7 +179,11 @@ const JobsTree = (props: IProps) => {
         className={styles.actions}
         data-testid={`rdi-nav-job-actions-${name}`}
       >
-        <RiTooltip content="Edit job file name" position="top">
+        <RiTooltip
+          content="Edit job file name"
+          position="top"
+          anchorClassName="flex-row"
+        >
           <IconButton
             icon={EditIcon}
             onClick={() => {
@@ -190,7 +194,11 @@ const JobsTree = (props: IProps) => {
             data-testid={`edit-job-name-${name}`}
           />
         </RiTooltip>
-        <RiTooltip content="Delete job" position="top">
+        <RiTooltip
+          content="Delete job"
+          position="top"
+          anchorClassName="flex-row"
+        >
           <ConfirmationPopover
             title={`Delete ${name}`}
             body={
@@ -269,6 +277,7 @@ const JobsTree = (props: IProps) => {
             <RiTooltip
               content="This file contains undeployed changes."
               position="top"
+              anchorClassName={styles.dotWrapper}
             >
               <span className={styles.dotWrapper}>
                 <span
@@ -337,6 +346,7 @@ const JobsTree = (props: IProps) => {
         <RiTooltip
           content={!hideTooltip ? 'Add a job file' : null}
           position="top"
+          anchorClassName="flex-row"
         >
           <IconButton
             icon={PlusIcon}

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/Navigation.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/Navigation.tsx
@@ -77,13 +77,12 @@ const Navigation = () => {
               <RiTooltip
                 content="This file contains undeployed changes."
                 position="top"
+                anchorClassName={styles.dotWrapper}
               >
-                <span className={styles.dotWrapper}>
-                  <span
-                    className={styles.dot}
-                    data-testid="updated-file-config-highlight"
-                  />
-                </span>
+                <span
+                  className={styles.dot}
+                  data-testid="updated-file-config-highlight"
+                />
               </RiTooltip>
             )}
           </div>

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-button/TemplateButton.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-button/TemplateButton.tsx
@@ -49,6 +49,7 @@ const TemplateButton = ({ setFieldValue, value }: TemplateButtonProps) => {
     <RiTooltip
       content={getTooltipContent(value, !templateOption)}
       position="bottom"
+      anchorClassName="flex-row"
     >
       <SecondaryButton
         inverted

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-form/TemplateForm.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-form/TemplateForm.tsx
@@ -212,6 +212,7 @@ const TemplateForm = (props: Props) => {
           content={getTooltipContent(value, isNoTemplateOptions)}
           position="bottom"
           className={styles.btn}
+          anchorClassName="flex-row"
         >
           <PrimaryButton
             disabled={isNoTemplateOptions || !!value}

--- a/redisinsight/ui/src/pages/redis-cluster/RedisClusterDatabases.tsx
+++ b/redisinsight/ui/src/pages/redis-cluster/RedisClusterDatabases.tsx
@@ -212,6 +212,7 @@ const RedisClusterDatabases = ({
             <CancelButton isPopoverOpen={isPopoverOpen} />
             <RiTooltip
               position="top"
+              anchorClassName="euiToolTip__btn-disabled"
               title={
                 isSubmitDisabled()
                   ? validationErrors.SELECT_AT_LEAST_ONE('database')

--- a/redisinsight/ui/src/pages/redis-cluster/RedisClusterDatabasesPage.tsx
+++ b/redisinsight/ui/src/pages/redis-cluster/RedisClusterDatabasesPage.tsx
@@ -122,7 +122,11 @@ const RedisClusterDatabasesPage = () => {
           !!dnsName && (
             <div className="host_port">
               <Text className="copyHostPortText">{text}</Text>
-              <RiTooltip position="right" content="Copy">
+              <RiTooltip
+                position="right"
+                content="Copy"
+                anchorClassName="copyHostPortTooltip"
+              >
                 <IconButton
                   icon={CopyIcon}
                   aria-label="Copy host:port"

--- a/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/UserApiKeysTable.tsx
+++ b/redisinsight/ui/src/pages/settings/components/cloud-settings/components/user-api-keys-table/UserApiKeysTable.tsx
@@ -88,7 +88,10 @@ const UserApiKeysTable = ({ items, loading }: Props) => {
         return (
           <div className={styles.nameField}>
             {!valid && (
-              <RiTooltip content="This API key is invalid. Remove it from Redis Cloud and create a new one instead.">
+              <RiTooltip
+                content="This API key is invalid. Remove it from Redis Cloud and create a new one instead."
+                anchorClassName={styles.invalidIconAnchor}
+              >
                 <EuiIcon
                   className={styles.invalidIcon}
                   type="alert"
@@ -151,7 +154,10 @@ const UserApiKeysTable = ({ items, loading }: Props) => {
         },
       }) => (
         <div>
-          <RiTooltip content="Copy API Key Name">
+          <RiTooltip
+            content="Copy API Key Name"
+            anchorClassName={styles.copyBtnAnchor}
+          >
             <IconButton
               icon={CopyIcon}
               aria-label="Copy API key"

--- a/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/datetime-form/DatetimeForm.tsx
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/datetime-form/DatetimeForm.tsx
@@ -221,6 +221,7 @@ const DatetimeForm = ({ onFormatChange }: Props) => {
             </FlexItem>
             <RiTooltip
               position="top"
+              anchorClassName="euiToolTip__btn-disabled"
               content={
                 showError ? error || 'This format is not supported' : null
               }

--- a/redisinsight/ui/src/pages/slow-log/components/Actions/Actions.tsx
+++ b/redisinsight/ui/src/pages/slow-log/components/Actions/Actions.tsx
@@ -177,7 +177,11 @@ const Actions = (props: Props) => {
             closePopover={closePopoverClear}
             panelPaddingSize="m"
             button={
-              <RiTooltip position="left" content="Clear Slow Log">
+              <RiTooltip
+                position="left"
+                content="Clear Slow Log"
+                anchorClassName={styles.icon}
+              >
                 <IconButton
                   icon={EraserIcon}
                   aria-label="Clear Slow Log"
@@ -195,6 +199,7 @@ const Actions = (props: Props) => {
         <RiTooltip
           title="Slow Log"
           position="bottom"
+          anchorClassName={styles.icon}
           content={
             <span data-testid="slowlog-tooltip-text">
               Slow Log is a list of slow operations for your Redis instance.

--- a/redisinsight/ui/src/pages/slow-log/components/SlowLogTable/SlowLogTable.tsx
+++ b/redisinsight/ui/src/pages/slow-log/components/SlowLogTable/SlowLogTable.tsx
@@ -81,11 +81,13 @@ const SlowLogTable = (props: Props) => {
       id: 'args',
       label: 'Command',
       render: (command) => (
-        <RiTooltip position="bottom" content={command}>
-          <span className={styles.commandTooltip}>
-            <span className={styles.commandText} data-testid="command-value">
-              {command}
-            </span>
+        <RiTooltip
+          position="bottom"
+          content={command}
+          anchorClassName={styles.commandTooltip}
+        >
+          <span className={styles.commandText} data-testid="command-value">
+            {command}
           </span>
         </RiTooltip>
       ),


### PR DESCRIPTION
## Description

reverts the removal of anchorClassName prop for tooltip component that happened here https://github.com/redis/RedisInsight/commit/bd05295f54a34c8cef4c0fc010b1cae354058f9d