### PR TITLE
RI-6570 Verify edit hash keys operations for in the browsers module

### DIFF
--- a/tests/playwright/pageObjects/browser-page.ts
+++ b/tests/playwright/pageObjects/browser-page.ts
@@ -2176,8 +2176,95 @@ export class BrowserPage extends BasePage {
         await this.page
             .locator(`[data-testid="set-remove-btn-${member}-icon"]`)
             .click()
+        await this.page.locator(`[data-testid^="set-remove-btn-${member}"]`)
+    }
+
+    async waitForHashDetailsToBeVisible(): Promise<void> {
+        await expect(this.page.getByTestId('hash-details')).toBeVisible()
+    }
+
+    async verifyHashFieldValueContains(
+        fieldName: string,
+        expectedValue: string,
+    ): Promise<void> {
+        const fieldValueElement = this.page.locator(
+            `[data-testid="hash_content-value-${fieldName}"]`,
+        )
+        await expect(fieldValueElement).toContainText(expectedValue)
+    }
+
+    async verifyHashFieldValueNotContains(
+        fieldName: string,
+        unwantedValue: string,
+    ): Promise<void> {
+        const fieldValueElement = this.page.locator(
+            `[data-testid="hash_content-value-${fieldName}"]`,
+        )
+        await expect(fieldValueElement).not.toContainText(unwantedValue)
+    }
+
+    async waitForHashFieldToBeVisible(fieldName: string): Promise<void> {
+        await expect(
+            this.page.locator(`[data-testid="hash-field-${fieldName}"]`),
+        ).toBeVisible()
+        await expect(
+            this.page.locator(
+                `[data-testid="hash_content-value-${fieldName}"]`,
+            ),
+        ).toBeVisible()
+    }
+
+    async getHashFieldValueElement(fieldName: string) {
+        return this.page.locator(
+            `[data-testid="hash_content-value-${fieldName}"]`,
+        )
+    }
+
+    async editHashFieldValue(
+        fieldName: string,
+        newValue: string,
+    ): Promise<void> {
+        const fieldValueElement = await this.getHashFieldValueElement(fieldName)
+        await fieldValueElement.hover()
         await this.page
-            .locator(`[data-testid^="set-remove-btn-${member}"]`)
+            .locator(`[data-testid^="hash_edit-btn-${fieldName}"]`)
+            .click()
+
+        const editorLocator = this.page.locator('textarea').first()
+        await expect(editorLocator).toBeVisible()
+        await editorLocator.clear()
+        await editorLocator.fill(newValue)
+        await this.applyButton.click()
+    }
+
+    async cancelHashFieldEdit(
+        fieldName: string,
+        newValue: string,
+    ): Promise<void> {
+        const fieldValueElement = await this.getHashFieldValueElement(fieldName)
+        await fieldValueElement.hover()
+        await this.page
+            .locator(`[data-testid^="hash_edit-btn-${fieldName}"]`)
+            .click()
+
+        const editorLocator = this.page.locator('textarea').first()
+        await expect(editorLocator).toBeVisible()
+        await editorLocator.clear()
+        await editorLocator.fill(newValue)
+
+        // Cancel using Escape key
+        await this.page.keyboard.press('Escape')
+        await expect(editorLocator).not.toBeVisible()
+    }
+
+    async removeHashField(fieldName: string): Promise<void> {
+        const fieldValueElement = await this.getHashFieldValueElement(fieldName)
+        await fieldValueElement.hover()
+        await this.page
+            .locator(`[data-testid="remove-hash-button-${fieldName}-icon"]`)
+            .click()
+        await this.page
+            .locator(`[data-testid^="remove-hash-button-${fieldName}"]`)
             .getByText('Remove')
             .click()
     }
@@ -2340,5 +2427,19 @@ export class BrowserPage extends BasePage {
                 // No elements expected or found - this is fine
             }
         }
+    }
+
+    async verifyHashFieldValue(
+        fieldName: string,
+        expectedValue: string,
+    ): Promise<void> {
+        const fieldValueElement = await this.getHashFieldValueElement(fieldName)
+        await expect(fieldValueElement).toContainText(expectedValue)
+    }
+
+    async verifyHashFieldNotVisible(fieldName: string): Promise<void> {
+        await expect(
+            this.page.locator(`[data-testid="hash-field-${fieldName}"]`),
+        ).not.toBeVisible()
     }
 }

