### PR TITLE
RI-6570 Verify delete operations for all key types in the browsers module

### DIFF
--- a/tests/playwright/pageObjects/browser-page.ts
+++ b/tests/playwright/pageObjects/browser-page.ts
@@ -1600,4 +1600,36 @@ export class BrowserPage extends BasePage {
         await this.verifyKeyTTL(expectedTTL)
         await this.closeKeyDetailsAndVerify()
     }
+
+    async verifyKeyExists(keyName: string): Promise<void> {
+        await this.searchByKeyName(keyName)
+        const keyExists = await this.isKeyIsDisplayedInTheList(keyName)
+        expect(keyExists).toBe(true)
+    }
+
+    async verifyKeyDoesNotExist(keyName: string): Promise<void> {
+        await this.searchByKeyName(keyName)
+        const keyStillExists = await this.isKeyIsDisplayedInTheList(keyName)
+        expect(keyStillExists).toBe(false)
+    }
+
+    async deleteKeyFromDetailsView(keyName: string): Promise<void> {
+        await this.openKeyDetailsByKeyName(keyName)
+        await this.deleteKeyButton.click()
+        await this.confirmDeleteKeyButton.click()
+    }
+
+    async deleteKeyFromListView(keyName: string): Promise<void> {
+        await this.deleteKeyByNameFromList(keyName)
+    }
+
+    async startKeyDeletion(keyName: string): Promise<void> {
+        await this.openKeyDetailsByKeyName(keyName)
+        await this.deleteKeyButton.click()
+    }
+
+    async cancelKeyDeletion(): Promise<void> {
+        // Click outside the confirmation popover to cancel deletion
+        await this.keyDetailsHeader.click()
+    }
 }

--- a/tests/playwright/tests/browser/keys-delete.spec.ts
+++ b/tests/playwright/tests/browser/keys-delete.spec.ts
@@ -1,0 +1,215 @@
+import { faker } from '@faker-js/faker'
+
+import { BrowserPage } from '../../pageObjects/browser-page'
+import { test } from '../../fixtures/test'
+import { ossStandaloneConfig } from '../../helpers/conf'
+import {
+    addStandaloneInstanceAndNavigateToIt,
+    navigateToStandaloneInstance,
+} from '../../helpers/utils'
+
+test.describe('Browser - Delete Key', () => {
+    let browserPage: BrowserPage
+    let keyName: string
+    let cleanupInstance: () => Promise<void>
+
+    test.beforeEach(async ({ page, api: { databaseService } }) => {
+        browserPage = new BrowserPage(page)
+        keyName = faker.string.alphanumeric(10)
+        cleanupInstance = await addStandaloneInstanceAndNavigateToIt(
+            page,
+            databaseService,
+        )
+
+        await navigateToStandaloneInstance(page)
+    })
+
+    test.afterEach(async ({ api: { keyService } }) => {
+        // Clean up: delete the key if it still exists
+        try {
+            await keyService.deleteKeyByNameApi(
+                keyName,
+                ossStandaloneConfig.databaseName,
+            )
+        } catch (error) {
+            // Key might already be deleted in test, ignore error
+        }
+
+        await cleanupInstance()
+    })
+
+    test.describe('when clicking on the delete button in the details view', () => {
+        test('should delete string key successfully', async ({
+            api: { keyService },
+        }) => {
+            // Arrange: Create a string key
+            const keyValue = faker.lorem.words(3)
+            await keyService.addStringKeyApi(
+                { keyName, value: keyValue },
+                ossStandaloneConfig,
+            )
+
+            // Verify key exists, delete it, and verify deletion
+            await browserPage.verifyKeyExists(keyName)
+            await browserPage.deleteKeyFromDetailsView(keyName)
+            await browserPage.verifyKeyDoesNotExist(keyName)
+        })
+
+        test('should delete hash key successfully', async ({
+            api: { keyService },
+        }) => {
+            // Arrange: Create a hash key
+            const fieldName = faker.string.alphanumeric(8)
+            const fieldValue = faker.lorem.words(2)
+            await keyService.addHashKeyApi(
+                {
+                    keyName,
+                    fields: [{ field: fieldName, value: fieldValue }],
+                },
+                ossStandaloneConfig,
+            )
+
+            // Verify key exists, delete it, and verify deletion
+            await browserPage.verifyKeyExists(keyName)
+            await browserPage.deleteKeyFromDetailsView(keyName)
+            await browserPage.verifyKeyDoesNotExist(keyName)
+        })
+
+        test('should delete list key successfully', async ({
+            api: { keyService },
+        }) => {
+            // Arrange: Create a list key
+            const listElements = [
+                faker.lorem.word(),
+                faker.lorem.word(),
+                faker.lorem.word(),
+            ]
+            await keyService.addListKeyApi(
+                { keyName, elements: listElements },
+                ossStandaloneConfig,
+            )
+
+            // Verify key exists, delete it, and verify deletion
+            await browserPage.verifyKeyExists(keyName)
+            await browserPage.deleteKeyFromDetailsView(keyName)
+            await browserPage.verifyKeyDoesNotExist(keyName)
+        })
+
+        test('should delete set key successfully', async ({
+            api: { keyService },
+        }) => {
+            // Arrange: Create a set key
+            const setMembers = [
+                faker.lorem.word(),
+                faker.lorem.word(),
+                faker.lorem.word(),
+            ]
+            await keyService.addSetKeyApi(
+                { keyName, members: setMembers },
+                ossStandaloneConfig,
+            )
+
+            // Verify key exists, delete it, and verify deletion
+            await browserPage.verifyKeyExists(keyName)
+            await browserPage.deleteKeyFromDetailsView(keyName)
+            await browserPage.verifyKeyDoesNotExist(keyName)
+        })
+
+        test('should delete sorted set key successfully', async ({
+            api: { keyService },
+        }) => {
+            // Arrange: Create a zset key
+            const zsetMembers = [
+                { name: faker.lorem.word(), score: 1.5 },
+                { name: faker.lorem.word(), score: 2.0 },
+                { name: faker.lorem.word(), score: 10 },
+            ]
+            await keyService.addZSetKeyApi(
+                { keyName, members: zsetMembers },
+                ossStandaloneConfig,
+            )
+
+            // Verify key exists, delete it, and verify deletion
+            await browserPage.verifyKeyExists(keyName)
+            await browserPage.deleteKeyFromDetailsView(keyName)
+            await browserPage.verifyKeyDoesNotExist(keyName)
+        })
+
+        test('should delete json key successfully', async ({
+            api: { keyService },
+        }) => {
+            // Arrange: Create a JSON key
+            const jsonValue = {
+                name: faker.person.fullName(),
+                age: faker.number.int({ min: 18, max: 80 }),
+                active: true,
+            }
+            await keyService.addJsonKeyApi(
+                { keyName, value: jsonValue },
+                ossStandaloneConfig,
+            )
+
+            // Verify key exists, delete it, and verify deletion
+            await browserPage.verifyKeyExists(keyName)
+            await browserPage.deleteKeyFromDetailsView(keyName)
+            await browserPage.verifyKeyDoesNotExist(keyName)
+        })
+
+        test('should delete stream key successfully', async ({
+            api: { keyService },
+        }) => {
+            // Arrange: Create a stream key
+            const streamEntries = [
+                {
+                    id: '*',
+                    fields: [
+                        { name: 'temperature', value: '25.5' },
+                        { name: 'location', value: 'sensor-001' },
+                    ],
+                },
+            ]
+            await keyService.addStreamKeyApi(
+                { keyName, entries: streamEntries },
+                ossStandaloneConfig,
+            )
+
+            // Verify key exists, delete it, and verify deletion
+            await browserPage.verifyKeyExists(keyName)
+            await browserPage.deleteKeyFromDetailsView(keyName)
+            await browserPage.verifyKeyDoesNotExist(keyName)
+        })
+    })
+
+    test('should delete key from list view using delete button', async ({
+        api: { keyService },
+    }) => {
+        // Arrange: Create a string key for this test
+        const keyValue = faker.lorem.words(2)
+        await keyService.addStringKeyApi(
+            { keyName, value: keyValue },
+            ossStandaloneConfig,
+        )
+
+        // Verify key exists, delete from list view, and verify deletion
+        await browserPage.verifyKeyExists(keyName)
+        await browserPage.deleteKeyFromListView(keyName)
+        await browserPage.verifyKeyDoesNotExist(keyName)
+    })
+
+    test('should cancel key deletion when outside of the deletion confirmation popover', async ({
+        api: { keyService },
+    }) => {
+        // Arrange: Create a string key
+        const keyValue = faker.lorem.words(3)
+        await keyService.addStringKeyApi(
+            { keyName, value: keyValue },
+            ossStandaloneConfig,
+        )
+
+        // Verify key exists, start deletion but cancel, and verify key still exists
+        await browserPage.verifyKeyExists(keyName)
+        await browserPage.startKeyDeletion(keyName)
+        await browserPage.cancelKeyDeletion()
+        await browserPage.verifyKeyExists(keyName)
+    })
+})


