### PR TITLE
RDI Tab and check

### DIFF
--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/chats-wrapper/ChatsWrapper.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/chats-wrapper/ChatsWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { EuiTab, EuiTabs } from '@elastic/eui'
 
@@ -32,6 +32,8 @@ const ChatsWrapper = () => {
     [FeatureFlags.databaseChat]: databaseChatFeature,
   } = useSelector(appFeatureFlagsFeaturesSelector)
   const location = useLocation()
+
+  const [initialRDIRedirect, setInitialRDIRedirect] = useState(false)
   
   // Check if we're on the RDI pipeline config page
   const isOnRdiPipelineConfig = isRdiPipelineConfigPage(location.pathname)
@@ -66,8 +68,8 @@ const ChatsWrapper = () => {
       dispatch(setSelectedTab(chats[0].tab))
     }
 
-    // If we're on RDI page and no RDI tab is active, switch to RDI Helper
-    if (isOnRdiPipelineConfig && activeTab !== AiChatType.RdiHelper) {
+    if (isOnRdiPipelineConfig && activeTab !== AiChatType.RdiHelper && !initialRDIRedirect) {
+      setInitialRDIRedirect(true)
       dispatch(setSelectedTab(AiChatType.RdiHelper))
     }
 
@@ -78,7 +80,7 @@ const ChatsWrapper = () => {
         chat: activeTab,
       },
     })