--- a/tests/playwright/tests/browser/keys-edit/edit-hash-key.spec.ts
+++ b/tests/playwright/tests/browser/keys-edit/edit-hash-key.spec.ts
@@ -1,0 +1,183 @@
+import { faker } from '@faker-js/faker'
+
+import { BrowserPage } from '../../../pageObjects/browser-page'
+import { test, expect } from '../../../fixtures/test'
+import { ossStandaloneConfig } from '../../../helpers/conf'
+import {
+    addStandaloneInstanceAndNavigateToIt,
+    navigateToStandaloneInstance,
+} from '../../../helpers/utils'
+
+test.describe('Browser - Edit Key Operations - Hash Key Editing', () => {
+    let browserPage: BrowserPage
+    let keyName: string
+    let cleanupInstance: () => Promise<void>
+
+    test.beforeEach(async ({ page, api: { databaseService } }) => {
+        browserPage = new BrowserPage(page)
+        keyName = faker.string.alphanumeric(10)
+        cleanupInstance = await addStandaloneInstanceAndNavigateToIt(
+            page,
+            databaseService,
+        )
+
+        await navigateToStandaloneInstance(page)
+    })
+
+    test.afterEach(async ({ api: { keyService } }) => {
+        // Clean up: delete the key if it exists
+        try {
+            await keyService.deleteKeyByNameApi(
+                keyName,
+                ossStandaloneConfig.databaseName,
+            )
+        } catch (error) {
+            // Key might already be deleted in test, ignore error
+        }
+
+        await cleanupInstance()
+    })
+
+    test('should edit hash field value successfully', async ({
+        api: { keyService },
+    }) => {
+        // Arrange: Create a hash key with a field
+        const fieldName = faker.string.alphanumeric(8)
+        const originalValue = faker.lorem.words(3)
+        const newValue = faker.lorem.words(4)
+
+        await keyService.addHashKeyApi(
+            {
+                keyName,
+                fields: [{ field: fieldName, value: originalValue }],
+            },
+            ossStandaloneConfig,
+        )
+
+        // Open key details and wait for hash to load
+        await browserPage.searchByKeyName(keyName)
+        await browserPage.openKeyDetailsByKeyName(keyName)
+
+        // Wait for field to be visible and verify original value
+        await browserPage.waitForHashFieldToBeVisible(fieldName)
+        await browserPage.verifyHashFieldValue(fieldName, originalValue)
+
+        // Edit the hash field value
+        await browserPage.editHashFieldValue(fieldName, newValue)
+
+        // Verify the value was updated
+        await browserPage.verifyHashFieldValue(fieldName, newValue)
+    })
+
+    test('should cancel hash field value edit operation', async ({
+        api: { keyService },
+    }) => {
+        // Arrange: Create a hash key with a field
+        const fieldName = faker.string.alphanumeric(8)
+        const originalValue = faker.lorem.words(3)
+        const attemptedNewValue = faker.lorem.words(4)
+
+        await keyService.addHashKeyApi(
+            {
+                keyName,
+                fields: [{ field: fieldName, value: originalValue }],
+            },
+            ossStandaloneConfig,
+        )
+
+        // Open key details and wait for hash to load
+        await browserPage.searchByKeyName(keyName)
+        await browserPage.openKeyDetailsByKeyName(keyName)
+        await browserPage.waitForHashDetailsToBeVisible()
+        await browserPage.verifyHashFieldValue(fieldName, originalValue)
+
+        // Start editing but cancel
+        await browserPage.cancelHashFieldEdit(fieldName, attemptedNewValue)
+
+        // Verify the original value is still present and attempted value is not
+        await browserPage.verifyHashFieldValueContains(fieldName, originalValue)
+        await browserPage.verifyHashFieldValueNotContains(
+            fieldName,
+            attemptedNewValue,
+        )
+    })
+
+    test('should add new field to hash key successfully', async ({
+        api: { keyService },
+    }) => {
+        // Arrange: Create a hash key with one field
+        const existingFieldName = faker.string.alphanumeric(8)
+        const existingFieldValue = faker.lorem.words(2)
+        const newFieldName = faker.string.alphanumeric(8)
+        const newFieldValue = faker.lorem.words(3)
+
+        await keyService.addHashKeyApi(
+            {
+                keyName,
+                fields: [
+                    { field: existingFieldName, value: existingFieldValue },
+                ],
+            },
+            ossStandaloneConfig,
+        )
+
+        // Open key details and verify initial state
+        await browserPage.searchByKeyName(keyName)
+        await browserPage.openKeyDetailsByKeyName(keyName)
+        await browserPage.waitForHashDetailsToBeVisible()
+        await browserPage.waitForKeyLengthToUpdate('1')
+
+        // Add a new field
+        await browserPage.addFieldToHash(newFieldName, newFieldValue)
+
+        // Verify new field appears and length updates
+        await browserPage.waitForHashFieldToBeVisible(newFieldName)
+        await browserPage.verifyHashFieldValue(newFieldName, newFieldValue)
+        await browserPage.waitForKeyLengthToUpdate('2')
+
+        // Verify existing field still exists
+        await browserPage.verifyHashFieldValue(
+            existingFieldName,
+            existingFieldValue,
+        )
+    })
+
+    test('should remove hash field successfully', async ({
+        api: { keyService },
+    }) => {
+        // Arrange: Create a hash key with multiple fields
+        const field1Name = faker.string.alphanumeric(8)
+        const field1Value = faker.lorem.words(2)
+        const field2Name = faker.string.alphanumeric(8)
+        const field2Value = faker.lorem.words(2)
+
+        await keyService.addHashKeyApi(
+            {
+                keyName,
+                fields: [
+                    { field: field1Name, value: field1Value },
+                    { field: field2Name, value: field2Value },
+                ],
+            },
+            ossStandaloneConfig,
+        )
+
+        // Open key details and verify initial state
+        await browserPage.searchByKeyName(keyName)
+        await browserPage.openKeyDetailsByKeyName(keyName)
+        await browserPage.waitForHashDetailsToBeVisible()
+        await browserPage.waitForKeyLengthToUpdate('2')
+
+        // Remove the first field
+        await browserPage.removeHashField(field1Name)
+
+        // Verify field was removed and length updated
+        await browserPage.waitForKeyLengthToUpdate('1')
+        await browserPage.verifyHashFieldNotVisible(field1Name)
+
+        // Verify other field still exists and key is still open
+        await browserPage.verifyHashFieldValue(field2Name, field2Value)
+        const keyStillExists = await browserPage.isKeyDetailsOpen(keyName)
+        expect(keyStillExists).toBe(true)
+    })
+})


