### PR TITLE
RI-7252 - RDI-empty-screen-is-missaligned

### DIFF
--- a/redisinsight/ui/src/pages/rdi/home/RdiPage.tsx
+++ b/redisinsight/ui/src/pages/rdi/home/RdiPage.tsx
@@ -122,11 +122,11 @@ const RdiPage = () => {
 
   const InstanceList = () =>
     !data.length ? (
-      <Card>
+      <>
         {!loading && !loadingChanging && (
           <EmptyMessage onAddInstanceClick={handleOpenConnectionForm} />
         )}
-      </Card>
+      </>
     ) : (
       <RIResizeObserver onResize={onResize}>
         {(resizeRef) => (

--- a/redisinsight/ui/src/pages/rdi/home/empty-message/styles.module.scss
+++ b/redisinsight/ui/src/pages/rdi/home/empty-message/styles.module.scss
@@ -3,7 +3,7 @@
   align-items: center;
   flex-direction: column;
 
-  max-width: 624px;
+  width: 100%;
 }
 
 .title {


### PR DESCRIPTION
Fixed the RDI empty screen from this
<img width="1770" height="1301" alt="image" src="https://github.com/user-attachments/assets/022c5157-d00c-4ed5-9199-6558d5cb44ec" />
to this 
<img width="1770" height="1301" alt="image" src="https://github.com/user-attachments/assets/d4faa5c4-4974-4977-b81f-979546cbc42d" />
which is very close to what we have in prod right now
<img width="2111" height="1339" alt="image" src="https://github.com/user-attachments/assets/e0b4d20f-da0d-4423-8498-fc41a4bafd90" />
