### PR TITLE
RI-7244 -Edit-and-remove-buttons-are-not-aligned

### DIFF
--- a/redisinsight/ui/src/components/base/forms/buttons/EmptyButton.tsx
+++ b/redisinsight/ui/src/components/base/forms/buttons/EmptyButton.tsx
@@ -2,12 +2,15 @@ import React from 'react'
 import { TextButton } from '@redis-ui/components'
 import { ButtonIcon } from 'uiSrc/components/base/forms/buttons/Button'
 import { IconType } from 'uiSrc/components/base/icons'
+import { Row } from '../../layout/flex'
+import { justifyValues } from '../../layout/flex/flex.styles'
 
 export type ButtonProps = React.ComponentProps<typeof TextButton> & {
   icon?: IconType
   iconSide?: 'left' | 'right'
   loading?: boolean
   size?: 'small' | 'large' | 'medium'
+  justify?: (typeof justifyValues)[number]
 }
 export const EmptyButton = ({
   children,
@@ -15,23 +18,28 @@ export const EmptyButton = ({
   iconSide = 'left',
   loading,
   size = 'small',
+  justify = 'center',
   ...rest
 }: ButtonProps) => (
   <TextButton {...rest}>
-    <ButtonIcon
-      buttonSide="left"
-      icon={icon}
-      iconSide={iconSide}
-      loading={loading}
-      size={size}
-    />
-    {children}
-    <ButtonIcon
-      buttonSide="right"
-      icon={icon}
-      iconSide={iconSide}
-      loading={loading}
-      size={size}
-    />
+    <Row
+      justify={justify}
+    >  
+      <ButtonIcon
+        buttonSide="left"
+        icon={icon}
+        iconSide={iconSide}
+        loading={loading}
+        size={size}
+      />
+      {children}
+      <ButtonIcon
+        buttonSide="right"
+        icon={icon}
+        iconSide={iconSide}
+        loading={loading}
+        size={size}
+      />
+    </Row>
   </TextButton>
 )

--- a/redisinsight/ui/src/pages/home/components/database-list-component/DatabasesListWrapper.tsx
+++ b/redisinsight/ui/src/pages/home/components/database-list-component/DatabasesListWrapper.tsx
@@ -619,6 +619,7 @@ const DatabasesListWrapper = (props: Props) => {
                   <div className="controlsPopoverContent">
                     <div>
                       <EmptyButton
+                        justify="start"
                         icon={EditIcon}
                         className="editInstanceBtn"
                         aria-label="Edit instance"


### PR DESCRIPTION
Adding justify to the text button allows us to change the default center alignment going from
<img width="486" height="502" alt="image" src="https://github.com/user-attachments/assets/9083343f-b6f3-4ba1-aa00-943dc55759c7" />

to
<img width="276" height="140" alt="image" src="https://github.com/user-attachments/assets/c792b85f-0a89-4458-ae0a-3c94aabfff49" />
which is consistent with the existing UI and I am guessing we'll need it for other places as well