### PR DESCRIPTION
# Description

Add new E2E tests to check the update functionalities for hash key types in the Browsers module. These tests make sure that when you click on a key, you can update all of its details in the Details Panel.

<img width="750" height="619" alt="image" src="https://github.com/user-attachments/assets/ab0a428d-6a9a-4ebf-b8bf-32e9aa3adacb" />

### How the tests work

- First, prepare the data for the test using the Redis API (it's easier and faster and also, the UI flow for creating keys is already covered in another test suite)
- Then we open the Details Panel by clicking on the key we just added (in the table in the UI)
- After that, we go and update the values, depending on the field type (and verify the change)

Note: Once [PR: 4723](https://github.com/redis/RedisInsight/pull/4723) is merged, make sure to update the target branch of this pull request to lead to [feature/RI-6570/PlayWright](https://github.com/redis/RedisInsight/tree/feature/RI-6570/PlayWright) branch.

## Code Changes

* Extend browser page locators to provide helpers for dealing with the state of the keys and their values in details drawer
* Add e2e tests to verify that you can edit all the information related to the various key types displayed in the details drawer

# How to run the tests

You can always refer to the README, but simply running the following command should do the trick for you

```
# From the root directory
yarn dev:api

# In a new tab, again from the root directory
yarn dev:ui

# In a new tab, but this time go to tests/playwright directory
yarn test:chromium:local-web browser/keys-edit 

# The, check the detailed report an all the video recordings
yarn playwright show-report
``` 

### Edit Hash Key

```
yarn test:chromium:local-web browser/keys-edit/edit-hash-key
```

<img width="1003" height="401" alt="image" src="https://github.com/user-attachments/assets/5e8068f5-ac29-4dbd-80ea-04a064e43a26" />
