### PR TITLE
RI-6570 Verify generic edit operations in the browsers module

### DIFF
--- a/tests/playwright/tests/browser/keys-edit.spec.ts
+++ b/tests/playwright/tests/browser/keys-edit.spec.ts
@@ -1,0 +1,188 @@
+import { faker } from '@faker-js/faker'
+
+import { BrowserPage } from '../../pageObjects/browser-page'
+import { test, expect } from '../../fixtures/test'
+import { ossStandaloneConfig } from '../../helpers/conf'
+import {
+    addStandaloneInstanceAndNavigateToIt,
+    navigateToStandaloneInstance,
+} from '../../helpers/utils'
+
+test.describe('Browser - Edit Key Operations', () => {
+    let browserPage: BrowserPage
+    let keyName: string
+    let cleanupInstance: () => Promise<void>
+
+    test.beforeEach(async ({ page, api: { databaseService } }) => {
+        browserPage = new BrowserPage(page)
+        keyName = faker.string.alphanumeric(10)
+        cleanupInstance = await addStandaloneInstanceAndNavigateToIt(
+            page,
+            databaseService,
+        )
+
+        await navigateToStandaloneInstance(page)
+    })
+
+    test.afterEach(async ({ api: { keyService } }) => {
+        // Clean up: delete the key if it exists
+        try {
+            await keyService.deleteKeyByNameApi(
+                keyName,
+                ossStandaloneConfig.databaseName,
+            )
+        } catch (error) {
+            // Key might already be deleted in test, ignore error
+        }
+
+        await cleanupInstance()
+    })
+
+    test.describe('Key Name Editing', () => {
+        test('should edit string key name successfully', async ({
+            api: { keyService },
+        }) => {
+            // Arrange: Create a string key
+            const keyValue = faker.lorem.words(3)
+            const newKeyName = `${keyName}_renamed`
+
+            await keyService.addStringKeyApi(
+                { keyName, value: keyValue },
+                ossStandaloneConfig,
+            )
+
+            // Open key details
+            await browserPage.searchByKeyName(keyName)
+            await browserPage.openKeyDetailsByKeyName(keyName)
+
+            // Edit key name
+            await browserPage.editKeyNameButton.click()
+            await browserPage.keyNameInput.clear()
+            await browserPage.keyNameInput.fill(newKeyName)
+            await browserPage.applyButton.click()
+
+            // Verify key name was updated in the details header
+            await expect
+                .poll(async () => {
+                    const keyNameText =
+                        await browserPage.keyNameFormDetails.textContent()
+                    return keyNameText
+                })
+                .toContain(newKeyName)
+
+            // Wait for the key list to update and verify the new key exists
+            await expect
+                .poll(async () => {
+                    await browserPage.searchByKeyName(newKeyName)
+                    return browserPage.isKeyIsDisplayedInTheList(newKeyName)
+                })
+                .toBe(true)
+
+            // Verify the old key name doesn't exist in list
+            await expect
+                .poll(async () => {
+                    await browserPage.searchByKeyName(keyName)
+                    return browserPage.isKeyIsDisplayedInTheList(keyName)
+                })
+                .toBe(false)
+
+            // Update keyName for cleanup
+            keyName = newKeyName
+        })
+
+        test('should cancel key name edit operation', async ({
+            api: { keyService },
+        }) => {
+            // Arrange: Create a string key
+            const keyValue = faker.lorem.words(3)
+            const originalKeyName = keyName
+            const attemptedNewName = `${keyName}_attempted_rename`
+
+            await keyService.addStringKeyApi(
+                { keyName, value: keyValue },
+                ossStandaloneConfig,
+            )
+
+            // Open key details
+            await browserPage.searchByKeyName(keyName)
+            await browserPage.openKeyDetailsByKeyName(keyName)
+
+            // Verify original key name is displayed
+            const displayedOriginalName =
+                await browserPage.keyNameFormDetails.textContent()
+            expect(displayedOriginalName).toContain(originalKeyName)
+
+            // Start editing but cancel
+            await browserPage.editKeyNameButton.click()
+            await browserPage.keyNameInput.clear()
+            await browserPage.keyNameInput.fill(attemptedNewName)
+
+            // Cancel the edit by clicking outside the edit area
+            await browserPage.keyDetailsHeader.click()
+
+            // Verify the original key name is still displayed (edit was cancelled)
+            const displayedNameAfterCancel =
+                await browserPage.keyNameFormDetails.textContent()
+            expect(displayedNameAfterCancel).toContain(originalKeyName)
+            expect(displayedNameAfterCancel).not.toContain(attemptedNewName)
+
+            // Verify the original key still exists in the list
+            await browserPage.searchByKeyName(originalKeyName)
+            const originalKeyExists =
+                await browserPage.isKeyIsDisplayedInTheList(originalKeyName)
+            expect(originalKeyExists).toBe(true)
+
+            // Verify the attempted new name doesn't exist
+            await browserPage.searchByKeyName(attemptedNewName)
+            const attemptedKeyExists =
+                await browserPage.isKeyIsDisplayedInTheList(attemptedNewName)
+            expect(attemptedKeyExists).toBe(false)
+        })
+    })
+
+    test.describe('TTL Editing', () => {
+        test('should edit string key TTL successfully', async ({
+            api: { keyService },
+        }) => {
+            // Arrange: Create a string key with TTL
+            const keyValue = faker.lorem.words(3)
+            const initialTTL = 3600 // 1 hour
+            const newTTL = 7200 // 2 hours
+
+            await keyService.addStringKeyApi(
+                { keyName, value: keyValue, expire: initialTTL },
+                ossStandaloneConfig,
+            )
+
+            // Open key details and verify initial TTL
+            await browserPage.openKeyDetailsAndVerify(keyName)
+            await browserPage.verifyTTLIsNotPersistent()
+
+            // Edit the TTL and verify update
+            await browserPage.editKeyTTLValue(newTTL)
+            await browserPage.waitForTTLToUpdate(initialTTL)
+            await browserPage.verifyTTLIsWithinRange(newTTL)
+        })
+
+        test('should remove TTL from string key (set to persistent)', async ({
+            api: { keyService },
+        }) => {
+            // Arrange: Create a string key with TTL
+            const keyValue = faker.lorem.words(3)
+            const initialTTL = 3600 // 1 hour
+
+            await keyService.addStringKeyApi(
+                { keyName, value: keyValue, expire: initialTTL },
+                ossStandaloneConfig,
+            )
+
+            // Open key details and verify initial TTL
+            await browserPage.openKeyDetailsAndVerify(keyName)
+            await browserPage.verifyTTLIsNotPersistent()
+
+            // Remove TTL and verify it becomes persistent
+            await browserPage.removeKeyTTL()
+            await browserPage.verifyTTLIsPersistent()
+        })
+    })
+})