### PR DESCRIPTION
# Description

Add new E2E tests to check the delete functionalities for different key types in the Browsers module. These tests make sure that you can delete an existing key - both from the list and its details page.

<img width="1576" height="748" alt="image" src="https://github.com/user-attachments/assets/889be56c-e4f4-4da0-8c00-a4cf1c556d1f" />

### How the tests work

- First, prepare the data for the test using the Redis API (it's easier and faster and also, the UI flow for creating keys is already covered in another test suite)
- Then we open the Details Panel by clicking on the key we just added (in the table in the UI)
- Then, we click on the delete icon button and verify whether the record is deleted successfully

_Note: Once [PR: 4723](https://github.com/redis/RedisInsight/pull/4723) is merged, make sure to update the target branch of this pull request to lead to [feature/RI-6570/PlayWright](https://github.com/redis/RedisInsight/tree/feature/RI-6570/PlayWright) branch._

## Code Changes

* Extend browser page locators to provide helpers for dealing with the state of the keys and their values in details drawer
* Add e2e tests to verify that you can delete all various key types

# How to run the tests

You can always refer to the README, but simply running the following command should do the trick for you

```
# From the root directory
yarn dev:api

# In a new tab, again from the root directory
yarn dev:ui

# In a new tab, but this time go to tests/playwright directory
yarn test:chromium:local-web browser/keys-delete 

# The, check the detailed report an all the video recordings
yarn playwright show-report
``` 

### Delete Keys

```
yarn test:chromium:local-web browser/keys-delete 
```

<img width="1003" height="762" alt="Screenshot 2025-07-16 at 14 08 05" src="https://github.com/user-attachments/assets/ce8f7f48-33f4-46a0-a470-21753a23277e" />

