### PR TITLE
RI-7211: replace eui form

### DIFF
--- a/redisinsight/ui/src/components/consents-settings/ConsentsNotifications/ConsentsNotifications.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsNotifications/ConsentsNotifications.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useFormik } from 'formik'
 import { has } from 'lodash'
-import { EuiForm } from '@elastic/eui'
 
 import { compareConsents } from 'uiSrc/utils'
 import {
@@ -89,11 +88,7 @@ const ConsentsNotifications = () => {
   }
 
   return (
-    <EuiForm
-      component="form"
-      onSubmit={formik.handleSubmit}
-      data-testid="consents-settings-form"
-    >
+    <form onSubmit={formik.handleSubmit} data-testid="consents-settings-form">
       <div className={styles.consentsWrapper}>
         <Title size="XS">Notifications</Title>
         {notificationConsents.map((consent: IConsent) => (
@@ -106,7 +101,7 @@ const ConsentsNotifications = () => {
           />
         ))}
       </div>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/components/consents-settings/ConsentsPrivacy/ConsentsPrivacy.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsPrivacy/ConsentsPrivacy.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useFormik } from 'formik'
 import { has } from 'lodash'
-import { EuiForm } from '@elastic/eui'
 
 import { compareConsents } from 'uiSrc/utils'
 import {
@@ -79,11 +78,7 @@ const ConsentsPrivacy = () => {
   }
 
   return (
-    <EuiForm
-      component="form"
-      onSubmit={formik.handleSubmit}
-      data-testid="consents-settings-form"
-    >
+    <form onSubmit={formik.handleSubmit} data-testid="consents-settings-form">
       <div className={styles.consentsWrapper}>
         <Text size="s" className={styles.smallText} color="subdued">
           To optimize your experience, Redis Insight uses third-party tools.
@@ -100,7 +95,7 @@ const ConsentsPrivacy = () => {
           />
         ))}
       </div>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { FormikErrors, useFormik } from 'formik'
 import { isEmpty, forEach } from 'lodash'
-import { EuiForm } from '@elastic/eui'
 import cx from 'classnames'
 
 import { HorizontalRule, RiTooltip } from 'uiSrc/components'
@@ -210,11 +209,7 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
   }
 
   return (
-    <EuiForm
-      component="form"
-      onSubmit={formik.handleSubmit}
-      data-testid="consents-settings-form"
-    >
+    <form onSubmit={formik.handleSubmit} data-testid="consents-settings-form">
       <div className={styles.consentsWrapper}>
         <Spacer size="m" />
         {consents.length > 1 && (
@@ -293,7 +288,8 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
           <HorizontalRule margin="l" className={styles.requiredHR} />
           <Spacer size="m" />
           <Text color="subdued" size="s" className={styles.smallText}>
-            Use of Redis Insight is governed by your signed agreement with Redis, or, if none, by the{' '}
+            Use of Redis Insight is governed by your signed agreement with
+            Redis, or, if none, by the{' '}
             <Link
               target="_blank"
               href="https://redis.io/software-subscription-agreement/?utm_source=redisinsight&utm_medium=app&utm_campaign=EULA"
@@ -344,7 +340,7 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
             <PrimaryButton
               className="btn-add"
               type="submit"
-              onClick={() => { }}
+              onClick={() => {}}
               disabled={submitIsDisabled()}
               icon={submitIsDisabled() ? InfoIcon : undefined}
               data-testid="btn-submit"
@@ -354,7 +350,7 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
           </RiTooltip>
         </FlexItem>
       </Row>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
+++ b/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
@@ -1,8 +1,9 @@
 import React, { ChangeEvent, Ref, useEffect, useRef, useState } from 'react'
 import { capitalize } from 'lodash'
 import cx from 'classnames'
-import { EuiFieldText, EuiForm, keys } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 
+import * as keys from 'uiSrc/constants/keys'
 import { RiPopover, RiTooltip } from 'uiSrc/components/base'
 import { FlexItem } from 'uiSrc/components/base/layout/flex'
 import { WindowEvent } from 'uiSrc/components/base/utils/WindowEvent'
@@ -51,7 +52,6 @@ export interface Props {
   disableFocusTrap?: boolean
   approveByValidation?: (value: string) => boolean
   approveText?: { title: string; text: string }
-  formComponentType?: 'form' | 'div'
   textFiledClassName?: string
 }
 
@@ -85,7 +85,6 @@ const InlineItemEditor = (props: Props) => {
     disableFocusTrap = false,
     approveByValidation,
     approveText,
-    formComponentType = 'form',
     textFiledClassName,
   } = props
   const containerEl: Ref<HTMLDivElement> = useRef(null)
@@ -199,8 +198,7 @@ const InlineItemEditor = (props: Props) => {
           <div ref={containerEl} className={styles.container}>
             <WindowEvent event="keydown" handler={handleOnEsc} />
             <FocusTrap disabled={disableFocusTrap}>
-              <EuiForm
-                component={formComponentType}
+              <form
                 className="relative"
                 onSubmit={(e: unknown) =>
                   handleFormSubmit(e as React.MouseEvent<HTMLElement>)
@@ -292,7 +290,7 @@ const InlineItemEditor = (props: Props) => {
                     </RiPopover>
                   )}
                 </div>
-              </EuiForm>
+              </form>
             </FocusTrap>
           </div>
         </OutsideClickDetector>

--- a/redisinsight/ui/src/components/multi-search/MultiSearch.tsx
+++ b/redisinsight/ui/src/components/multi-search/MultiSearch.tsx
@@ -1,7 +1,8 @@
 import React, { ChangeEvent, useEffect, useRef, useState } from 'react'
 import cx from 'classnames'
-import { EuiFieldText, keys } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 
+import * as keys from 'uiSrc/constants/keys'
 import { GroupBadge, RiTooltip } from 'uiSrc/components'
 import { OutsideClickDetector } from 'uiSrc/components/base/utils'
 import { Nullable } from 'uiSrc/utils'

--- a/redisinsight/ui/src/components/oauth/shared/oauth-form/components/oauth-sso-form/OAuthSsoForm.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-form/components/oauth-sso-form/OAuthSsoForm.tsx
@@ -1,6 +1,6 @@
 import { isEmpty } from 'lodash'
 import React, { ChangeEvent, useState } from 'react'
-import { EuiFieldText, EuiForm } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 import { FormikErrors, useFormik } from 'formik'
 import { validateEmail, validateField } from 'uiSrc/utils'
 
@@ -89,7 +89,7 @@ const OAuthSsoForm = ({ onBack, onSubmit }: Props) => {
       <Title className={styles.title} size="S">
         Single Sign-On
       </Title>
-      <EuiForm component="form" onSubmit={formik.handleSubmit}>
+      <form onSubmit={formik.handleSubmit}>
         <Row>
           <FlexItem>
             <FormField className={styles.formRaw} label="Email">
@@ -126,7 +126,7 @@ const OAuthSsoForm = ({ onBack, onSubmit }: Props) => {
             <SubmitButton text="Login" disabled={submitIsDisabled()} />
           </FlexItem>
         </Row>
-      </EuiForm>
+      </form>
     </div>
   )
 }

--- a/redisinsight/ui/src/components/side-panels/SidePanels.tsx
+++ b/redisinsight/ui/src/components/side-panels/SidePanels.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react'
 import cx from 'classnames'
-import { KeyboardKeys as keys } from 'uiSrc/constants/keys'
+
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useLocation, useParams } from 'react-router-dom'
+import { KeyboardKeys as keys } from 'uiSrc/constants/keys'
 
 import {
   changeSelectedTab,

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/shared/chat-form/ChatForm.spec.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/shared/chat-form/ChatForm.spec.tsx
@@ -28,7 +28,7 @@ describe('ChatForm', () => {
 
     fireEvent.click(screen.getByTestId('ai-submit-message-btn'))
 
-    expect(onSubmit).toBeCalledWith('test')
+    expect(onSubmit).toHaveBeenCalledWith('test')
   })
 
   it('should submit by enter', () => {
@@ -45,7 +45,7 @@ describe('ChatForm', () => {
       key: 'Enter',
     })
 
-    expect(onSubmit).toBeCalledWith('test')
+    expect(onSubmit).toHaveBeenCalledWith('test')
   })
 
   it('should show agreements popover', async () => {
@@ -68,7 +68,7 @@ describe('ChatForm', () => {
     })
     await waitForRiPopoverVisible()
 
-    expect(onSubmit).not.toBeCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
 
     expect(screen.getByTestId('ai-submit-message-btn')).toBeInTheDocument()
 
@@ -76,6 +76,6 @@ describe('ChatForm', () => {
       fireEvent.click(screen.getByTestId('ai-accept-agreements'))
     })
 
-    expect(onSubmit).toBeCalledWith('test')
+    expect(onSubmit).toHaveBeenCalledWith('test')
   })
 })

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/shared/chat-form/ChatForm.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/shared/chat-form/ChatForm.tsx
@@ -1,5 +1,4 @@
 import React, { Ref, useRef, useState } from 'react'
-import { EuiForm, keys } from '@elastic/eui'
 
 import cx from 'classnames'
 import { isModifiedEvent } from 'uiSrc/services'
@@ -11,6 +10,7 @@ import { SendIcon } from 'uiSrc/components/base/icons'
 import { Title } from 'uiSrc/components/base/text/Title'
 import { Text } from 'uiSrc/components/base/text'
 import { TextArea } from 'uiSrc/components/base/inputs'
+import * as keys from 'uiSrc/constants/keys'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -113,13 +113,13 @@ const ChatForm = (props: Props) => {
         }
         className={styles.validationTooltip}
       >
-        <EuiForm
+        <form
           className={cx(styles.wrapper, {
             [styles.isFormDisabled]: validation,
           })}
-          component="form"
           onSubmit={handleSubmitForm}
           onKeyDown={handleKeyDown}
+          role="presentation"
         >
           <TextArea
             ref={textAreaRef}
@@ -163,7 +163,7 @@ const ChatForm = (props: Props) => {
               </PrimaryButton>
             </>
           </RiPopover>
-        </EuiForm>
+        </form>
       </RiTooltip>
       <Text textAlign="center" size="xs" className={styles.agreementText}>
         Verify the accuracy of any information provided by Redis Copilot before

--- a/redisinsight/ui/src/components/table-column-search-trigger/TableColumnSearchTrigger.tsx
+++ b/redisinsight/ui/src/components/table-column-search-trigger/TableColumnSearchTrigger.tsx
@@ -14,7 +14,6 @@ export interface Props {
   initialValue?: string
   handleOpenState: (isOpen: boolean) => void
   fieldName: string
-  prependSearchName: string
   onApply?: (value: string) => void
   searchValidation?: Maybe<(value: string) => string>
 }
@@ -45,17 +44,6 @@ const TableColumnSearchTrigger = (props: Props) => {
 
   const handleOpen = () => {
     handleOpenState(true)
-  }
-
-  const handleOnBlur = (e?: React.FocusEvent<HTMLInputElement>) => {
-    const relatedTarget = e?.relatedTarget as HTMLInputElement
-    const target = e?.target as HTMLInputElement
-    if (relatedTarget?.classList.contains('euiFormControlLayoutClearButton')) {
-      return
-    }
-    if (!target.value) {
-      handleOpenState(false)
-    }
   }
 
   const handleApply = (_value: string): void => {

--- a/redisinsight/ui/src/components/table-column-search-trigger/TableColumnSearchTrigger.tsx
+++ b/redisinsight/ui/src/components/table-column-search-trigger/TableColumnSearchTrigger.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import cx from 'classnames'
-import { keys } from '@elastic/eui'
 
+import * as keys from 'uiSrc/constants/keys'
 import { SearchInput } from 'uiSrc/components/base/inputs'
 import { Maybe, Nullable } from 'uiSrc/utils'
 import { SearchIcon } from 'uiSrc/components/base/icons'

--- a/redisinsight/ui/src/components/table-column-search/TableColumnSearch.tsx
+++ b/redisinsight/ui/src/components/table-column-search/TableColumnSearch.tsx
@@ -7,7 +7,6 @@ import styles from './styles.module.scss'
 export interface Props {
   appliedValue: string
   fieldName: string
-  prependSearchName: string
   onApply?: (value: string) => void
   searchValidation?: Maybe<(value: string) => string>
 }

--- a/redisinsight/ui/src/constants/keys.ts
+++ b/redisinsight/ui/src/constants/keys.ts
@@ -193,19 +193,41 @@ export enum SearchHistoryMode {
   Redisearch = 'redisearch',
 }
 
+export const ENTER = 'Enter'
+export const SPACE = ' '
+export const ESCAPE = 'Escape'
+export const TAB = 'Tab'
+export const BACKSPACE = 'Backspace'
+export const F2 = 'F2'
+
+export const ALT = 'Alt'
+export const SHIFT = 'Shift'
+export const CTRL = 'Control'
+export const META = 'Meta' // Windows, Command, Option
+
+export const ARROW_DOWN = 'ArrowDown'
+export const ARROW_UP = 'ArrowUp'
+export const ARROW_LEFT = 'ArrowLeft'
+export const ARROW_RIGHT = 'ArrowRight'
+
+export const PAGE_UP = 'PageUp'
+export const PAGE_DOWN = 'PageDown'
+export const END = 'End'
+export const HOME = 'Home'
+
 export enum KeyboardKeys {
-  ENTER = "Enter",
-  SPACE = " ",
-  ESCAPE = "Escape",
-  TAB = "Tab",
-  BACKSPACE = "Backspace",
-  F2 = "F2",
-  ARROW_DOWN = "ArrowDown",
-  ARROW_UP = "ArrowUp",
-  ARROW_LEFT = "ArrowLeft",
-  ARROW_RIGHT = "ArrowRight",
-  PAGE_UP = "PageUp",
-  PAGE_DOWN = "PageDown",
-  END = "End",
-  HOME = "Home"
+  ENTER = 'Enter',
+  SPACE = ' ',
+  ESCAPE = 'Escape',
+  TAB = 'Tab',
+  BACKSPACE = 'Backspace',
+  F2 = 'F2',
+  ARROW_DOWN = 'ArrowDown',
+  ARROW_UP = 'ArrowUp',
+  ARROW_LEFT = 'ArrowLeft',
+  ARROW_RIGHT = 'ArrowRight',
+  PAGE_UP = 'PageUp',
+  PAGE_DOWN = 'PageDown',
+  END = 'End',
+  HOME = 'Home',
 }

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyHash/AddKeyHash.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyHash/AddKeyHash.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { EuiFieldText, EuiForm } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 import { toNumber } from 'lodash'
 import {
   isVersionHigherOrEquals,
@@ -163,7 +163,7 @@ const AddKeyHash = (props: Props) => {
     !(item.fieldName.length || item.fieldValue.length || item.fieldTTL?.length)
 
   return (
-    <EuiForm component="form" onSubmit={onFormSubmit}>
+    <form onSubmit={onFormSubmit}>
       <AddMultipleFields
         items={fields}
         isClearDisabled={isClearDisabled}
@@ -261,7 +261,7 @@ const AddKeyHash = (props: Props) => {
           </Row>
         </>
       </AddKeyFooter>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyList/AddKeyList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyList/AddKeyList.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, FormEvent, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { EuiForm, EuiFieldText } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 
 import { Maybe, stringToBuffer } from 'uiSrc/utils'
 import { addKeyStateSelector, addListKey } from 'uiSrc/slices/browser/keys'
@@ -86,7 +86,7 @@ const AddKeyList = (props: Props) => {
   }
 
   return (
-    <EuiForm component="form" onSubmit={onFormSubmit}>
+    <form onSubmit={onFormSubmit}>
       <RiSelect
         value={destination}
         options={optionsDestinations}
@@ -142,7 +142,7 @@ const AddKeyList = (props: Props) => {
           </Row>
         </>
       </AddKeyFooter>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyReJSON/AddKeyReJSON.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyReJSON/AddKeyReJSON.tsx
@@ -1,7 +1,6 @@
 import React, { FormEvent, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
-import { EuiForm } from '@elastic/eui'
 
 import { Maybe, stringToBuffer } from 'uiSrc/utils'
 import { addKeyStateSelector, addReJSONKey } from 'uiSrc/slices/browser/keys'
@@ -79,7 +78,7 @@ const AddKeyReJSON = (props: Props) => {
   }
 
   return (
-    <EuiForm component="form" onSubmit={onFormSubmit}>
+    <form onSubmit={onFormSubmit}>
       <FormField label={config.value.label}>
         <>
           <MonacoJson
@@ -132,7 +131,7 @@ const AddKeyReJSON = (props: Props) => {
           </Row>
         </>
       </AddKeyFooter>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeySet/AddKeySet.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeySet/AddKeySet.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { EuiFieldText, EuiForm } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 import { Maybe, stringToBuffer } from 'uiSrc/utils'
 import { addKeyStateSelector, addSetKey } from 'uiSrc/slices/browser/keys'
 
@@ -128,7 +128,7 @@ const AddKeySet = (props: Props) => {
     members.length === 1 && !item.name.length
 
   return (
-    <EuiForm component="form" onSubmit={onFormSubmit}>
+    <form onSubmit={onFormSubmit}>
       <AddMultipleFields
         items={members}
         isClearDisabled={isClearDisabled}
@@ -187,7 +187,7 @@ const AddKeySet = (props: Props) => {
           </Row>
         </>
       </AddKeyFooter>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyStream/AddKeyStream.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyStream/AddKeyStream.tsx
@@ -1,6 +1,5 @@
 import React, { FormEvent, useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
-import { EuiForm } from '@elastic/eui'
 import { addStreamKey } from 'uiSrc/slices/browser/keys'
 import {
   entryIdRegex,
@@ -90,11 +89,7 @@ const AddKeyStream = (props: Props) => {
   }
 
   return (
-    <EuiForm
-      className={styles.container}
-      component="form"
-      onSubmit={onFormSubmit}
-    >
+    <form className={styles.container} onSubmit={onFormSubmit}>
       <StreamEntryFields
         entryID={entryID}
         entryIdError={entryIdError}
@@ -133,7 +128,7 @@ const AddKeyStream = (props: Props) => {
           </Row>
         </>
       </AddKeyFooter>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyString/AddKeyString.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyString/AddKeyString.tsx
@@ -1,7 +1,6 @@
 import React, { FormEvent, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { EuiForm } from '@elastic/eui'
 import { Maybe, stringToBuffer } from 'uiSrc/utils'
 
 import { addKeyStateSelector, addStringKey } from 'uiSrc/slices/browser/keys'
@@ -54,7 +53,7 @@ const AddKeyString = (props: Props) => {
   }
 
   return (
-    <EuiForm component="form" onSubmit={onFormSubmit}>
+    <form onSubmit={onFormSubmit}>
       <FormField label={config.value.label}>
         <TextArea
           name="value"
@@ -98,7 +97,7 @@ const AddKeyString = (props: Props) => {
           </Row>
         </>
       </AddKeyFooter>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/components/add-key/AddKeyZset/AddKeyZset.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-key/AddKeyZset/AddKeyZset.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { toNumber } from 'lodash'
-import { EuiFieldText, EuiForm } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 import { Maybe, stringToBuffer, validateScoreNumber } from 'uiSrc/utils'
 import { isNaNConvertedString } from 'uiSrc/utils/numbers'
 import { addKeyStateSelector, addZsetKey } from 'uiSrc/slices/browser/keys'
@@ -182,7 +182,7 @@ const AddKeyZset = (props: Props) => {
     members.length === 1 && !(item.name.length || item.score.length)
 
   return (
-    <EuiForm component="form" onSubmit={onFormSubmit}>
+    <form onSubmit={onFormSubmit}>
       <AddMultipleFields
         items={members}
         isClearDisabled={isClearDisabled}
@@ -266,7 +266,7 @@ const AddKeyZset = (props: Props) => {
           </Row>
         </>
       </AddKeyFooter>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/components/search-key-list/SearchKeyList.tsx
+++ b/redisinsight/ui/src/pages/browser/components/search-key-list/SearchKeyList.tsx
@@ -1,8 +1,8 @@
-import { keys } from '@elastic/eui'
 import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import cx from 'classnames'
 
+import * as keys from 'uiSrc/constants/keys'
 import MultiSearch from 'uiSrc/components/multi-search/MultiSearch'
 import {
   SCAN_COUNT_DEFAULT,

--- a/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/Node.tsx
+++ b/redisinsight/ui/src/pages/browser/components/virtual-tree/components/Node/Node.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState, useRef } from 'react'
 import { NodePublicState } from 'react-vtree/dist/es/Tree'
 import cx from 'classnames'
-import {  keys as ElasticKeys } from '@elastic/eui'
-
 import { useSelector } from 'react-redux'
+
+import * as keys from 'uiSrc/constants/keys'
 import { Maybe } from 'uiSrc/utils'
 import { KeyTypes, ModulesKeyTypes, BrowserColumns } from 'uiSrc/constants'
 import KeyRowTTL from 'uiSrc/pages/browser/components/key-row-ttl'
@@ -91,7 +91,7 @@ const Node = ({
   }
 
   const handleKeyDown = ({ key }: React.KeyboardEvent<HTMLDivElement>) => {
-    if (key === ElasticKeys.SPACE) {
+    if (key === keys.SPACE) {
       handleClick()
     }
   }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/components/add-item/AddItem.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/components/add-item/AddItem.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
-import { EuiFieldText, EuiForm, keys } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 import { useSelector } from 'react-redux'
 
+import * as keys from 'uiSrc/constants/keys'
 import { rejsonDataSelector } from 'uiSrc/slices/browser/rejson'
 import { checkExistingPath } from 'uiSrc/utils/rejson'
 import FieldMessage from 'uiSrc/components/field-message/FieldMessage'
@@ -89,8 +90,7 @@ const AddItem = (props: Props) => {
         <div>
           <WindowEvent event="keydown" handler={(e) => handleOnEsc(e)} />
           <FocusTrap>
-            <EuiForm
-              component="form"
+            <form
               className="relative"
               onSubmit={(e) => handleFormSubmit(e)}
               style={{ display: 'flex' }}
@@ -148,7 +148,7 @@ const AddItem = (props: Props) => {
                   />
                 </div>
               </ConfirmOverwrite>
-            </EuiForm>
+            </form>
             {!!error && (
               <div className={cx(styles.errorMessage)}>
                 <FieldMessage

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/components/edit-entire-item-action/EditEntireItemAction.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/components/edit-entire-item-action/EditEntireItemAction.tsx
@@ -1,8 +1,8 @@
-import React, { ChangeEvent, useState } from 'react'
-import { EuiForm, keys } from '@elastic/eui'
+import React, { useState } from 'react'
 import cx from 'classnames'
 import jsonValidator from 'json-dup-key-validator'
 
+import * as keys from 'uiSrc/constants/keys'
 import { CancelSlimIcon, CheckThinIcon } from 'uiSrc/components/base/icons'
 import FieldMessage from 'uiSrc/components/field-message/FieldMessage'
 import { Nullable } from 'uiSrc/utils'
@@ -67,8 +67,7 @@ const EditEntireItemAction = (props: Props) => {
           <div>
             <WindowEvent event="keydown" handler={(e) => handleOnEsc(e)} />
             <FocusTrap>
-              <EuiForm
-                component="form"
+              <form
                 className="relative"
                 onSubmit={handleFormSubmit}
                 data-testid="json-entire-form"
@@ -89,25 +88,25 @@ const EditEntireItemAction = (props: Props) => {
                   onCancel={() => setIsConfirmationVisible(false)}
                   onConfirm={confirmApply}
                 >
-                <div className={cx(styles.controls, styles.controlsBottom)}>
-                  <IconButton
-                    icon={CancelSlimIcon}
-                    aria-label="Cancel add"
-                    className={styles.declineBtn}
-                    onClick={onCancel}
-                    data-testid="cancel-edit-btn"
-                  />
-                  <IconButton
-                    icon={CheckThinIcon}
-                    color="primary"
-                    type="submit"
-                    aria-label="Apply"
-                    className={styles.applyBtn}
-                    data-testid="apply-edit-btn"
-                  />
-                </div>
+                  <div className={cx(styles.controls, styles.controlsBottom)}>
+                    <IconButton
+                      icon={CancelSlimIcon}
+                      aria-label="Cancel add"
+                      className={styles.declineBtn}
+                      onClick={onCancel}
+                      data-testid="cancel-edit-btn"
+                    />
+                    <IconButton
+                      icon={CheckThinIcon}
+                      color="primary"
+                      type="submit"
+                      aria-label="Apply"
+                      className={styles.applyBtn}
+                      data-testid="apply-edit-btn"
+                    />
+                  </div>
                 </ConfirmOverwrite>
-              </EuiForm>
+              </form>
               {error && (
                 <div
                   className={cx(

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessageClaimPopover/MessageClaimPopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessageClaimPopover/MessageClaimPopover.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, ChangeEvent } from 'react'
 import { useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
-import { EuiForm } from '@elastic/eui'
 import { useFormik } from 'formik'
 import { orderBy, filter } from 'lodash'
 
@@ -207,7 +206,7 @@ const MessageClaimPopover = (props: Props) => {
       closePopover={() => {}}
       button={consumerOptions.length < 1 ? buttonTooltip : button}
     >
-      <EuiForm>
+      <form>
         <Row responsive gap="m">
           <FlexItem>
             <FormField label="Consumer">
@@ -351,7 +350,7 @@ const MessageClaimPopover = (props: Props) => {
             </PrimaryButton>
           </div>
         </Row>
-      </EuiForm>
+      </form>
     </RiPopover>
   )
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/shared/editable-popover/EditablePopover.tsx
@@ -1,8 +1,6 @@
 import React, { FormEvent, useEffect, useState } from 'react'
-
-import { EuiForm } from '@elastic/eui'
-
 import cx from 'classnames'
+
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import {
@@ -112,7 +110,7 @@ const EditablePopover = (props: Props) => {
       icon={btnIconType || EditIcon}
       aria-label="Edit field"
       color="primary"
-      onClick={isDisabledEditButton ? () => { } : handleButtonClick}
+      onClick={isDisabledEditButton ? () => {} : handleButtonClick}
       className={editBtnClassName}
       data-testid={`${prefix}_edit-btn-${field}`}
     />
@@ -137,10 +135,7 @@ const EditablePopover = (props: Props) => {
         >
           {content}
           {isDelayed && (
-            <Loader
-              className={cx(editBtnClassName, styles.spinner)}
-              size="m"
-            />
+            <Loader className={cx(editBtnClassName, styles.spinner)} size="m" />
           )}
           {!isPopoverOpen && isHovering && !isDelayed && button}
         </div>
@@ -148,7 +143,7 @@ const EditablePopover = (props: Props) => {
       data-testid="popover-item-editor"
       onClick={(e) => e.stopPropagation()}
     >
-      <EuiForm component="form" onSubmit={onFormSubmit}>
+      <form onSubmit={onFormSubmit}>
         <div className={styles.content}>{children}</div>
         <Spacer size="s" />
         <Row className={styles.footer} justify="end" gap="m">
@@ -173,7 +168,7 @@ const EditablePopover = (props: Props) => {
             </PrimaryButton>
           </FlexItem>
         </Row>
-      </EuiForm>
+      </form>
     </RiPopover>
   )
 }

--- a/redisinsight/ui/src/pages/home/components/add-database-screen/AddDatabaseScreen.tsx
+++ b/redisinsight/ui/src/pages/home/components/add-database-screen/AddDatabaseScreen.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import { EuiForm } from '@elastic/eui'
 import { useFormik } from 'formik'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory } from 'react-router'
@@ -105,11 +104,7 @@ const AddDatabaseScreen = (props: Props) => {
 
   return (
     <div className="eui-yScroll">
-      <EuiForm
-        component="form"
-        onSubmit={formik.handleSubmit}
-        data-testid="form"
-      >
+      <form onSubmit={formik.handleSubmit} data-testid="form">
         <Row responsive>
           <FlexItem grow>
             <ConnectionUrl
@@ -124,13 +119,7 @@ const AddDatabaseScreen = (props: Props) => {
             <RiTooltip
               position="top"
               anchorClassName="euiToolTip__btn-disabled"
-              content={
-                isInvalid ? (
-                  <span>
-                    {ConnectionUrlError}
-                  </span>
-                ) : null
-              }
+              content={isInvalid ? <span>{ConnectionUrlError}</span> : null}
             >
               <EmptyButton
                 size="small"
@@ -160,13 +149,7 @@ const AddDatabaseScreen = (props: Props) => {
                 <RiTooltip
                   position="top"
                   anchorClassName="euiToolTip__btn-disabled"
-                  content={
-                    isInvalid ? (
-                      <span>
-                        {ConnectionUrlError}
-                      </span>
-                    ) : null
-                  }
+                  content={isInvalid ? <span>{ConnectionUrlError}</span> : null}
                 >
                   <PrimaryButton
                     size="small"
@@ -182,7 +165,7 @@ const AddDatabaseScreen = (props: Props) => {
             </Row>
           </FlexItem>
         </Row>
-      </EuiForm>
+      </form>
       <Spacer />
       <div className={styles.hr}>Or</div>
       <Spacer />

--- a/redisinsight/ui/src/pages/home/components/cloud-connection/cloud-connection-form/CloudConnectionForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/cloud-connection/cloud-connection-form/CloudConnectionForm.tsx
@@ -2,9 +2,10 @@ import React, { ChangeEvent, useEffect, useState } from 'react'
 import ReactDOM from 'react-dom'
 import { FormikErrors, useFormik } from 'formik'
 import { isEmpty } from 'lodash'
-import { EuiFieldText, EuiForm, keys } from '@elastic/eui'
-
+import { EuiFieldText } from '@elastic/eui'
 import { useSelector } from 'react-redux'
+
+import * as keys from 'uiSrc/constants/keys'
 import { validateField } from 'uiSrc/utils/validations'
 import validationErrors from 'uiSrc/constants/validationErrors'
 import { FeatureFlagComponent, RiTooltip } from 'uiSrc/components'
@@ -184,7 +185,7 @@ const CloudConnectionForm = (props: Props) => {
       <MessageCloudApiKeys />
       <Spacer />
       <WindowEvent event="keydown" handler={onKeyDown} />
-      <EuiForm component="form" onSubmit={formik.handleSubmit}>
+      <form onSubmit={formik.handleSubmit}>
         <Row responsive>
           <FlexItem>
             <FormField label="API Account Key*">
@@ -228,7 +229,7 @@ const CloudConnectionForm = (props: Props) => {
           </FlexItem>
         </Row>
         <Footer />
-      </EuiForm>
+      </form>
     </div>
   )
 

--- a/redisinsight/ui/src/pages/home/components/cluster-connection/cluster-connection-form/ClusterConnectionForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/cluster-connection/cluster-connection-form/ClusterConnectionForm.tsx
@@ -2,8 +2,9 @@ import React, { ChangeEvent, useEffect, useState } from 'react'
 import ReactDOM from 'react-dom'
 import { isEmpty } from 'lodash'
 import { FormikErrors, useFormik } from 'formik'
-import { EuiFieldText, EuiForm, keys } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 
+import * as keys from 'uiSrc/constants/keys'
 import { MAX_PORT_NUMBER, validateField } from 'uiSrc/utils/validations'
 import { handlePasteHostName } from 'uiSrc/utils'
 import validationErrors from 'uiSrc/constants/validationErrors'
@@ -220,7 +221,7 @@ const ClusterConnectionForm = (props: Props) => {
       <MessageEnterpriceSoftware />
       <br />
 
-      <EuiForm>
+      <form>
         <WindowEvent event="keydown" handler={onKeyDown} />
         <Row responsive>
           <FlexItem grow={4}>
@@ -298,7 +299,7 @@ const ClusterConnectionForm = (props: Props) => {
             </FormField>
           </FlexItem>
         </Row>
-      </EuiForm>
+      </form>
       <Footer />
     </div>
   )

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/ManualConnectionForm.tsx
@@ -1,4 +1,3 @@
-import { keys } from '@elastic/eui'
 import { FormikErrors, useFormik } from 'formik'
 import { isEmpty, pick } from 'lodash'
 import React, { useEffect, useRef, useState } from 'react'
@@ -6,6 +5,7 @@ import ReactDOM from 'react-dom'
 import { useDispatch, useSelector } from 'react-redux'
 
 import cx from 'classnames'
+import * as keys from 'uiSrc/constants/keys'
 import { resetInstanceUpdateAction } from 'uiSrc/slices/instances/instances'
 import { ConnectionType } from 'uiSrc/slices/interfaces'
 import { BuildType } from 'uiSrc/constants/env'

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/AddConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/AddConnection.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { EuiForm } from '@elastic/eui'
 import { FormikProps } from 'formik'
 import {
   DatabaseForm,
@@ -37,11 +36,11 @@ const AddConnection = (props: Props) => {
   } = props
 
   return (
-    <EuiForm
-      component="form"
+    <form
       onSubmit={formik.handleSubmit}
       data-testid="form"
       onKeyDown={onKeyDown}
+      role="presentation"
     >
       {activeTab === ManualFormTab.General && (
         <>
@@ -86,7 +85,7 @@ const AddConnection = (props: Props) => {
       {activeTab === ManualFormTab.Decompression && (
         <DecompressionAndFormatters formik={formik} />
       )}
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditConnection.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { EuiForm } from '@elastic/eui'
 import { FormikProps } from 'formik'
 import {
   DatabaseForm,
@@ -43,11 +42,11 @@ const EditConnection = (props: Props) => {
   } = props
 
   return (
-    <EuiForm
-      component="form"
+    <form
       onSubmit={formik.handleSubmit}
       data-testid="form"
       onKeyDown={onKeyDown}
+      role="presentation"
     >
       {activeTab === ManualFormTab.General && (
         <>
@@ -102,7 +101,7 @@ const EditConnection = (props: Props) => {
       {activeTab === ManualFormTab.Decompression && (
         <DecompressionAndFormatters formik={formik} />
       )}
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditSentinelConnection.tsx
+++ b/redisinsight/ui/src/pages/home/components/manual-connection/manual-connection-form/forms/EditSentinelConnection.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { EuiFieldText, EuiForm } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 import { FormikProps } from 'formik'
 import {
   PrimaryGroupSentinel,
@@ -128,11 +128,11 @@ const EditSentinelConnection = (props: Props) => {
   )
 
   return (
-    <EuiForm
-      component="form"
+    <form
       onSubmit={formik.handleSubmit}
       data-testid="form"
       onKeyDown={onKeyDown}
+      role="presentation"
     >
       {activeTab === ManualFormTab.General && (
         <>{isCloneMode ? GeneralFormClodeMode : GeneralFormEditMode}</>
@@ -148,7 +148,7 @@ const EditSentinelConnection = (props: Props) => {
       {activeTab === ManualFormTab.Decompression && (
         <DecompressionAndFormatters formik={formik} />
       )}
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/home/components/sentinel-connection/sentinel-connection-form/SentinelConnectionForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/sentinel-connection/sentinel-connection-form/SentinelConnectionForm.tsx
@@ -1,9 +1,9 @@
-import { EuiForm, keys } from '@elastic/eui'
 import { FormikErrors, useFormik } from 'formik'
 import { isEmpty, pick } from 'lodash'
 import React, { useRef, useState } from 'react'
 import ReactDOM from 'react-dom'
 
+import * as keys from 'uiSrc/constants/keys'
 import validationErrors from 'uiSrc/constants/validationErrors'
 import { fieldDisplayNames } from 'uiSrc/pages/home/constants'
 import { getFormErrors, getSubmitButtonContent } from 'uiSrc/pages/home/utils'
@@ -142,11 +142,11 @@ const SentinelConnectionForm = (props: Props) => {
       <div className="getStartedForm eui-yScroll" ref={formRef}>
         <MessageSentinel />
         <br />
-        <EuiForm
-          component="form"
+        <form
           onSubmit={formik.handleSubmit}
           data-testid="form"
           onKeyDown={onKeyDown}
+          role="presentation"
         >
           <DatabaseForm
             formik={formik}
@@ -164,7 +164,7 @@ const SentinelConnectionForm = (props: Props) => {
             certificates={certificates}
             caCertificates={caCertificates}
           />
-        </EuiForm>
+        </form>
       </div>
       <Footer />
     </div>

--- a/redisinsight/ui/src/pages/pub-sub/components/publish-message/PublishMessage.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/components/publish-message/PublishMessage.tsx
@@ -1,4 +1,4 @@
-import { EuiFieldText, EuiForm } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 import cx from 'classnames'
 import React, {
   ChangeEvent,
@@ -80,11 +80,7 @@ const PublishMessage = () => {
   }
 
   return (
-    <EuiForm
-      className={styles.container}
-      component="form"
-      onSubmit={onFormSubmit}
-    >
+    <form className={styles.container} onSubmit={onFormSubmit}>
       <FlexItem
         grow
         className={cx('flexItemNoFullWidth', 'inlineFieldsNoSpace')}
@@ -154,7 +150,7 @@ const PublishMessage = () => {
           </PrimaryButton>
         </FlexItem>
       </Row>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/rdi/home/connection-form/ConnectionForm.tsx
+++ b/redisinsight/ui/src/pages/rdi/home/connection-form/ConnectionForm.tsx
@@ -1,4 +1,4 @@
-import { EuiFieldText, EuiForm, ToolTipPositions } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 import {
   Field,
   FieldInputProps,
@@ -34,7 +34,7 @@ import styles from './styles.module.scss'
 
 export interface AppendInfoProps
   extends Omit<RiTooltipProps, 'children' | 'delay' | 'position'> {
-  position?: ToolTipPositions
+  position?: RiTooltipProps['position']
 }
 
 export interface ConnectionFormValues {
@@ -166,11 +166,7 @@ const ConnectionForm = (props: Props) => {
     >
       {({ isValid, errors, values }) => (
         <Form className={styles.form}>
-          <EuiForm
-            component="div"
-            className="databasePanelWrapper"
-            data-testid="connection-form"
-          >
+          <div className="databasePanelWrapper" data-testid="connection-form">
             <div className={cx('container relative')}>
               <FormField label="RDI Alias*" className={styles.withoutPadding}>
                 <Field name="name">
@@ -267,7 +263,7 @@ const ConnectionForm = (props: Props) => {
               errors={errors}
               onSubmit={() => handleSubmit(values)}
             />
-          </EuiForm>
+          </div>
         </Form>
       )}
     </Formik>

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-panel/Panel.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-panel/Panel.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
-import { keys } from '@elastic/eui'
+
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import { isArray, upperFirst } from 'lodash'
 
+import * as keys from 'uiSrc/constants/keys'
 import { PipelineJobsTabs } from 'uiSrc/slices/interfaces/rdi'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import {

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-form/TemplateForm.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/template-form/TemplateForm.tsx
@@ -1,4 +1,3 @@
-import { EuiForm } from '@elastic/eui'
 import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
@@ -168,7 +167,7 @@ const TemplateForm = (props: Props) => {
     <div className={cx(styles.container)}>
       <Text className={styles.title}>Select a template</Text>
       <Spacer size="s" />
-      <EuiForm component="form">
+      <form>
         <Spacer size="xs" />
         {pipelineTypeOptions?.length > 1 && (
           <FormField className={styles.formRow}>
@@ -198,7 +197,7 @@ const TemplateForm = (props: Props) => {
             </>
           </FormField>
         )}
-      </EuiForm>
+      </form>
       <div className={styles.actions}>
         <SecondaryButton
           onClick={handleCancel}

--- a/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/datetime-form/DatetimeForm.tsx
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/datetime-form/DatetimeForm.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useFormik } from 'formik'
-import { EuiFieldText, EuiForm } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 import { checkDateTimeFormat, formatTimestamp } from 'uiSrc/utils'
 import {
   DATETIME_FORMATTER_DEFAULT,
@@ -177,11 +177,7 @@ const DatetimeForm = ({ onFormatChange }: Props) => {
   ]
 
   return (
-    <EuiForm
-      component="form"
-      onSubmit={formik.handleSubmit}
-      data-testid="format-timestamp-form"
-    >
+    <form onSubmit={formik.handleSubmit} data-testid="format-timestamp-form">
       <RiRadioGroup
         items={dateTimeFormatOptions}
         id="datetime-format"
@@ -240,7 +236,7 @@ const DatetimeForm = ({ onFormatChange }: Props) => {
           </>
         )}
       </Row>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/timezone-form/TimezoneForm.tsx
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/timezone-form/TimezoneForm.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useFormik } from 'formik'
 
-import { EuiForm } from '@elastic/eui'
 import { TimezoneOption, timezoneOptions } from 'uiSrc/constants'
 import {
   updateUserConfigSettingsAction,

--- a/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/timezone-form/TimezoneForm.tsx
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/components/timezone-form/TimezoneForm.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useFormik } from 'formik'
+
 import { EuiForm } from '@elastic/eui'
 import { TimezoneOption, timezoneOptions } from 'uiSrc/constants'
 import {
@@ -61,11 +62,7 @@ const TimezoneForm = () => {
   }
 
   return (
-    <EuiForm
-      component="form"
-      onSubmit={formik.handleSubmit}
-      data-testid="format-timezone-form"
-    >
+    <form onSubmit={formik.handleSubmit} data-testid="format-timezone-form">
       <div>
         <RiSelect
           style={{ width: 240 }}
@@ -79,7 +76,7 @@ const TimezoneForm = () => {
           data-test-subj="select-timezone"
         />
       </div>
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/settings/components/theme-settings/ThemeSettings.spec.tsx
+++ b/redisinsight/ui/src/pages/settings/components/theme-settings/ThemeSettings.spec.tsx
@@ -2,11 +2,12 @@ import React from 'react'
 import { cloneDeep } from 'lodash'
 import {
   cleanup,
-  fireEvent,
   mockedStore,
   render,
   screen,
+  userEvent,
   waitFor,
+  waitForRedisUiSelectVisible,
 } from 'uiSrc/utils/test-utils'
 import { DEFAULT_THEME, Theme, THEMES } from 'uiSrc/constants'
 import { TelemetryEvent } from 'uiSrc/telemetry'
@@ -49,7 +50,9 @@ describe('ThemeSettings', () => {
     expect(selectedTheme).not.toBeUndefined()
 
     await waitFor(() => {
-      expect(screen.getByText(selectedTheme?.inputDisplay as string)).toBeInTheDocument()
+      expect(
+        screen.getByText(selectedTheme?.inputDisplay as string),
+      ).toBeInTheDocument()
     })
   })
 
@@ -64,15 +67,16 @@ describe('ThemeSettings', () => {
     }
 
     render(<ThemeSettings />, { store })
-
     const dropdownButton = screen.getByTestId('select-theme')
-    fireEvent.click(dropdownButton)
+    await userEvent.click(dropdownButton)
+
+    await waitForRedisUiSelectVisible()
 
     await waitFor(() => {
       expect(screen.getByText('Light Theme')).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByText('Light Theme'))
+    await userEvent.click(screen.getByText('Light Theme'))
 
     expect(updateUserConfigSettingsAction).toHaveBeenCalledWith({
       theme: newTheme,
@@ -97,7 +101,9 @@ describe('ThemeSettings', () => {
     render(<ThemeSettings />, { store })
 
     const dropdownButton = screen.getByTestId('select-theme')
-    fireEvent.click(dropdownButton)
+    await userEvent.click(dropdownButton)
+
+    await waitForRedisUiSelectVisible()
 
     const darkTheme = THEMES.find((theme) => theme.value === Theme.Dark)
 

--- a/redisinsight/ui/src/pages/settings/components/theme-settings/ThemeSettings.tsx
+++ b/redisinsight/ui/src/pages/settings/components/theme-settings/ThemeSettings.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { EuiForm, EuiFormRow, EuiSuperSelect, EuiTitle } from '@elastic/eui'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import {
   updateUserConfigSettingsAction,
@@ -9,6 +8,12 @@ import {
 import { ThemeContext } from 'uiSrc/contexts/themeContext'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { DEFAULT_THEME, THEMES } from 'uiSrc/constants'
+import {
+  defaultValueRender,
+  RiSelect,
+} from 'uiSrc/components/base/forms/select/RiSelect'
+import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { Title } from 'uiSrc/components/base/text'
 
 const ThemeSettings = () => {
   const dispatch = useDispatch()
@@ -44,23 +49,22 @@ const ThemeSettings = () => {
   }
 
   return (
-    <EuiForm component="form">
-      <EuiTitle size="xs">
-        <h4>Color Theme</h4>
-      </EuiTitle>
+    <form>
+      <Title size="XS">Color Theme</Title>
       <Spacer size="m" />
-      <EuiFormRow label="Specifies the color theme to be used in Redis Insight:">
-        <EuiSuperSelect
+      <FormField label="Specifies the color theme to be used in Redis Insight:">
+        <RiSelect
+          valueRender={defaultValueRender}
           options={options}
-          valueOfSelected={selectedTheme}
+          value={selectedTheme}
           onChange={onChange}
           style={{ marginTop: '12px' }}
           data-test-subj="select-theme"
           data-testid="select-theme"
         />
-      </EuiFormRow>
+      </FormField>
       <Spacer size="xl" />
-    </EuiForm>
+    </form>
   )
 }
 

--- a/redisinsight/ui/src/pages/slow-log/components/SlowLogConfig/SlowLogConfig.tsx
+++ b/redisinsight/ui/src/pages/slow-log/components/SlowLogConfig/SlowLogConfig.tsx
@@ -1,4 +1,4 @@
-import { EuiFieldText, EuiForm } from '@elastic/eui'
+import { EuiFieldText } from '@elastic/eui'
 import { toNumber } from 'lodash'
 import React, { ChangeEvent, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
@@ -175,7 +175,7 @@ const SlowLogConfig = ({ closePopover, onRefresh }: Props) => {
       {connectionType === ConnectionType.Cluster && clusterContent()}
       {connectionType !== ConnectionType.Cluster && (
         <>
-          <EuiForm component="form">
+          <form>
             <FormField
               layout="horizontal"
               className={styles.formRow}
@@ -255,7 +255,7 @@ const SlowLogConfig = ({ closePopover, onRefresh }: Props) => {
               </>
             </FormField>
             <Spacer size="m" />
-          </EuiForm>
+          </form>
 
           <Row className={styles.footer}>
             <FlexItem className={styles.helpText}>


### PR DESCRIPTION
This pull request focuses on removing the dependency on the `EuiForm` component from `@elastic/eui` across multiple files and replacing it with standard HTML `<form>` elements. Additionally, it introduces improvements to keyboard key handling by consolidating constants into a single file. Below are the most important changes grouped by theme:

Replace usage of `EuiForm` with plain `form`

`EuiForm` does not provide any additional styling or behavior that we're using, so there is no sense at this time to use dedicated component for this purpose.

In some places an attribbute `role="presentation"` is added to satisfy eslint a11y error.

### Removal of `EuiForm` Component:
* Replaced `EuiForm` with standard `<form>` elements in `ConsentsNotifications`, `ConsentsPrivacy`, and `ConsentsSettings` components, ensuring consistent form handling (`redisinsight/ui/src/components/consents-settings/ConsentsNotifications/ConsentsNotifications.tsx`, `redisinsight/ui/src/components/consents-settings/ConsentsPrivacy/ConsentsPrivacy.tsx`, `redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx`). [[1]](diffhunk://#diff-b4e5be160732de1eae47b0f9f3f1b2213d8c4f211728c59b519ef3e89c854ddfL92-R91) [[2]](diffhunk://#diff-c95646cd5c6a72a036d86221d1911a52d09c78b2b93b1bb23556dc796473ba1fL82-R81) [[3]](diffhunk://#diff-6e9499a5138f63234f2e2d232b6a3150f2f326d1860589e37ee9f126772b9c01L213-R212)
* Updated `InlineItemEditor` and `ChatForm` components to use `<form>` instead of `EuiForm`, simplifying the structure and removing unused props (`redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx`, `redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/shared/chat-form/ChatForm.tsx`). [[1]](diffhunk://#diff-1db2724fbf39ca7e7b310a838680e5fa6409ecb3432b81999f4ccd47ca337c14L202-R201) [[2]](diffhunk://#diff-acddb77104a35b6abbf6ebb38cdc0a23588dcb0fde7b90ada3fcd5ef1cfcf4f4L116-R122)
* Removed the `EuiForm` import from additional files where it was no longer used (`redisinsight/ui/src/components/multi-search/MultiSearch.tsx`, `redisinsight/ui/src/pages/browser/components/add-key/AddKeyHash/AddKeyHash.tsx`). [[1]](diffhunk://#diff-f47d91b3b270978f0a3a0dd5a84c252bd6147248b80ab091398c62957220fdb0L3-R5) [[2]](diffhunk://#diff-e9eb47713ca242b4b74377b6fe5365281563f1ac88d87bddbd619a409614ad30L9-R9)

### Keyboard Key Handling Improvements:
* Consolidated keyboard key constants into `uiSrc/constants/keys.ts` for better maintainability and consistency across the codebase. Updated imports in various components to use the new constants (`redisinsight/ui/src/constants/keys.ts`, `redisinsight/ui/src/components/table-column-search-trigger/TableColumnSearchTrigger.tsx`, `redisinsight/ui/src/components/side-panels/SidePanels.tsx`). [[1]](diffhunk://#diff-5d48ef610188c9249859bd47672c7c6ca54aaf04c83adb1aa4e4ebea2ddf1d8cR196-R232) [[2]](diffhunk://#diff-45978548c80999703e5ad89790341ece367e173cf4f42b3f311cd0fc7902c15dL3-R4) [[3]](diffhunk://#diff-c35daf9f48459067e29561c89c312575d5d6e6a4c8728a32dc7a2edfe1697070L3-R6)

### Test Updates:
* Updated test assertions in `ChatForm.spec.tsx` to use `toHaveBeenCalledWith` instead of `toBeCalledWith` for improved readability and alignment with best practices (`redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/shared/chat-form/ChatForm.spec.tsx`). [[1]](diffhunk://#diff-923c87fc30b96520e160beb351c235186a7b7f75b49ba04149566f91f4d29e7cL31-R31) [[2]](diffhunk://#diff-923c87fc30b96520e160beb351c235186a7b7f75b49ba04149566f91f4d29e7cL48-R48)

These changes collectively enhance the maintainability and readability of the codebase while reducing dependencies on external libraries.