### PR TITLE
RI-6570 Verify read operations for all key types in the browsers module

### DIFF
--- a/tests/playwright/helpers/api/api-keys.ts
+++ b/tests/playwright/helpers/api/api-keys.ts
@@ -164,6 +164,32 @@ export class APIKeyRequests {
         }
     }
 
+    async addJsonKeyApi(
+        keyParameters: { keyName: string; value: any; expire?: number },
+        databaseParameters: AddNewDatabaseParameters,
+    ): Promise<void> {
+        const databaseId = await this.databaseAPIRequests.getDatabaseIdByName(
+            databaseParameters.databaseName,
+        )
+        const requestBody: any = {
+            keyName: Buffer.from(keyParameters.keyName, 'utf-8'),
+            data: JSON.stringify(keyParameters.value),
+        }
+
+        if (keyParameters.expire) {
+            requestBody.expire = keyParameters.expire
+        }
+
+        const response = await this.apiClient.post(
+            `/databases/${databaseId}/rejson-rl?encoding=buffer`,
+            requestBody,
+        )
+
+        if (response.status !== 201) {
+            throw new Error('The creation of new JSON key request failed')
+        }
+    }
+
     async searchKeyByNameApi(
         keyName: string,
         databaseName: string,

--- a/tests/playwright/helpers/api/api-keys.ts
+++ b/tests/playwright/helpers/api/api-keys.ts
@@ -7,6 +7,7 @@ import {
     SetKeyParameters,
     StreamKeyParameters,
 } from '../../types'
+import { stringToBuffer } from '../utils'
 
 const bufferPathMask = '/databases/databaseId/keys?encoding=buffer'
 export class APIKeyRequests {
@@ -23,8 +24,8 @@ export class APIKeyRequests {
             databaseParameters.databaseName,
         )
         const requestBody = {
-            keyName: Buffer.from(keyParameters.keyName, 'utf-8'),
-            value: Buffer.from(keyParameters.value, 'utf-8'),
+            keyName: stringToBuffer(keyParameters.keyName),
+            value: stringToBuffer(keyParameters.value),
             expire: keyParameters?.expire,
         }
 
@@ -46,11 +47,11 @@ export class APIKeyRequests {
             databaseParameters.databaseName,
         )
         const requestBody = {
-            keyName: Buffer.from(keyParameters.keyName, 'utf-8'),
+            keyName: stringToBuffer(keyParameters.keyName),
             fields: keyParameters.fields.map((fields) => ({
                 ...fields,
-                field: Buffer.from(fields.field, 'utf-8'),
-                value: Buffer.from(fields.value, 'utf-8'),
+                field: stringToBuffer(fields.field),
+                value: stringToBuffer(fields.value),
             })),
             expire: keyParameters?.expire,
         }
@@ -70,9 +71,9 @@ export class APIKeyRequests {
             databaseParameters.databaseName,
         )
         const requestBody = {
-            keyName: Buffer.from(keyParameters.keyName, 'utf-8'),
+            keyName: stringToBuffer(keyParameters.keyName),
             elements: keyParameters.elements.map((element) =>
-                Buffer.from(element, 'utf-8'),
+                stringToBuffer(element),
             ),
             expire: keyParameters?.expire,
         }
@@ -95,12 +96,12 @@ export class APIKeyRequests {
             databaseParameters.databaseName,
         )
         const requestBody = {
-            keyName: Buffer.from(keyParameters.keyName, 'utf-8'),
+            keyName: stringToBuffer(keyParameters.keyName),
             entries: keyParameters.entries.map((member) => ({
                 ...member,
                 fields: member.fields.map(({ name, value }) => ({
-                    name: Buffer.from(name, 'utf-8'),
-                    value: Buffer.from(value, 'utf-8'),
+                    name: stringToBuffer(name),
+                    value: stringToBuffer(value),
                 })),
             })),
             expire: keyParameters?.expire,
@@ -121,9 +122,9 @@ export class APIKeyRequests {
             databaseParameters.databaseName,
         )
         const requestBody = {
-            keyName: Buffer.from(keyParameters.keyName, 'utf-8'),
+            keyName: stringToBuffer(keyParameters.keyName),
             members: keyParameters.members.map((member) =>
-                Buffer.from(member, 'utf-8'),
+                stringToBuffer(member),
             ),
             expire: keyParameters?.expire,
         }
@@ -147,9 +148,9 @@ export class APIKeyRequests {
             databaseParameters.databaseName,
         )
         const requestBody = {
-            keyName: Buffer.from(keyParameters.keyName, 'utf-8'),
+            keyName: stringToBuffer(keyParameters.keyName),
             members: keyParameters.members.map((member) => ({
-                name: Buffer.from(member.name, 'utf-8'),
+                name: stringToBuffer(member.name),
                 score: member.score,
             })),
             expire: keyParameters?.expire,
@@ -173,7 +174,7 @@ export class APIKeyRequests {
             databaseParameters.databaseName,
         )
         const requestBody: any = {
-            keyName: Buffer.from(keyParameters.keyName, 'utf-8'),
+            keyName: stringToBuffer(keyParameters.keyName),
             data: JSON.stringify(keyParameters.value),
         }
 
@@ -221,7 +222,7 @@ export class APIKeyRequests {
             databaseName,
         )
         if (doesKeyExist.length > 0) {
-            const requestBody = { keyNames: [Buffer.from(keyName, 'utf-8')] }
+            const requestBody = { keyNames: [stringToBuffer(keyName)] }
             const response = await this.apiClient.delete(
                 bufferPathMask.replace('databaseId', databaseId),
                 {

--- a/tests/playwright/helpers/api/api-keys.ts
+++ b/tests/playwright/helpers/api/api-keys.ts
@@ -88,7 +88,7 @@ export class APIKeyRequests {
     }
 
     async addStreamKeyApi(
-        keyParameters: StreamKeyParameters,
+        keyParameters: StreamKeyParameters & { expire?: number },
         databaseParameters: AddNewDatabaseParameters,
     ): Promise<void> {
         const databaseId = await this.databaseAPIRequests.getDatabaseIdByName(
@@ -103,6 +103,7 @@ export class APIKeyRequests {
                     value: Buffer.from(value, 'utf-8'),
                 })),
             })),
+            expire: keyParameters?.expire,
         }
         const response = await this.apiClient.post(
             `/databases/${databaseId}/streams?encoding=buffer`,

--- a/tests/playwright/helpers/api/api-keys.ts
+++ b/tests/playwright/helpers/api/api-keys.ts
@@ -113,7 +113,7 @@ export class APIKeyRequests {
     }
 
     async addSetKeyApi(
-        keyParameters: SetKeyParameters,
+        keyParameters: SetKeyParameters & { expire?: number },
         databaseParameters: AddNewDatabaseParameters,
     ): Promise<void> {
         const databaseId = await this.databaseAPIRequests.getDatabaseIdByName(
@@ -124,6 +124,7 @@ export class APIKeyRequests {
             members: keyParameters.members.map((member) =>
                 Buffer.from(member, 'utf-8'),
             ),
+            expire: keyParameters?.expire,
         }
         const response = await this.apiClient.post(
             `/databases/${databaseId}/set?encoding=buffer`,

--- a/tests/playwright/helpers/api/api-keys.ts
+++ b/tests/playwright/helpers/api/api-keys.ts
@@ -39,7 +39,7 @@ export class APIKeyRequests {
     }
 
     async addHashKeyApi(
-        keyParameters: HashKeyParameters,
+        keyParameters: HashKeyParameters & { expire?: number },
         databaseParameters: AddNewDatabaseParameters,
     ): Promise<void> {
         const databaseId = await this.databaseAPIRequests.getDatabaseIdByName(
@@ -52,6 +52,7 @@ export class APIKeyRequests {
                 field: Buffer.from(fields.field, 'utf-8'),
                 value: Buffer.from(fields.value, 'utf-8'),
             })),
+            expire: keyParameters?.expire,
         }
         const response = await this.apiClient.post(
             `/databases/${databaseId}/hash?encoding=buffer`,

--- a/tests/playwright/helpers/api/api-keys.ts
+++ b/tests/playwright/helpers/api/api-keys.ts
@@ -62,6 +62,31 @@ export class APIKeyRequests {
             throw new Error('The creation of new Hash key request failed')
     }
 
+    async addListKeyApi(
+        keyParameters: { keyName: string; elements: string[]; expire?: number },
+        databaseParameters: AddNewDatabaseParameters,
+    ): Promise<void> {
+        const databaseId = await this.databaseAPIRequests.getDatabaseIdByName(
+            databaseParameters.databaseName,
+        )
+        const requestBody = {
+            keyName: Buffer.from(keyParameters.keyName, 'utf-8'),
+            elements: keyParameters.elements.map((element) =>
+                Buffer.from(element, 'utf-8'),
+            ),
+            expire: keyParameters?.expire,
+        }
+
+        const response = await this.apiClient.post(
+            `/databases/${databaseId}/list?encoding=buffer`,
+            requestBody,
+        )
+
+        if (response.status !== 201) {
+            throw new Error('The creation of new List key request failed')
+        }
+    }
+
     async addStreamKeyApi(
         keyParameters: StreamKeyParameters,
         databaseParameters: AddNewDatabaseParameters,

--- a/tests/playwright/helpers/api/api-keys.ts
+++ b/tests/playwright/helpers/api/api-keys.ts
@@ -134,6 +134,36 @@ export class APIKeyRequests {
             throw new Error('The creation of new Set key request failed')
     }
 
+    async addZSetKeyApi(
+        keyParameters: {
+            keyName: string
+            members: Array<{ name: string; score: number }>
+            expire?: number
+        },
+        databaseParameters: AddNewDatabaseParameters,
+    ): Promise<void> {
+        const databaseId = await this.databaseAPIRequests.getDatabaseIdByName(
+            databaseParameters.databaseName,
+        )
+        const requestBody = {
+            keyName: Buffer.from(keyParameters.keyName, 'utf-8'),
+            members: keyParameters.members.map((member) => ({
+                name: Buffer.from(member.name, 'utf-8'),
+                score: member.score,
+            })),
+            expire: keyParameters?.expire,
+        }
+
+        const response = await this.apiClient.post(
+            `/databases/${databaseId}/zSet?encoding=buffer`,
+            requestBody,
+        )
+
+        if (response.status !== 201) {
+            throw new Error('The creation of new ZSet key request failed')
+        }
+    }
+
     async searchKeyByNameApi(
         keyName: string,
         databaseName: string,

--- a/tests/playwright/helpers/api/api-keys.ts
+++ b/tests/playwright/helpers/api/api-keys.ts
@@ -15,6 +15,29 @@ export class APIKeyRequests {
         private databaseAPIRequests: DatabaseAPIRequests,
     ) {}
 
+    async addStringKeyApi(
+        keyParameters: { keyName: string; value: string; expire?: number },
+        databaseParameters: AddNewDatabaseParameters,
+    ): Promise<void> {
+        const databaseId = await this.databaseAPIRequests.getDatabaseIdByName(
+            databaseParameters.databaseName,
+        )
+        const requestBody = {
+            keyName: Buffer.from(keyParameters.keyName, 'utf-8'),
+            value: Buffer.from(keyParameters.value, 'utf-8'),
+            expire: keyParameters?.expire,
+        }
+
+        const response = await this.apiClient.post(
+            `/databases/${databaseId}/string?encoding=buffer`,
+            requestBody,
+        )
+
+        if (response.status !== 201) {
+            throw new Error('The creation of new String key request failed')
+        }
+    }
+
     async addHashKeyApi(
         keyParameters: HashKeyParameters,
         databaseParameters: AddNewDatabaseParameters,
@@ -92,9 +115,8 @@ export class APIKeyRequests {
             cursor: '0',
             match: keyName,
         }
-        const databaseId = await this.databaseAPIRequests.getDatabaseIdByName(
-            databaseName,
-        )
+        const databaseId =
+            await this.databaseAPIRequests.getDatabaseIdByName(databaseName)
         const response = await this.apiClient.post(
             bufferPathMask.replace('databaseId', databaseId),
             requestBody,
@@ -108,9 +130,8 @@ export class APIKeyRequests {
         keyName: string,
         databaseName: string,
     ): Promise<void> {
-        const databaseId = await this.databaseAPIRequests.getDatabaseIdByName(
-            databaseName,
-        )
+        const databaseId =
+            await this.databaseAPIRequests.getDatabaseIdByName(databaseName)
         const doesKeyExist = await this.searchKeyByNameApi(
             keyName,
             databaseName,

--- a/tests/playwright/helpers/utils.ts
+++ b/tests/playwright/helpers/utils.ts
@@ -32,3 +32,7 @@ export async function navigateToStandaloneInstance(page: Page): Promise<void> {
     await expect(db).toBeVisible({ timeout: 5000 })
     await db.first().click()
 }
+
+export function stringToBuffer(str: string): Buffer {
+    return Buffer.from(str, 'utf-8')
+}

--- a/tests/playwright/pageObjects/browser-page.ts
+++ b/tests/playwright/pageObjects/browser-page.ts
@@ -526,7 +526,7 @@ export class BrowserPage extends BasePage {
             .locator('span')
         this.hashField = page.getByTestId('hash-field-').first()
         this.hashFieldValue = page.getByTestId('hash_content-value-')
-        this.setMembersList = page.getByTestId('set-member-value-')
+        this.setMembersList = page.locator('[data-testid^="set-member-value-"]')
         this.zsetMembersList = page.getByTestId('zset-member-value-')
         this.zsetScoresList = page.getByTestId('zset_content-value-')
         this.listElementsList = page.locator(
@@ -1386,6 +1386,21 @@ export class BrowserPage extends BasePage {
     async getAllListElements(): Promise<string[]> {
         // Get all list elements' text content
         const elements = await this.listElementsList.all()
+        const values: string[] = []
+
+        for (let i = 0; i < elements.length; i += 1) {
+            const text = await elements[i].textContent()
+            if (text && text.trim()) {
+                values.push(text.trim())
+            }
+        }
+
+        return values
+    }
+
+    async getAllSetMembers(): Promise<string[]> {
+        // Get all set members' text content
+        const elements = await this.setMembersList.all()
         const values: string[] = []
 
         for (let i = 0; i < elements.length; i += 1) {

--- a/tests/playwright/pageObjects/browser-page.ts
+++ b/tests/playwright/pageObjects/browser-page.ts
@@ -529,7 +529,9 @@ export class BrowserPage extends BasePage {
         this.setMembersList = page.getByTestId('set-member-value-')
         this.zsetMembersList = page.getByTestId('zset-member-value-')
         this.zsetScoresList = page.getByTestId('zset_content-value-')
-        this.listElementsList = page.getByTestId('list_content-value-')
+        this.listElementsList = page.locator(
+            '[data-testid^="list_content-value-"]',
+        )
         this.jsonKeyValue = page.getByTestId('json-data')
         this.jsonError = page.getByTestId('edit-json-error')
         this.tooltip = page.locator('[role="tooltip"]')
@@ -1379,5 +1381,20 @@ export class BrowserPage extends BasePage {
 
     async getKeyTTL(): Promise<string | null> {
         return this.keyDetailsTTL.textContent()
+    }
+
+    async getAllListElements(): Promise<string[]> {
+        // Get all list elements' text content
+        const elements = await this.listElementsList.all()
+        const values: string[] = []
+
+        for (let i = 0; i < elements.length; i += 1) {
+            const text = await elements[i].textContent()
+            if (text && text.trim()) {
+                values.push(text.trim())
+            }
+        }
+
+        return values
     }
 }

--- a/tests/playwright/pageObjects/browser-page.ts
+++ b/tests/playwright/pageObjects/browser-page.ts
@@ -1442,4 +1442,22 @@ export class BrowserPage extends BasePage {
 
         return members
     }
+
+    async getAllStreamEntries(): Promise<string[]> {
+        // Get all stream field elements that contain the actual data
+        const fieldElements = await this.page
+            .locator('[data-testid^="stream-entry-field-"]')
+            .all()
+
+        const fieldValues: string[] = []
+
+        for (let i = 0; i < fieldElements.length; i += 1) {
+            const text = await fieldElements[i].textContent()
+            if (text && text.trim()) {
+                fieldValues.push(text.trim())
+            }
+        }
+
+        return fieldValues
+    }
 }

--- a/tests/playwright/pageObjects/browser-page.ts
+++ b/tests/playwright/pageObjects/browser-page.ts
@@ -527,8 +527,12 @@ export class BrowserPage extends BasePage {
         this.hashField = page.getByTestId('hash-field-').first()
         this.hashFieldValue = page.getByTestId('hash_content-value-')
         this.setMembersList = page.locator('[data-testid^="set-member-value-"]')
-        this.zsetMembersList = page.getByTestId('zset-member-value-')
-        this.zsetScoresList = page.getByTestId('zset_content-value-')
+        this.zsetMembersList = page.locator(
+            '[data-testid^="zset-member-value-"]',
+        )
+        this.zsetScoresList = page.locator(
+            '[data-testid^="zset_content-value-"]',
+        )
         this.listElementsList = page.locator(
             '[data-testid^="list_content-value-"]',
         )
@@ -1411,5 +1415,31 @@ export class BrowserPage extends BasePage {
         }
 
         return values
+    }
+
+    async getAllZsetMembers(): Promise<Array<{ name: string; score: string }>> {
+        // Get all zset members' names and scores
+        const memberElements = await this.zsetMembersList.all()
+        const scoreElements = await this.zsetScoresList.all()
+        const members: Array<{ name: string; score: string }> = []
+
+        for (let i = 0; i < memberElements.length; i += 1) {
+            const memberText = await memberElements[i].textContent()
+            const scoreText = await scoreElements[i].textContent()
+
+            if (
+                memberText &&
+                memberText.trim() &&
+                scoreText &&
+                scoreText.trim()
+            ) {
+                members.push({
+                    name: memberText.trim(),
+                    score: scoreText.trim(),
+                })
+            }
+        }
+
+        return members
     }
 }

--- a/tests/playwright/pageObjects/browser-page.ts
+++ b/tests/playwright/pageObjects/browser-page.ts
@@ -486,9 +486,7 @@ export class BrowserPage extends BasePage {
         this.hashTtlFieldInput = page.getByTestId('hash-ttl')
         this.listKeyElementEditorInput = page.getByTestId('list_value-editor-')
         this.stringKeyValueInput = page.getByTestId('string-value')
-        this.jsonKeyValueInput = page.locator(
-            'div[data-mode-id=json] textarea',
-        )
+        this.jsonKeyValueInput = page.locator('div[data-mode-id=json] textarea')
         this.jsonUploadInput = page.getByTestId('upload-input-file')
         this.setMemberInput = page.getByTestId('member-name')
         this.zsetMemberScoreInput = page.getByTestId('member-score')
@@ -1281,5 +1279,75 @@ export class BrowserPage extends BasePage {
     async clickGuideLinksByName(guide: string): Promise<void> {
         const linkGuide = this.page.locator(guide)
         await linkGuide.click()
+    }
+
+    async isKeyDetailsOpen(keyName: string): Promise<boolean> {
+        try {
+            // Check if the key details header is visible (only present when key is selected)
+            const headerIsVisible = await this.page
+                .getByTestId('key-details-header')
+                .isVisible()
+
+            if (!headerIsVisible) {
+                return false
+            }
+
+            // Check if the key name in the header matches the expected key
+            const keyNameIsVisible = await this.keyNameFormDetails
+                .filter({ hasText: keyName })
+                .isVisible()
+
+            if (!keyNameIsVisible) {
+                return false
+            }
+
+            // Check if any key details content is visible
+            const detailsContainers = [
+                'string-details',
+                'hash-details',
+                'set-details',
+                'list-details',
+                'zset-details',
+                'json-details',
+                'stream-details',
+            ]
+
+            for (const containerId of detailsContainers) {
+                const container = this.page.getByTestId(containerId)
+                if (await container.isVisible()) {
+                    return true
+                }
+            }
+
+            return false
+        } catch (error) {
+            return false
+        }
+    }
+
+    async isKeyDetailsClosed(): Promise<boolean> {
+        try {
+            // Give a small moment for UI transitions to complete
+            await this.page.waitForTimeout(100)
+
+            // Check if the key details header is gone
+            const headerIsVisible = await this.page
+                .getByTestId('key-details-header')
+                .isVisible()
+
+            // Check if the close right panel button is not visible
+            const closeRightPanelBtn = await this.page
+                .getByTestId('close-right-panel-btn')
+                .isVisible()
+
+            // Details are closed if header is gone OR close panel button is not visible
+            return !headerIsVisible || !closeRightPanelBtn
+        } catch (error) {
+            return false
+        }
+    }
+
+    async closeKeyDetails(): Promise<void> {
+        await this.closeKeyButton.click()
     }
 }

--- a/tests/playwright/pageObjects/browser-page.ts
+++ b/tests/playwright/pageObjects/browser-page.ts
@@ -1350,4 +1350,34 @@ export class BrowserPage extends BasePage {
     async closeKeyDetails(): Promise<void> {
         await this.closeKeyButton.click()
     }
+
+    async hashFieldExists(
+        fieldName: string,
+        fieldValue: string,
+    ): Promise<boolean> {
+        try {
+            const fieldLocator = this.page.locator(
+                `[data-testid="hash-field-${fieldName}"]`,
+            )
+            const valueLocator = this.page.locator(
+                `[data-testid="hash_content-value-${fieldName}"]`,
+            )
+
+            const fieldExists = await fieldLocator.isVisible()
+            const valueExists = await valueLocator.isVisible()
+
+            if (!fieldExists || !valueExists) {
+                return false
+            }
+
+            const actualValue = await valueLocator.textContent()
+            return actualValue?.includes(fieldValue) || false
+        } catch {
+            return false
+        }
+    }
+
+    async getKeyTTL(): Promise<string | null> {
+        return this.keyDetailsTTL.textContent()
+    }
 }

--- a/tests/playwright/tests/browser/keys-read.spec.ts
+++ b/tests/playwright/tests/browser/keys-read.spec.ts
@@ -289,4 +289,74 @@ test.describe('Browser - Read Key Details', () => {
         const isDetailsClosed = await browserPage.isKeyDetailsClosed()
         expect(isDetailsClosed).toBe(true)
     })
+
+    test.only('should open key details when clicking on zset key', async ({
+        api: { keyService },
+    }) => {
+        const zsetMembers = [
+            { name: faker.lorem.word(), score: 1.5 },
+            { name: faker.lorem.word(), score: 2.0 },
+            { name: faker.lorem.word(), score: 10 },
+        ]
+        const keyTTL = 3600 // 1 hour
+
+        // Create a zset key with multiple members and TTL using API
+        await keyService.addZSetKeyApi(
+            { keyName, members: zsetMembers, expire: keyTTL },
+            ossStandaloneConfig,
+        )
+
+        // Search for the key to ensure it's visible
+        await browserPage.searchByKeyName(keyName)
+
+        // Click on the key to open details
+        await browserPage.openKeyDetailsByKeyName(keyName)
+
+        // Verify key details panel is open
+        const isDetailsOpen = await browserPage.isKeyDetailsOpen(keyName)
+        expect(isDetailsOpen).toBe(true)
+
+        // Verify zset members are displayed
+        const displayedMembers = await browserPage.getAllZsetMembers()
+        expect(displayedMembers).toHaveLength(zsetMembers.length)
+
+        // Verify all expected members and scores are present
+        zsetMembers.forEach((expectedMember) => {
+            const foundMember = displayedMembers.find(
+                (member) => member.name === expectedMember.name,
+            )
+            expect(foundMember).toBeDefined()
+            expect(foundMember?.score).toBe(expectedMember.score.toString())
+        })
+
+        // Verify the key length shows correct number of members
+        const keyLength = await browserPage.getKeyLength()
+        expect(keyLength).toBe(zsetMembers.length.toString())
+
+        // Verify the key size (bytes) is displayed correctly
+        const keySizeText = await browserPage.keySizeDetails.textContent()
+        expect(keySizeText).toBeTruthy()
+
+        // Verify the TTL value is displayed correctly
+        const displayedTTL = await browserPage.getKeyTTL()
+        expect(displayedTTL).toContain('TTL:')
+
+        // Extract the TTL value from the text and verify it's within expected range
+        const ttlMatch = displayedTTL?.match(/TTL:\s*(\d+|No limit)/)
+        expect(ttlMatch).toBeTruthy()
+
+        if (ttlMatch && ttlMatch[1] !== 'No limit') {
+            const actualTTL = parseInt(ttlMatch[1], 10)
+            // TTL should be close to what we set (allowing for some time passage during test execution)
+            expect(actualTTL).toBeGreaterThan(keyTTL - 60)
+            expect(actualTTL).toBeLessThanOrEqual(keyTTL)
+        }
+
+        // Close the details
+        await browserPage.closeKeyDetails()
+
+        // Verify details are closed
+        const isDetailsClosed = await browserPage.isKeyDetailsClosed()
+        expect(isDetailsClosed).toBe(true)
+    })
 })

--- a/tests/playwright/tests/browser/keys-read.spec.ts
+++ b/tests/playwright/tests/browser/keys-read.spec.ts
@@ -1,0 +1,100 @@
+import { faker } from '@faker-js/faker'
+
+import { BrowserPage } from '../../pageObjects/browser-page'
+import { test, expect } from '../../fixtures/test'
+import { ossStandaloneConfig } from '../../helpers/conf'
+import {
+    addStandaloneInstanceAndNavigateToIt,
+    navigateToStandaloneInstance,
+} from '../../helpers/utils'
+
+test.describe('Browser - Read Key Details', () => {
+    let browserPage: BrowserPage
+    let keyName: string
+    let cleanupInstance: () => Promise<void>
+
+    test.beforeEach(async ({ page, api: { databaseService } }) => {
+        browserPage = new BrowserPage(page)
+        keyName = faker.string.alphanumeric(10)
+        cleanupInstance = await addStandaloneInstanceAndNavigateToIt(
+            page,
+            databaseService,
+        )
+
+        await navigateToStandaloneInstance(page)
+    })
+
+    test.afterEach(async ({ api: { keyService } }) => {
+        // Clean up: delete the key if it exists
+        try {
+            await keyService.deleteKeyByNameApi(
+                keyName,
+                ossStandaloneConfig.databaseName,
+            )
+        } catch (error) {
+            // Key might already be deleted in test, ignore error
+        }
+
+        await cleanupInstance()
+    })
+
+    test('should open key details when clicking on string key', async ({
+        api: { keyService },
+    }) => {
+        // Arrange test data
+        const keyValue = faker.lorem.words(3)
+        const keyTTL = 3600 // 1 hour
+
+        // Create a string key with TTL using API
+        await keyService.addStringKeyApi(
+            { keyName, value: keyValue, expire: keyTTL },
+            ossStandaloneConfig,
+        )
+
+        // Search for the key to ensure it's visible
+        await browserPage.searchByKeyName(keyName)
+
+        // Click on the key to open details
+        await browserPage.openKeyDetailsByKeyName(keyName)
+
+        // Verify key details panel is open
+        const isDetailsOpen = await browserPage.isKeyDetailsOpen(keyName)
+        expect(isDetailsOpen).toBe(true)
+
+        // Verify the key value is displayed
+        const displayedValue = await browserPage.getStringKeyValue()
+        expect(displayedValue).toContain(keyValue)
+
+        // Verify the key length is displayed correctly
+        const displayedLength = await browserPage.getKeyLength()
+        expect(displayedLength).toBe(`${keyValue.length}`)
+
+        // Verify the key size (bytes) is displayed correctly
+        const keySizeText = await browserPage.keySizeDetails.textContent()
+        expect(keySizeText).toBeTruthy()
+
+        // Verify the TTL value is displayed correctly
+        const displayedTTL = await browserPage.keyDetailsTTL.textContent()
+        expect(displayedTTL).toContain('TTL:')
+
+        // Extract the TTL value from the text and verify it's within expected range
+        // TTL format is "TTL: {value}" where value could be the actual number or "No limit"
+        const ttlMatch = displayedTTL?.match(/TTL:\s*(\d+|No limit)/)
+        expect(ttlMatch).toBeTruthy()
+
+        if (ttlMatch && ttlMatch[1] !== 'No limit') {
+            const actualTTL = parseInt(ttlMatch[1], 10)
+            // TTL should be close to what we set (allowing for some time passage during test execution)
+            // Should be between our set value minus 60 seconds (1 minute buffer) and our set value
+            expect(actualTTL).toBeGreaterThan(keyTTL - 60)
+            expect(actualTTL).toBeLessThanOrEqual(keyTTL)
+        }
+
+        // Close the details
+        await browserPage.closeKeyDetails()
+
+        // Verify details are closed
+        const isDetailsClosed = await browserPage.isKeyDetailsClosed()
+        expect(isDetailsClosed).toBe(true)
+    })
+})

--- a/tests/playwright/tests/browser/keys-read.spec.ts
+++ b/tests/playwright/tests/browser/keys-read.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 
 import { BrowserPage } from '../../pageObjects/browser-page'
-import { test, expect } from '../../fixtures/test'
+import { test } from '../../fixtures/test'
 import { ossStandaloneConfig } from '../../helpers/conf'
 import {
     addStandaloneInstanceAndNavigateToIt,
@@ -51,51 +51,13 @@ test.describe('Browser - Read Key Details', () => {
             ossStandaloneConfig,
         )
 
-        // Search for the key to ensure it's visible
-        await browserPage.searchByKeyName(keyName)
-
-        // Click on the key to open details
-        await browserPage.openKeyDetailsByKeyName(keyName)
-
-        // Verify key details panel is open
-        const isDetailsOpen = await browserPage.isKeyDetailsOpen(keyName)
-        expect(isDetailsOpen).toBe(true)
-
-        // Verify the key value is displayed
-        const displayedValue = await browserPage.getStringKeyValue()
-        expect(displayedValue).toContain(keyValue)
-
-        // Verify the key length is displayed correctly
-        const displayedLength = await browserPage.getKeyLength()
-        expect(displayedLength).toBe(`${keyValue.length}`)
-
-        // Verify the key size (bytes) is displayed correctly
-        const keySizeText = await browserPage.keySizeDetails.textContent()
-        expect(keySizeText).toBeTruthy()
-
-        // Verify the TTL value is displayed correctly
-        const displayedTTL = await browserPage.getKeyTTL()
-        expect(displayedTTL).toContain('TTL:')
-
-        // Extract the TTL value from the text and verify it's within expected range
-        // TTL format is "TTL: {value}" where value could be the actual number or "No limit"
-        const ttlMatch = displayedTTL?.match(/TTL:\s*(\d+|No limit)/)
-        expect(ttlMatch).toBeTruthy()
-
-        if (ttlMatch && ttlMatch[1] !== 'No limit') {
-            const actualTTL = parseInt(ttlMatch[1], 10)
-            // TTL should be close to what we set (allowing for some time passage during test execution)
-            // Should be between our set value minus 60 seconds (1 minute buffer) and our set value
-            expect(actualTTL).toBeGreaterThan(keyTTL - 60)
-            expect(actualTTL).toBeLessThanOrEqual(keyTTL)
-        }
-
-        // Close the details
-        await browserPage.closeKeyDetails()
-
-        // Verify details are closed
-        const isDetailsClosed = await browserPage.isKeyDetailsClosed()
-        expect(isDetailsClosed).toBe(true)
+        // Open key details and verify all aspects
+        await browserPage.openKeyDetailsAndVerify(keyName)
+        await browserPage.verifyStringKeyContent(keyValue)
+        await browserPage.verifyKeyLength(`${keyValue.length}`)
+        await browserPage.verifyKeySize()
+        await browserPage.verifyKeyTTL(keyTTL)
+        await browserPage.closeKeyDetailsAndVerify()
     })
 
     test('should open key details when clicking on hash key', async ({
@@ -115,47 +77,13 @@ test.describe('Browser - Read Key Details', () => {
             ossStandaloneConfig,
         )
 
-        // Search and open details
-        await browserPage.searchByKeyName(keyName)
-        await browserPage.openKeyDetailsByKeyName(keyName)
-
-        // Verify details are open and show hash structure
-        const isDetailsOpen = await browserPage.isKeyDetailsOpen(keyName)
-        expect(isDetailsOpen).toBe(true)
-
-        // Verify the hash field is displayed
-        const hashField = await browserPage.hashFieldExists(
-            fieldName,
-            fieldValue,
-        )
-        expect(hashField).toBe(true)
-
-        // Verify the key length (number of hash fields) is displayed correctly
-        const displayedLength = await browserPage.getKeyLength()
-        expect(displayedLength).toBe('1') // We created 1 field
-
-        // Verify the key size (bytes) is displayed correctly
-        const keySizeText = await browserPage.keySizeDetails.textContent()
-        expect(keySizeText).toBeTruthy()
-
-        // Verify the TTL is displayed
-        const displayedTTL = await browserPage.getKeyTTL()
-        expect(displayedTTL).toContain('TTL:')
-
-        // Extract the numeric part of TTL and verify it's close to expected value
-        const ttlMatch = displayedTTL?.match(/TTL:\s*(\d+)/)
-        if (ttlMatch) {
-            const actualTTL = parseInt(ttlMatch[1], 10)
-            expect(actualTTL).toBeGreaterThan(keyTTL - 60) // Allow 60 seconds margin
-            expect(actualTTL).toBeLessThanOrEqual(keyTTL)
-        }
-
-        // Close the details
-        await browserPage.closeKeyDetails()
-
-        // Verify details are closed
-        const isDetailsClosed = await browserPage.isKeyDetailsClosed()
-        expect(isDetailsClosed).toBe(true)
+        // Open key details and verify all aspects
+        await browserPage.openKeyDetailsAndVerify(keyName)
+        await browserPage.verifyHashKeyContent(fieldName, fieldValue)
+        await browserPage.verifyKeyLength('1') // We created 1 field
+        await browserPage.verifyKeySize()
+        await browserPage.verifyKeyTTL(keyTTL)
+        await browserPage.closeKeyDetailsAndVerify()
     })
 
     test('should open key details when clicking on list key', async ({
@@ -174,54 +102,13 @@ test.describe('Browser - Read Key Details', () => {
             ossStandaloneConfig,
         )
 
-        // Search for the key to ensure it's visible
-        await browserPage.searchByKeyName(keyName)
-
-        // Click on the key to open details
-        await browserPage.openKeyDetailsByKeyName(keyName)
-
-        // Verify key details panel is open
-        const isDetailsOpen = await browserPage.isKeyDetailsOpen(keyName)
-        expect(isDetailsOpen).toBe(true)
-
-        // Verify list elements are displayed
-        const displayedElements = await browserPage.getAllListElements()
-        expect(displayedElements).toHaveLength(listElements.length)
-
-        // Verify all expected elements are present (order might be different)
-        listElements.forEach((expectedElement) => {
-            expect(displayedElements).toContain(expectedElement)
-        })
-
-        // Verify the key length shows correct number of elements
-        const keyLength = await browserPage.getKeyLength()
-        expect(keyLength).toBe(listElements.length.toString())
-
-        // Verify the key size (bytes) is displayed correctly
-        const keySizeText = await browserPage.keySizeDetails.textContent()
-        expect(keySizeText).toBeTruthy()
-
-        // Verify the TTL value is displayed correctly
-        const displayedTTL = await browserPage.getKeyTTL()
-        expect(displayedTTL).toContain('TTL:')
-
-        // Extract the TTL value from the text and verify it's within expected range
-        const ttlMatch = displayedTTL?.match(/TTL:\s*(\d+|No limit)/)
-        expect(ttlMatch).toBeTruthy()
-
-        if (ttlMatch && ttlMatch[1] !== 'No limit') {
-            const actualTTL = parseInt(ttlMatch[1], 10)
-            // TTL should be close to what we set (allowing for some time passage during test execution)
-            expect(actualTTL).toBeGreaterThan(keyTTL - 60)
-            expect(actualTTL).toBeLessThanOrEqual(keyTTL)
-        }
-
-        // Close the details
-        await browserPage.closeKeyDetails()
-
-        // Verify details are closed
-        const isDetailsClosed = await browserPage.isKeyDetailsClosed()
-        expect(isDetailsClosed).toBe(true)
+        // Open key details and verify all aspects
+        await browserPage.openKeyDetailsAndVerify(keyName)
+        await browserPage.verifyListKeyContent(listElements)
+        await browserPage.verifyKeyLength(listElements.length.toString())
+        await browserPage.verifyKeySize()
+        await browserPage.verifyKeyTTL(keyTTL)
+        await browserPage.closeKeyDetailsAndVerify()
     })
 
     test('should open key details when clicking on set key', async ({
@@ -240,54 +127,13 @@ test.describe('Browser - Read Key Details', () => {
             ossStandaloneConfig,
         )
 
-        // Search for the key to ensure it's visible
-        await browserPage.searchByKeyName(keyName)
-
-        // Click on the key to open details
-        await browserPage.openKeyDetailsByKeyName(keyName)
-
-        // Verify key details panel is open
-        const isDetailsOpen = await browserPage.isKeyDetailsOpen(keyName)
-        expect(isDetailsOpen).toBe(true)
-
-        // Verify set members are displayed
-        const displayedMembers = await browserPage.getAllSetMembers()
-        expect(displayedMembers).toHaveLength(setMembers.length)
-
-        // Verify all expected members are present (sets are unordered)
-        setMembers.forEach((expectedMember) => {
-            expect(displayedMembers).toContain(expectedMember)
-        })
-
-        // Verify the key length shows correct number of members
-        const keyLength = await browserPage.getKeyLength()
-        expect(keyLength).toBe(setMembers.length.toString())
-
-        // Verify the key size (bytes) is displayed correctly
-        const keySizeText = await browserPage.keySizeDetails.textContent()
-        expect(keySizeText).toBeTruthy()
-
-        // Verify the TTL value is displayed correctly
-        const displayedTTL = await browserPage.getKeyTTL()
-        expect(displayedTTL).toContain('TTL:')
-
-        // Extract the TTL value from the text and verify it's within expected range
-        const ttlMatch = displayedTTL?.match(/TTL:\s*(\d+|No limit)/)
-        expect(ttlMatch).toBeTruthy()
-
-        if (ttlMatch && ttlMatch[1] !== 'No limit') {
-            const actualTTL = parseInt(ttlMatch[1], 10)
-            // TTL should be close to what we set (allowing for some time passage during test execution)
-            expect(actualTTL).toBeGreaterThan(keyTTL - 60)
-            expect(actualTTL).toBeLessThanOrEqual(keyTTL)
-        }
-
-        // Close the details
-        await browserPage.closeKeyDetails()
-
-        // Verify details are closed
-        const isDetailsClosed = await browserPage.isKeyDetailsClosed()
-        expect(isDetailsClosed).toBe(true)
+        // Open key details and verify all aspects
+        await browserPage.openKeyDetailsAndVerify(keyName)
+        await browserPage.verifySetKeyContent(setMembers)
+        await browserPage.verifyKeyLength(setMembers.length.toString())
+        await browserPage.verifyKeySize()
+        await browserPage.verifyKeyTTL(keyTTL)
+        await browserPage.closeKeyDetailsAndVerify()
     })
 
     test('should open key details when clicking on zset key', async ({
@@ -306,58 +152,13 @@ test.describe('Browser - Read Key Details', () => {
             ossStandaloneConfig,
         )
 
-        // Search for the key to ensure it's visible
-        await browserPage.searchByKeyName(keyName)
-
-        // Click on the key to open details
-        await browserPage.openKeyDetailsByKeyName(keyName)
-
-        // Verify key details panel is open
-        const isDetailsOpen = await browserPage.isKeyDetailsOpen(keyName)
-        expect(isDetailsOpen).toBe(true)
-
-        // Verify zset members are displayed
-        const displayedMembers = await browserPage.getAllZsetMembers()
-        expect(displayedMembers).toHaveLength(zsetMembers.length)
-
-        // Verify all expected members and scores are present
-        zsetMembers.forEach((expectedMember) => {
-            const foundMember = displayedMembers.find(
-                (member) => member.name === expectedMember.name,
-            )
-            expect(foundMember).toBeDefined()
-            expect(foundMember?.score).toBe(expectedMember.score.toString())
-        })
-
-        // Verify the key length shows correct number of members
-        const keyLength = await browserPage.getKeyLength()
-        expect(keyLength).toBe(zsetMembers.length.toString())
-
-        // Verify the key size (bytes) is displayed correctly
-        const keySizeText = await browserPage.keySizeDetails.textContent()
-        expect(keySizeText).toBeTruthy()
-
-        // Verify the TTL value is displayed correctly
-        const displayedTTL = await browserPage.getKeyTTL()
-        expect(displayedTTL).toContain('TTL:')
-
-        // Extract the TTL value from the text and verify it's within expected range
-        const ttlMatch = displayedTTL?.match(/TTL:\s*(\d+|No limit)/)
-        expect(ttlMatch).toBeTruthy()
-
-        if (ttlMatch && ttlMatch[1] !== 'No limit') {
-            const actualTTL = parseInt(ttlMatch[1], 10)
-            // TTL should be close to what we set (allowing for some time passage during test execution)
-            expect(actualTTL).toBeGreaterThan(keyTTL - 60)
-            expect(actualTTL).toBeLessThanOrEqual(keyTTL)
-        }
-
-        // Close the details
-        await browserPage.closeKeyDetails()
-
-        // Verify details are closed
-        const isDetailsClosed = await browserPage.isKeyDetailsClosed()
-        expect(isDetailsClosed).toBe(true)
+        // Open key details and verify all aspects
+        await browserPage.openKeyDetailsAndVerify(keyName)
+        await browserPage.verifyZsetKeyContent(zsetMembers)
+        await browserPage.verifyKeyLength(zsetMembers.length.toString())
+        await browserPage.verifyKeySize()
+        await browserPage.verifyKeyTTL(keyTTL)
+        await browserPage.closeKeyDetailsAndVerify()
     })
 
     test('should open key details when clicking on json key', async ({
@@ -381,58 +182,15 @@ test.describe('Browser - Read Key Details', () => {
             ossStandaloneConfig,
         )
 
-        // Search for the key to ensure it's visible
-        await browserPage.searchByKeyName(keyName)
-
-        // Click on the key to open details
-        await browserPage.openKeyDetailsByKeyName(keyName)
-
-        // Verify key details panel is open
-        const isDetailsOpen = await browserPage.isKeyDetailsOpen(keyName)
-        expect(isDetailsOpen).toBe(true)
-
-        // Verify the JSON content is displayed
-        const displayedValue = await browserPage.getJsonKeyValue()
-
-        // Check for properties that should be visible in the top-level JSON view
-        expect(displayedValue).toContain(jsonValue.name)
-        expect(displayedValue).toContain(jsonValue.age.toString())
-        expect(displayedValue).toContain(jsonValue.active.toString())
-
-        // For nested objects and arrays, they might be collapsed and show as {...} or [...]
-        // So we just verify the JSON structure is present
-        expect(displayedValue).toContain('name')
-        expect(displayedValue).toContain('age')
-        expect(displayedValue).toContain('active')
-        expect(displayedValue).toContain('hobbies')
-        expect(displayedValue).toContain('address')
-
-        // Verify the key length shows correct number of elements
-        const keyLength = await browserPage.getKeyLength()
-        expect(keyLength).toBe(Object.keys(jsonValue).length.toString())
-
-        // Verify the key size (bytes) is displayed correctly
-        const keySizeText = await browserPage.keySizeDetails.textContent()
-        expect(keySizeText).toBeTruthy()
-
-        // Verify the TTL is displayed
-        const displayedTTL = await browserPage.getKeyTTL()
-        expect(displayedTTL).toContain('TTL:')
-
-        // Extract the numeric part of TTL and verify it's close to expected value
-        const ttlMatch = displayedTTL?.match(/TTL:\s*(\d+)/)
-        if (ttlMatch) {
-            const actualTTL = parseInt(ttlMatch[1], 10)
-            expect(actualTTL).toBeGreaterThan(keyTTL - 60) // Allow 60 seconds margin
-            expect(actualTTL).toBeLessThanOrEqual(keyTTL)
-        }
-
-        // Close the details
-        await browserPage.closeKeyDetails()
-
-        // Verify details are closed
-        const isDetailsClosed = await browserPage.isKeyDetailsClosed()
-        expect(isDetailsClosed).toBe(true)
+        // Open key details and verify all aspects
+        await browserPage.openKeyDetailsAndVerify(keyName)
+        await browserPage.verifyJsonKeyContent(jsonValue)
+        await browserPage.verifyKeyLength(
+            Object.keys(jsonValue).length.toString(),
+        )
+        await browserPage.verifyKeySize()
+        await browserPage.verifyKeyTTL(keyTTL)
+        await browserPage.closeKeyDetailsAndVerify()
     })
 
     test('should open key details when clicking on stream key', async ({
@@ -464,59 +222,12 @@ test.describe('Browser - Read Key Details', () => {
             ossStandaloneConfig,
         )
 
-        // Search for the key to ensure it's visible
-        await browserPage.searchByKeyName(keyName)
-
-        // Click on the key to open details
-        await browserPage.openKeyDetailsByKeyName(keyName)
-
-        // Verify key details panel is open
-        const isDetailsOpen = await browserPage.isKeyDetailsOpen(keyName)
-        expect(isDetailsOpen).toBe(true)
-
-        // Verify stream entries are displayed
-        const displayedFieldValues = await browserPage.getAllStreamEntries()
-        expect(displayedFieldValues.length).toBeGreaterThan(0)
-
-        // Combine all field values to check for expected content
-        const allFieldsText = displayedFieldValues.join(' ')
-
-        // Check that all expected field values are present
-        expect(allFieldsText).toContain('25.5')
-        expect(allFieldsText).toContain('60')
-        expect(allFieldsText).toContain('sensor-001')
-        expect(allFieldsText).toContain('26.2')
-        expect(allFieldsText).toContain('58')
-        expect(allFieldsText).toContain('sensor-002')
-
-        // Verify the key length shows correct number of entries
-        const keyLength = await browserPage.getKeyLength()
-        expect(keyLength).toBe(streamEntries.length.toString())
-
-        // Verify the key size (bytes) is displayed correctly
-        const keySizeText = await browserPage.keySizeDetails.textContent()
-        expect(keySizeText).toBeTruthy()
-
-        // Verify the TTL value is displayed correctly
-        const displayedTTL = await browserPage.getKeyTTL()
-        expect(displayedTTL).toContain('TTL:')
-
-        // Extract the TTL value from the text and verify it's within expected range
-        const ttlMatch = displayedTTL?.match(/TTL:\s*(\d+|No limit)/)
-        expect(ttlMatch).toBeTruthy()
-
-        if (ttlMatch && ttlMatch[1] !== 'No limit') {
-            const actualTTL = parseInt(ttlMatch[1], 10)
-            // TTL should be close to what we set (allowing for some time passage during test execution)
-            expect(actualTTL).toBeGreaterThan(keyTTL - 60)
-            expect(actualTTL).toBeLessThanOrEqual(keyTTL)
-        }
-
-        // Close the details
-        await browserPage.closeKeyDetails()
-
-        // Verify details are closed
-        const isDetailsClosed = await browserPage.isKeyDetailsClosed()
-        expect(isDetailsClosed).toBe(true)
+        // Open key details and verify all aspects
+        await browserPage.openKeyDetailsAndVerify(keyName)
+        await browserPage.verifyStreamKeyContent(streamEntries)
+        await browserPage.verifyKeyLength(streamEntries.length.toString())
+        await browserPage.verifyKeySize()
+        await browserPage.verifyKeyTTL(keyTTL)
+        await browserPage.closeKeyDetailsAndVerify()
     })
 })


### PR DESCRIPTION
# Description

Add new E2E tests to check the read functionality for different key types in the **Browsers** module. These tests make sure that when you click on a key, all its details show up correctly in the Details Panel (name, value(s), TTL, etc.).

### How the tests work
* First, prepare the data for the test using the Redis API (it's easier and faster and also, the UI flow for creating keys is already covered in another test suite)
* Then we open the **Details Panel** by clicking on the key we just added (in the table in the UI)
* Finally, we check that all the key information is displayed correctly, like "**Key name**", "**Value(s)**", "**TTL**", etc.

<img width="1341" height="748" alt="image" src="https://github.com/user-attachments/assets/ce6bc7b2-4c8c-435f-bb5b-280c74669dcc" />

## Code Changes

* Extend the API to support adding various key types, enabling us to easily assemble test data
* Extend browser page locators to provide helpers for checking the state of the keys details drawer
* Add e2e tests to verify that the information related to the various key types is properly displayed in the details drawer

# How to run the tests

You can always refer to the README, but simply running the following command should do the trick for you

```
# From the root directory
yarn dev:api

# In a new tab, again from the root directory
yarn dev:ui

# In a new tab, but this time go to tests/playwright directory
yarn test:chromium:local-web browser/keys-read 

# The, check the detailed report an all the video recordings
yarn playwright show-report
``` 

<img width="1006" height="590" alt="image" src="https://github.com/user-attachments/assets/2e0c9455-2611-43ee-9b72-f13252db352c" />