-  }, [databaseChatFeature, databaseChatFeature, activeTab])
+  }, [databaseChatFeature, databaseChatFeature, activeTab, initialRDIRedirect])
 
   const selectTab = (tab: AiChatType) => {
     dispatch(setSelectedTab(tab))

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/rdi-helper-chat/RdiHelperChat.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/rdi-helper-chat/RdiHelperChat.tsx
@@ -1,0 +1,153 @@
+import React, { useCallback, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { EuiButtonEmpty } from '@elastic/eui'
+
+import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
+import { AiChatMessage, AiChatType, AiChatMessageType } from 'uiSrc/slices/interfaces/aiAssistant'
+import { Nullable } from 'uiSrc/utils'
+
+import { ChatForm, ChatHistory, RestartChat } from '../shared'
+
+import styles from './styles.module.scss'
+
+const RDI_HELPER_INITIAL_MESSAGE = (
+  <div>
+    <p>👋 Hello! I&apos;m your RDI Helper, here to assist you with Redis Data Integration pipeline management.</p>
+    <p>I can help you with:</p>
+    <ul>
+      <li>Pipeline configuration and syntax</li>
+      <li>Data transformation troubleshooting</li>
+      <li>RDI best practices and optimization</li>
+      <li>Error resolution and debugging</li>
+    </ul>
+    <p>What can I help you with today?</p>
+  </div>
+)
+
+const RDI_HELPER_AGREEMENTS = [
+  'I understand that this RDI Helper feature is in preview',
+  'AI-generated content may be inaccurate or incomplete',
+  'I will verify important information independently'
+]
+
+const RdiHelperChat = () => {
+  
+  const [messages, setMessages] = useState<AiChatMessage[]>([])
+  const [agreements, setAgreements] = useState<boolean>(false)
+  const [loading] = useState<boolean>(false)
+  const [inProgressMessage] = useState<Nullable<AiChatMessage>>(null)
+  
+  const { instanceId } = useParams<{ instanceId: string }>()
+
+  const handleSubmit = useCallback(
+    (message: string) => {
+      if (!agreements) {
+        setAgreements(true)
+        sendEventTelemetry({
+          event: TelemetryEvent.AI_CHAT_BOT_TERMS_ACCEPTED,
+          eventData: {
+            databaseId: instanceId,
+            chat: AiChatType.RdiHelper,
+          },
+        })
+      }
+
+      // For now, this is a placeholder - the actual AI integration would go here
+      // You would implement the RDI-specific AI chat logic here
+      const userMessage: AiChatMessage = {
+        id: Date.now().toString(),
+        type: AiChatMessageType.HumanMessage,
+        content: message,
+      }
+      
+      setMessages(prev => [...prev, userMessage])
+      
+      // Simulate AI response (replace with actual AI integration)
+      setTimeout(() => {
+        const aiResponse: AiChatMessage = {
+          id: (Date.now() + 1).toString(),
+          type: AiChatMessageType.AIMessage,
+          content: `Thank you for your RDI question: "${message}". This is a placeholder response. ` +
+            `The actual RDI AI assistant integration would provide specific help with your pipeline management needs.`,
+        }
+        setMessages(prev => [...prev, aiResponse])
+      }, 1000)
+
+      sendEventTelemetry({
+        event: TelemetryEvent.AI_CHAT_MESSAGE_SENT,
+        eventData: {
+          chat: AiChatType.RdiHelper,
+        },
+      })
+    },
+    [instanceId, agreements],
+  )
+
+  const onClearSession = useCallback(() => {
+    setMessages([])
+    setAgreements(false)
+    
+    sendEventTelemetry({
+      event: TelemetryEvent.AI_CHAT_SESSION_RESTARTED,
+      eventData: {
+        chat: AiChatType.RdiHelper,
+      },
+    })
+  }, [])
+
+  const onRunCommand = useCallback(() => {
+    // RDI-specific command handling would go here
+  }, [])
+
+  const handleAgreementsDisplay = useCallback(() => {
+    sendEventTelemetry({
+      event: TelemetryEvent.AI_CHAT_BOT_TERMS_DISPLAYED,
+      eventData: {
+        chat: AiChatType.RdiHelper,
+      },
+    })
+  }, [])
+
+  return (
+    <div className={styles.wrapper} data-testid="ai-rdi-helper-chat">
+      <div className={styles.header}>
+        <span />
+        <RestartChat
+          button={
+            <EuiButtonEmpty
+              disabled={!!inProgressMessage || !messages?.length}
+              iconType="eraser"
+              size="xs"
+              className={styles.headerBtn}
+              data-testid="ai-rdi-restart-session-btn"
+            />
+          }
+          onConfirm={onClearSession}
+        />
+      </div>
+      <div className={styles.chatHistory}>
+        <ChatHistory
+          autoScroll
+          isLoading={loading}
+          modules={[]}
+          initialMessage={RDI_HELPER_INITIAL_MESSAGE}
+          inProgressMessage={inProgressMessage}
+          history={messages}
+          onRunCommand={onRunCommand}
+          onRestart={onClearSession}
+        />
+      </div>
+      <div className={styles.chatForm}>
+        <ChatForm
+          onAgreementsDisplayed={handleAgreementsDisplay}
+          agreements={!agreements ? RDI_HELPER_AGREEMENTS : undefined}
+          placeholder="Ask me about RDI pipeline configuration..."
+          isDisabled={inProgressMessage?.content === ''}
+          onSubmit={handleSubmit}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default RdiHelperChat 

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/rdi-helper-chat/index.ts
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/rdi-helper-chat/index.ts
@@ -1,0 +1,3 @@
+import RdiHelperChat from './RdiHelperChat'
+
+export default RdiHelperChat 

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/rdi-helper-chat/styles.module.scss
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/rdi-helper-chat/styles.module.scss
@@ -1,0 +1,36 @@
+.wrapper {
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 12px 12px;
+  border-bottom: 1px solid var(--separatorColor);
+  min-height: 48px;
+}
+
+.title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--euiColorPrimary);
+}
+
+.headerBtn {
+  min-width: auto !important;
+  height: 24px !important;
+}
+
+.chatHistory {
+  flex-grow: 1;
+  overflow: hidden;
+}
+
+.chatForm {
+  border-top: 1px solid var(--separatorColor);
+} 

--- a/redisinsight/ui/src/slices/interfaces/aiAssistant.ts
+++ b/redisinsight/ui/src/slices/interfaces/aiAssistant.ts
@@ -1,6 +1,7 @@
 export enum AiChatType {
   Assistance = 'document',
   Query = 'database',
+  RdiHelper = 'rdi',
 }
 
 export enum AiChatMessageType {

--- a/redisinsight/ui/src/utils/rdi/index.ts
+++ b/redisinsight/ui/src/utils/rdi/index.ts
@@ -1,4 +1,5 @@
 import getRdiUrl from './getUrlRdiInstance'
 import isEqualPipelineFile from './pipeline'
+import isRdiPipelineConfigPage from './isRdiPipelineConfigPage'
 
-export { getRdiUrl, isEqualPipelineFile }
+export { getRdiUrl, isEqualPipelineFile, isRdiPipelineConfigPage }

--- a/redisinsight/ui/src/utils/rdi/isRdiPipelineConfigPage.ts
+++ b/redisinsight/ui/src/utils/rdi/isRdiPipelineConfigPage.ts
@@ -1,0 +1,14 @@
+/**
+ * Check if current URL is on RDI pipeline management config page
+ * Matches pattern: /integrate/{instanceId}/pipeline-management/config
+ */
+const isRdiPipelineConfigPage = (pathname?: string): boolean => {
+  const currentPath = pathname || window.location.pathname
+  
+  // Match pattern: /integrate/{instanceId}/pipeline-management/config
+  const rdiPipelineConfigPattern = /^\/integrate\/[^/]+\/pipeline-management\/config$/
+  
+  return rdiPipelineConfigPattern.test(currentPath)
+}
+
+export default isRdiPipelineConfigPage 


### PR DESCRIPTION
Added a simple util that checks the URL of the page and if it matches, returns true. Used to enable a third tab in the copilot chat window. Currently limited to the page for initial set up after connecting to an RDI instance.

[https://www.loom.com/share/720faf8aa7424f40b351b2a45b6f59cd](https://www.loom.com/share/720faf8aa7424f40b351b2a45b6f59cd)