### PR TITLE
RI-7226: fix RiTooltip when content is empty

### DIFF
--- a/redisinsight/ui/src/components/base/tooltip/RITooltip.tsx
+++ b/redisinsight/ui/src/components/base/tooltip/RITooltip.tsx
@@ -23,7 +23,7 @@ export const RiTooltip = ({
   <TooltipProvider>
     <Tooltip
       {...props}
-      content={<HoverContent title={title} content={content} />}
+      content={content && <HoverContent title={title} content={content} />}
       placement={position}
       openDelayDuration={delay}
     >


### PR DESCRIPTION
## Description


| Before  | After |
| ------------- | ------------- |
| <img width="301" height="239" alt="Screenshot 2025-07-21 at 17 31 57" src="https://github.com/user-attachments/assets/cfa216c7-2a36-4daf-8588-5de448418731" />  | <img width="304" height="236" alt="Screenshot 2025-07-21 at 17 31 48" src="https://github.com/user-attachments/assets/d1a65e03-f34d-4f07-bf3d-b0d75b639f08" /> |
