### PR TITLE
RI-7197 Introduce vector search actions panel

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesDrawer.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesDrawer.spec.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { cleanup, render, screen } from 'uiSrc/utils/test-utils'
+import {
+  ManageIndexesDrawer,
+  ManageIndexesDrawerProps,
+} from './ManageIndexesDrawer'
+
+// Workaround for @redis-ui/components Title component issue with react-children-utilities
+// TypeError: react_utils.childrenToString is not a function
+jest.mock('uiSrc/components/base/layout/drawer', () => ({
+  ...jest.requireActual('uiSrc/components/base/layout/drawer'),
+  DrawerHeader: jest.fn().mockReturnValue(null),
+}))
+
+const renderComponent = (props?: Partial<ManageIndexesDrawerProps>) => {
+  const defaultProps: ManageIndexesDrawerProps = {
+    open: true,
+    onOpenChange: jest.fn(),
+  }
+
+  return render(<ManageIndexesDrawer {...defaultProps} {...props} />)
+}
+
+describe('ManageIndexesDrawer', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  it('should render', () => {
+    const { container } = renderComponent()
+
+    expect(container).toBeTruthy()
+
+    const drawer = screen.getByTestId('manage-indexes-drawer')
+    expect(drawer).toBeInTheDocument()
+
+    // Note: Since we mocked DrawerHeader, we can't check its presence
+    // const header = screen.getByText('Manage indexes')
+    // expect(header).toBeInTheDocument()
+
+    // TODO: Check the body content, once implemented
+    const body = screen.getByTestId('manage-indexes-drawer-body')
+    expect(body).toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesDrawer.tsx
+++ b/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesDrawer.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { DrawerProps } from '@redis-ui/components'
+import {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+} from 'uiSrc/components/base/layout/drawer'
+
+export interface ManageIndexesDrawerProps extends DrawerProps {}
+
+export const ManageIndexesDrawer = ({
+  open,
+  onOpenChange,
+  ...rest
+}: ManageIndexesDrawerProps) => (
+  <Drawer
+    open={open}
+    onOpenChange={onOpenChange}
+    data-testid="manage-indexes-drawer"
+    {...rest}
+  >
+    <DrawerHeader title="Manage indexes" />
+    <DrawerBody data-testid="manage-indexes-drawer-body">
+      <p>Manage indexes info will be added later</p>
+    </DrawerBody>
+  </Drawer>
+)

--- a/redisinsight/ui/src/pages/vector-search/query/HeaderActions.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/HeaderActions.spec.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { cleanup, render, screen, userEvent } from 'uiSrc/utils/test-utils'
+
+import { HeaderActions } from './HeaderActions'
+
+// Workaround for @redis-ui/components Title component issue with react-children-utilities
+// TypeError: react_utils.childrenToString is not a function
+jest.mock('uiSrc/components/base/layout/drawer', () => ({
+  ...jest.requireActual('uiSrc/components/base/layout/drawer'),
+  DrawerHeader: jest.fn().mockReturnValue(null),
+}))
+
+const renderComponent = () => render(<HeaderActions />)
+
+describe('ManageIndexesDrawer', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  it('should render', () => {
+    const { container } = renderComponent()
+
+    expect(container).toBeTruthy()
+
+    const headerActions = screen.getByTestId('vector-search-header-actions')
+    expect(headerActions).toBeInTheDocument()
+
+    // Verify the presence of the actions
+    const savedQueriesButton = screen.getByText('Saved queries')
+    expect(savedQueriesButton).toBeInTheDocument()
+
+    const manageIndexesButton = screen.getByText('Manage indexes')
+    expect(manageIndexesButton).toBeInTheDocument()
+  })
+
+  it('should open a drawer when "Manage indexes" is clicked', async () => {
+    renderComponent()
+
+    const manageIndexesButton = screen.getByText('Manage indexes')
+    expect(manageIndexesButton).toBeInTheDocument()
+
+    // Simulate clicking the "Manage indexes" button
+    await userEvent.click(manageIndexesButton)
+
+    // Check if the drawer is opened
+    const drawer = screen.getByTestId('manage-indexes-drawer')
+    expect(drawer).toBeInTheDocument()
+
+    // Simulate clicking outside the drawer to close it
+    await userEvent.click(document.body, { pointerEventsCheck: 0 })
+    expect(drawer).not.toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/vector-search/query/HeaderActions.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/query/HeaderActions.styles.ts
@@ -1,0 +1,16 @@
+import { TextButton } from '@redis-ui/components'
+import styled from 'styled-components'
+import { FlexGroup } from 'uiSrc/components/base/layout/flex'
+
+export const StyledHeaderAction = styled(FlexGroup)`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+`
+
+export const StyledTextButton = styled(TextButton)`
+  color: ${({ theme }) => theme.color.blue400};
+  &:hover {
+    color: ${({ theme }) => theme.color.blue500};
+  }
+`

--- a/redisinsight/ui/src/pages/vector-search/query/HeaderActions.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/HeaderActions.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react'
+import { StyledHeaderAction, StyledTextButton } from './HeaderActions.styles'
+import { ManageIndexesDrawer } from '../manage-indexes/ManageIndexesDrawer'
+
+export const HeaderActions = () => {
+  const [isManageIndexesDrawerOpen, setIsManageIndexesDrawerOpen] =
+    useState<boolean>(false)
+
+  return (
+    <>
+      <StyledHeaderAction data-testid="vector-search-header-actions">
+        <StyledTextButton>Saved queries</StyledTextButton>
+        <StyledTextButton onClick={() => setIsManageIndexesDrawerOpen(true)}>
+          Manage indexes
+        </StyledTextButton>
+      </StyledHeaderAction>
+
+      <ManageIndexesDrawer
+        open={isManageIndexesDrawerOpen}
+        onOpenChange={setIsManageIndexesDrawerOpen}
+      />
+    </>
+  )
+}

--- a/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
+import { HeaderActions } from './HeaderActions'
+import { CreateIndexWrapper } from '../create-index/styles'
 
-export const VectorSearchQuery = () => {
-  // TODO: implement this component
-  // https://www.figma.com/design/oO2eYRuuLmfzUYLkvCkFhM/Search-page?node-id=645-37412&t=TSwcttCYa4Ld9WzC-4
-  ;
-  return <h4>TODO</h4>
-}
+// TODO: implement this component
+// https://www.figma.com/design/oO2eYRuuLmfzUYLkvCkFhM/Search-page?node-id=645-37412&t=TSwcttCYa4Ld9WzC-4
+export const VectorSearchQuery = () => (
+  <CreateIndexWrapper direction="column" justify="between">
+    <HeaderActions />
+  </CreateIndexWrapper>
+)


### PR DESCRIPTION
# Description

Introduce a simple Vector Search actions panel that can be later injected in the proper place in the UI:
- Added simple component to present the different action buttons, based on the Redis UI `TextButton` component ([docs](https://redislabsdev.github.io/redis-ui/?path=/docs/components-buttons-textbutton--docs))
- Added button for "**Manage Indexes**" to open a container, based on the Redis UI `Drawer` component [docs](https://redislabsdev.github.io/redis-ui/?path=/docs/components-drawer--docs)
- Added a placeholder button for "**Saved Queries**" drawer, which will be implemented separately

### Vector Search actions

<img width="1061" height="517" alt="image" src="https://github.com/user-attachments/assets/fba84daa-e6cd-404f-8da6-306f37dbb8d2" />

### Manage Indexes drawer

_Note: For now, the content of the drawer is blank, but it will be implemented in a separate pull request_
<img width="1053" height="540" alt="image" src="https://github.com/user-attachments/assets/c8c2e263-6469-4b61-a6e1-12e6c7b91f41" />

# How to test it

These are base components that will be included in the new wizard for the Vector Search, but currently, you can find them integrated on a temporary page, for the sake of testing them.

Simply flip this temporary switch in `redisinsight/ui/src/pages/vector-search/VectorSearchPage.tsx` and then click on the "**Search**" icon in the left side nav to open the page:

```
export const VectorSearchPage = () => {
  const hasIndexes = true // Toggle between "wizard" and "search" view

```
