### PR TITLE
RI-7226: fix RiTooltip when title/content is empty

### DIFF
--- a/redisinsight/ui/src/components/base/tooltip/RITooltip.tsx
+++ b/redisinsight/ui/src/components/base/tooltip/RITooltip.tsx
@@ -23,7 +23,9 @@ export const RiTooltip = ({
   <TooltipProvider>
     <Tooltip
       {...props}
-      content={content && <HoverContent title={title} content={content} />}
+      content={
+        (content || title) && <HoverContent title={title} content={content} />
+      }
       placement={position}
       openDelayDuration={delay}
     >

--- a/redisinsight/ui/src/components/base/tooltip/RiTooltip.spec.tsx
+++ b/redisinsight/ui/src/components/base/tooltip/RiTooltip.spec.tsx
@@ -62,7 +62,7 @@ describe('RiTooltip', () => {
     expect(screen.queryByRole('heading')).not.toBeInTheDocument()
   })
 
-  it('should not render tooltip when content and title is provided', async () => {
+  it('should not render tooltip when content and title are not provided', async () => {
     render(
       <RiTooltip>
         <TestButton />

--- a/redisinsight/ui/src/components/base/tooltip/RiTooltip.spec.tsx
+++ b/redisinsight/ui/src/components/base/tooltip/RiTooltip.spec.tsx
@@ -62,9 +62,9 @@ describe('RiTooltip', () => {
     expect(screen.queryByRole('heading')).not.toBeInTheDocument()
   })
 
-  it('should not render tooltip when content is not provided', async () => {
+  it('should not render tooltip when content and title is provided', async () => {
     render(
-      <RiTooltip title="Test Title">
+      <RiTooltip>
         <TestButton />
       </RiTooltip>,
     )
@@ -119,8 +119,12 @@ describe('RiTooltip', () => {
     })
     await waitForRiTooltipVisible()
 
-    expect(screen.getAllByTestId('tooltip-custom-content')[0]).toBeInTheDocument()
-    expect(screen.getAllByText('Custom content with HTML')[0]).toBeInTheDocument()
+    expect(
+      screen.getAllByTestId('tooltip-custom-content')[0],
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByText('Custom content with HTML')[0],
+    ).toBeInTheDocument()
     expect(
       screen.getAllByRole('button', { name: 'Hover me' })[0],
     ).toBeInTheDocument()


### PR DESCRIPTION
## Description

If only title or only content is provided, the tooltip should render 