### PR TITLE
RI-7187 show deployed pipeline by default

### DIFF
--- a/redisinsight/ui/src/pages/rdi/pipeline-management/PipelineManagementPage.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/PipelineManagementPage.spec.tsx
@@ -12,6 +12,7 @@ import {
 } from 'uiSrc/slices/app/context'
 import { PageNames, Pages } from 'uiSrc/constants'
 import { MOCK_RDI_PIPELINE_DATA } from 'uiSrc/mocks/data/rdi'
+import { getPipeline } from 'uiSrc/slices/rdi/pipeline'
 import PipelineManagementPage, { Props } from './PipelineManagementPage'
 
 const mockedProps = mock<Props>()
@@ -99,6 +100,7 @@ describe('PipelineManagementPage', () => {
 
     unmount()
     const expectedActions = [
+      getPipeline(),
       setLastPageContext(PageNames.rdiPipelineManagement),
       setLastPipelineManagementPage(Pages.rdiPipelineConfig('rdiInstanceId')),
     ]

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/PipelineManagementPage.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/PipelineManagementPage.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { IRoute, PageNames, Pages } from 'uiSrc/constants'
 import { connectedInstanceSelector } from 'uiSrc/slices/rdi/instances'
 import {
+  fetchRdiPipeline,
   fetchRdiPipelineJobFunctions,
   fetchRdiPipelineSchema,
 } from 'uiSrc/slices/rdi/pipeline'
@@ -43,6 +44,7 @@ const PipelineManagementPage = ({ routes = [] }: Props) => {
   setTitle(`${rdiInstanceName} - Pipeline Management`)
 
   useEffect(() => {
+    dispatch(fetchRdiPipeline(rdiInstanceId))
     dispatch(fetchRdiPipelineSchema(rdiInstanceId))
     dispatch(fetchRdiPipelineJobFunctions(rdiInstanceId))
   }, [])

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/Navigation.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/Navigation.tsx
@@ -109,7 +109,7 @@ const Navigation = () => {
         <EuiTextColor component="div">Pipeline Management</EuiTextColor>
       </div>
       <div className={styles.tabs} data-testid="rdi-pipeline-tabs">
-        {renderTabs()}
+        {!loading && renderTabs()}
       </div>
     </div>
   )

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/source-pipeline-dialog/SourcePipelineModal.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/source-pipeline-dialog/SourcePipelineModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   EuiIcon,
   EuiModal,
@@ -13,6 +13,7 @@ import { useParams } from 'react-router-dom'
 import { TelemetryEvent, sendEventTelemetry } from 'uiSrc/telemetry'
 import {
   fetchRdiPipeline,
+  rdiPipelineSelector,
   setChangedFile,
   setPipeline,
 } from 'uiSrc/slices/rdi/pipeline'
@@ -39,9 +40,19 @@ export enum PipelineSourceOptions {
 
 const SourcePipelineDialog = () => {
   const [isShowDownloadDialog, setIsShowDownloadDialog] = useState(false)
+  const [hasRdiPipelineDeployed, setHasRdiPipelineDeployed] =
+    useState(false)
+
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
 
   const { isOpenDialog } = useSelector(appContextPipelineManagement)
+
+  const { loading: pipelineLoading, config: pipelineConfig } =
+    useSelector(rdiPipelineSelector)
+
+  useEffect(() => {
+    setHasRdiPipelineDeployed(!pipelineLoading && pipelineConfig?.length > 0)
+  }, [pipelineConfig, pipelineLoading])
 
   const dispatch = useDispatch()
 
@@ -95,7 +106,7 @@ const SourcePipelineDialog = () => {
     )
   }
 
-  if (!isOpenDialog) {
+  if (!isOpenDialog || hasRdiPipelineDeployed) {
     return null
   }
 

--- a/redisinsight/ui/src/slices/rdi/pipeline.ts
+++ b/redisinsight/ui/src/slices/rdi/pipeline.ts
@@ -34,7 +34,7 @@ import successMessages from 'uiSrc/components/notifications/success-messages'
 import { AppDispatch, RootState } from '../store'
 
 export const initialState: IStateRdiPipeline = {
-  loading: false,
+  loading: true,
   error: '',
   data: null,
   config: '',


### PR DESCRIPTION
# Description

Show deployed pipeline from RDI server by default otherwise show a popup as now

## When pipeline exists:
<img width="1838" height="421" alt="Screenshot 2025-07-23 at 17 05 22" src="https://github.com/user-attachments/assets/e65b0324-2f11-4ce1-ae42-c6794578c8e7" />
 
## When pipeline doesn't exist:
<img width="1840" height="532" alt="Screenshot 2025-07-23 at 17 05 33" src="https://github.com/user-attachments/assets/66847e87-07f4-49ef-a287-d21aa3bc8551" />