### PR DESCRIPTION
# Description

Add new E2E tests to check the generic update functionalities in the Browsers module. These tests make sure that when you click on a key, you can update its name and TTL.

<img width="1318" height="819" alt="image" src="https://github.com/user-attachments/assets/daa018e9-07e6-4f1d-a7b5-111b878708c2" />

### How the tests work

- First, prepare the data for the test using the Redis API (it's easier and faster and also, the UI flow for creating keys is already covered in another test suite)
- Then we open the Details Panel by clicking on the key we just added (in the table in the UI)
- After that, we go and update the key name and its TTL

_Note: Once [PR: 4723](https://github.com/redis/RedisInsight/pull/4723) is merged, make sure to update the target branch of this pull request to lead to [feature/RI-6570/PlayWright](https://github.com/redis/RedisInsight/tree/feature/RI-6570/PlayWright) branch._

## Code Changes

* Extend browser page locators to provide helpers for dealing with the state of the keys and their values in details drawer
* Add e2e tests to verify that you can edit all the information related to the various key types displayed in the details drawer

# How to run the tests

You can always refer to the README, but simply running the following command should do the trick for you

```
# From the root directory
yarn dev:api

# In a new tab, again from the root directory
yarn dev:ui

# In a new tab, but this time go to tests/playwright directory
yarn test:chromium:local-web browser/keys-edit 

# The, check the detailed report an all the video recordings
yarn playwright show-report
``` 

### Edit (generic)

```
yarn test:chromium:local-web browser/keys-edit.spec
```
<img width="1008" height="395" alt="image" src="https://github.com/user-attachments/assets/e545f066-e8aa-4e8d-8482-c89334fe4fef" />
