### PR TITLE
RI-7217 allow to deplot rdi pipeline with validation errors

### DIFF
--- a/redisinsight/ui/src/components/base/icons/Icon.tsx
+++ b/redisinsight/ui/src/components/base/icons/Icon.tsx
@@ -12,6 +12,7 @@ type BaseIconProps = Omit<MonochromeIconProps, 'color' | 'size'> & {
     | (string & {})
   size?: IconSizeType | null
   isSvg?: boolean
+  style?: React.CSSProperties
 }
 
 const sizesMap = {
@@ -43,6 +44,7 @@ export const Icon = ({
   color = 'primary600',
   size,
   className,
+  style = {},
   ...rest
 }: BaseIconProps) => {
   let sizeValue: number | string | undefined
@@ -73,7 +75,13 @@ export const Icon = ({
     ? svgProps
     : { color, customColor, size, customSize, ...rest }
 
-  return <IconComponent {...props} className={cx(className, 'RI-Icon')} />
+  return (
+    <IconComponent
+      {...props}
+      style={{ ...style, verticalAlign: 'middle' }}
+      className={cx(className, 'RI-Icon')}
+    />
+  )
 }
 
 export type IconProps = Omit<BaseIconProps, 'icon'>

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/deploy-pipeline-button/DeployPipelineButton.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/deploy-pipeline-button/DeployPipelineButton.spec.tsx
@@ -8,6 +8,7 @@ import {
   render,
   screen,
 } from 'uiSrc/utils/test-utils'
+import { rdiPipelineSelector } from 'uiSrc/slices/rdi/pipeline'
 import DeployPipelineButton, { Props } from './DeployPipelineButton'
 
 const mockedProps: Props = {
@@ -25,6 +26,7 @@ jest.mock('uiSrc/slices/rdi/pipeline', () => ({
   rdiPipelineSelector: jest.fn().mockReturnValue({
     loading: false,
     config: 'value',
+    isPipelineValid: true,
     jobs: [
       { name: 'job1', value: '1' },
       { name: 'job2', value: '2' },
@@ -88,7 +90,7 @@ describe('DeployPipelineButton', () => {
     })
   })
 
-  it('should open confirmation popover', () => {
+  it('should open confirmation popover with default message', () => {
     render(<DeployPipelineButton {...mockedProps} />)
 
     expect(screen.queryByTestId('deploy-confirm-btn')).not.toBeInTheDocument()
@@ -96,5 +98,35 @@ describe('DeployPipelineButton', () => {
     fireEvent.click(screen.getByTestId('deploy-rdi-pipeline'))
 
     expect(screen.queryByTestId('deploy-confirm-btn')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Are you sure you want to deploy the pipeline?'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'Your RDI pipeline contains errors. Are you sure you want to continue?',
+      ),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should open confirmation popover with warning message due to validation errors', () => {
+    ;(rdiPipelineSelector as jest.Mock).mockImplementation(() => ({
+      isPipelineValid: false,
+    }))
+
+    render(<DeployPipelineButton {...mockedProps} />)
+
+    expect(screen.queryByTestId('deploy-confirm-btn')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('deploy-rdi-pipeline'))
+
+    expect(screen.queryByTestId('deploy-confirm-btn')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Are you sure you want to deploy the pipeline?'),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'Your RDI pipeline contains errors. Are you sure you want to continue?',
+      ),
+    ).toBeInTheDocument()
   })
 })

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/deploy-pipeline-button/DeployPipelineButton.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/deploy-pipeline-button/DeployPipelineButton.tsx
@@ -14,7 +14,7 @@ import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { createAxiosError, pipelineToJson } from 'uiSrc/utils'
 import { addErrorNotification } from 'uiSrc/slices/app/notifications'
 import { rdiErrorMessages } from 'uiSrc/pages/rdi/constants'
-import { Text } from 'uiSrc/components/base/text'
+import { ColorText, Text } from 'uiSrc/components/base/text'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import { OutsideClickDetector } from 'uiSrc/components/base/utils'
@@ -128,14 +128,19 @@ const DeployPipelineButton = ({ loading, disabled, onReset }: Props) => {
           </PrimaryButton>
         }
       >
-        {isPipelineValid ? (
-          <Title size="XS">Are you sure you want to deploy the pipeline?</Title>
-        ) : (
-          <Text color="danger" size="M">
-           <RiIcon type="InfoIcon" size="M" color="danger500" />
-           Your RDI pipeline contains errors. Are you sure you want to continue?
-          </Text>
-        )}
+        <Title size="XS">
+          {isPipelineValid ? (
+            <ColorText color="default">
+              Are you sure you want to deploy the pipeline?
+            </ColorText>
+          ) : (
+            <ColorText color="warning">
+              <RiIcon type="ToastDangerIcon" size="L" color="attention500" />
+              Your RDI pipeline contains errors. Are you sure you want to
+              continue?
+            </ColorText>
+          )}
+        </Title>
         <Spacer size="s" />
         <Text size="s">
           When deployed, this local configuration will overwrite any existing

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/deploy-pipeline-button/DeployPipelineButton.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/buttons/deploy-pipeline-button/DeployPipelineButton.tsx
@@ -36,7 +36,8 @@ const DeployPipelineButton = ({ loading, disabled, onReset }: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
   const [resetPipeline, setResetPipeline] = useState(false)
 
-  const { config, jobs, resetChecked } = useSelector(rdiPipelineSelector)
+  const { config, jobs, resetChecked, isPipelineValid } =
+    useSelector(rdiPipelineSelector)
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
   const dispatch = useDispatch()
@@ -127,7 +128,14 @@ const DeployPipelineButton = ({ loading, disabled, onReset }: Props) => {
           </PrimaryButton>
         }
       >
-        <Title size="XS">Are you sure you want to deploy the pipeline?</Title>
+        {isPipelineValid ? (
+          <Title size="XS">Are you sure you want to deploy the pipeline?</Title>
+        ) : (
+          <Text color="danger" size="M">
+           <RiIcon type="InfoIcon" size="M" color="danger500" />
+           Your RDI pipeline contains errors. Are you sure you want to continue?
+          </Text>
+        )}
         <Spacer size="s" />
         <Text size="s">
           When deployed, this local configuration will overwrite any existing

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/pipeline-actions/PipelineActions.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/pipeline-actions/PipelineActions.spec.tsx
@@ -168,7 +168,7 @@ describe('PipelineActions', () => {
     )
   })
 
-  it('should dispatch validation errors if validation fails', () => {
+  it('should dispatch validation errors if validation fails but still deploy button should be enabled', () => {
     ;(validatePipeline as jest.Mock).mockReturnValue({
       result: false,
       configValidationErrors: ['Missing field'],
@@ -199,6 +199,8 @@ describe('PipelineActions', () => {
         }),
       ]),
     )
+
+    expect(screen.queryByTestId('deploy-rdi-pipeline')).not.toBeDisabled()
   })
 
   describe('TelemetryEvent', () => {

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/pipeline-actions/PipelineActions.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/pipeline-actions/PipelineActions.tsx
@@ -22,7 +22,6 @@ import {
   PipelineStatus,
 } from 'uiSrc/slices/interfaces'
 
-import { RiTooltip } from 'uiSrc/components'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import DeployPipelineButton from '../buttons/deploy-pipeline-button'
 import ResetPipelineButton from '../buttons/reset-pipeline-button'

--- a/redisinsight/ui/src/pages/rdi/instance/components/header/components/pipeline-actions/PipelineActions.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/components/header/components/pipeline-actions/PipelineActions.tsx
@@ -38,7 +38,6 @@ export interface Props {
 const PipelineActions = ({ collectorStatus, pipelineStatus }: Props) => {
   const {
     loading: deployLoading,
-    isPipelineValid,
     schema,
     config,
     jobs,
@@ -141,7 +140,6 @@ const PipelineActions = ({ collectorStatus, pipelineStatus }: Props) => {
   const isLoadingBtn = (actionBtn: PipelineAction) =>
     action === actionBtn && actionLoading
   const disabled = deployLoading || actionLoading
-  const isDeployButtonDisabled = disabled || !isPipelineValid
 
   return (
     <Row gap="m" justify="end" align="center">
@@ -168,21 +166,11 @@ const PipelineActions = ({ collectorStatus, pipelineStatus }: Props) => {
         )}
       </FlexItem>
       <FlexItem>
-        <RiTooltip
-          content={
-            isPipelineValid
-              ? ''
-              : 'Please fix the validation errors before deploying'
-          }
-          position="left"
-          anchorClassName="flex-row"
-        >
-          <DeployPipelineButton
-            loading={deployLoading}
-            disabled={isDeployButtonDisabled}
-            onReset={resetPipeline}
-          />
-        </RiTooltip>
+        <DeployPipelineButton
+          loading={deployLoading}
+          disabled={disabled}
+          onReset={resetPipeline}
+        />
       </FlexItem>
       <FlexItem style={{ margin: 0 }}>
         <RdiConfigFileActionMenu />

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-tree/JobsTree.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-tree/JobsTree.tsx
@@ -1,6 +1,4 @@
-import {
-  EuiAccordion,
-} from '@elastic/eui'
+import { EuiAccordion } from '@elastic/eui'
 import cx from 'classnames'
 import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
@@ -30,6 +28,7 @@ import {
 } from 'uiSrc/components/base/forms/buttons'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { Loader } from 'uiSrc/components/base/display'
+import ValidationErrorsList from 'uiSrc/pages/rdi/pipeline-management/components/validation-errors-list/ValidationErrorsList'
 import styles from './styles.module.scss'
 
 export interface IProps {
@@ -159,7 +158,11 @@ const JobsTree = (props: IProps) => {
   const handleToggleAccordion = (isOpen: boolean) =>
     setAccordionState(isOpen ? 'open' : 'closed')
 
-  const jobName = (name: string, isValid: boolean = true, validationErrors: string[] = []) => (
+  const jobName = (
+    name: string,
+    isValid: boolean = true,
+    validationErrors: string[] = [],
+  ) => (
     <>
       <FlexItem
         grow
@@ -173,15 +176,7 @@ const JobsTree = (props: IProps) => {
           <RiTooltip
             position="right"
             content={
-              validationErrors?.length && (
-                <Text size="s">
-                  <ul>
-                    {validationErrors.map((err) => (
-                      <li>{err}</li>
-                    ))}
-                  </ul>
-                </Text>
-              )
+              <ValidationErrorsList validationErrors={validationErrors} />
             }
           >
             <RiIcon
@@ -319,7 +314,7 @@ const JobsTree = (props: IProps) => {
           </FlexItem>
           {currentJobName === name
             ? jobNameEditor(name, idx)
-            : jobName(name, isJobValid(name), getJobValidionErrors(name) )}
+            : jobName(name, isJobValid(name), getJobValidionErrors(name))}
         </Row>
       </Row>
     ))

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-tree/JobsTree.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-tree/JobsTree.tsx
@@ -159,7 +159,7 @@ const JobsTree = (props: IProps) => {
   const handleToggleAccordion = (isOpen: boolean) =>
     setAccordionState(isOpen ? 'open' : 'closed')
 
-  const jobName = (name: string, isValid: boolean = true) => (
+  const jobName = (name: string, isValid: boolean = true, validationErrors: string[] = []) => (
     <>
       <FlexItem
         grow
@@ -170,11 +170,27 @@ const JobsTree = (props: IProps) => {
         {name}
 
         {!isValid && (
-          <RiIcon
-            type="IndicatorXIcon"
-            className="rdi-pipeline-nav__error"
-            data-testid="rdi-pipeline-nav__error"
-          />
+          <RiTooltip
+            position="right"
+            content={
+              validationErrors?.length && (
+                <Text size="s">
+                  <ul>
+                    {validationErrors.map((err) => (
+                      <li>{err}</li>
+                    ))}
+                  </ul>
+                </Text>
+              )
+            }
+          >
+            <RiIcon
+              type="InfoIcon"
+              className="rdi-pipeline-nav__error"
+              data-testid="rdi-pipeline-nav__error"
+              color="danger500"
+            />
+          </RiTooltip>
         )}
       </FlexItem>
       <FlexItem
@@ -263,6 +279,9 @@ const JobsTree = (props: IProps) => {
       ? jobsValidationErrors[jobName].length === 0
       : true
 
+  const getJobValidionErrors = (jobName: string) =>
+    jobsValidationErrors[jobName] || []
+
   const renderJobsList = (jobs: IRdiPipelineJob[]) =>
     jobs.map(({ name }, idx) => (
       <Row
@@ -300,7 +319,7 @@ const JobsTree = (props: IProps) => {
           </FlexItem>
           {currentJobName === name
             ? jobNameEditor(name, idx)
-            : jobName(name, isJobValid(name))}
+            : jobName(name, isJobValid(name), getJobValidionErrors(name) )}
         </Row>
       </Row>
     ))

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-tree/styles.module.scss
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/jobs-tree/styles.module.scss
@@ -2,6 +2,7 @@
   .navItem {
     cursor: pointer;
     white-space: pre !important;
+    flex-direction: row !important;
 
     &:hover {
       text-decoration: underline;

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/Navigation.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/navigation/Navigation.tsx
@@ -71,6 +71,7 @@ const Navigation = () => {
           data-testid={`rdi-pipeline-tab-${RdiPipelineTabs.Config}`}
           isLoading={loading}
           isValid={configValidationErrors.length === 0}
+          validationErrors={configValidationErrors}
         >
           <div className={styles.dotWrapper}>
             {!!changes.config && (

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/tab/Tab.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/tab/Tab.spec.tsx
@@ -92,4 +92,84 @@ describe('Tab', () => {
 
     expect(screen.getByTestId('tab-child')).toBeInTheDocument()
   })
+
+  it('should display validation errors in tooltip when isValid is false and validationErrors are provided', () => {
+    const validationErrors = [
+      'Missing required field: name',
+      'Invalid data type for age'
+    ]
+
+    render(
+      <Tab
+        title="Invalid Config"
+        isSelected={false}
+        fileName="config.yaml"
+        isValid={false}
+        validationErrors={validationErrors}
+      />
+    )
+
+    expect(screen.getByTestId('rdi-nav-config-error')).toBeInTheDocument()
+
+    const errorIcon = screen.getByTestId('rdi-nav-config-error')
+    expect(errorIcon).toBeInTheDocument()
+  })
+
+  it('should not display validation errors when isValid is true even if validationErrors are provided', () => {
+    const validationErrors = [
+      'Some validation error'
+    ]
+
+    render(
+      <Tab
+        title="Valid Config"
+        isSelected={false}
+        fileName="config.yaml"
+        isValid
+        validationErrors={validationErrors}
+      />
+    )
+
+    expect(screen.queryByTestId('rdi-nav-config-error')).not.toBeInTheDocument()
+  })
+
+  it('should display error icon even when validationErrors is empty but isValid is false', () => {
+    render(
+      <Tab
+        title="Invalid Config"
+        isSelected={false}
+        fileName="config.yaml"
+        isValid={false}
+        validationErrors={[]}
+      />
+    )
+
+    expect(screen.getByTestId('rdi-nav-config-error')).toBeInTheDocument()
+  })
+
+  it('should handle validationErrors prop correctly when not provided', () => {
+    render(
+      <Tab
+        title="Invalid Config"
+        isSelected={false}
+        fileName="config.yaml"
+        isValid={false}
+      />
+    )
+
+    expect(screen.getByTestId('rdi-nav-config-error')).toBeInTheDocument()
+  })
+
+  it('should not show error icon when fileName is not provided even if isValid is false', () => {
+    render(
+      <Tab
+        title="Invalid Config"
+        isSelected={false}
+        isValid={false}
+        validationErrors={['Some error']}
+      />
+    )
+
+    expect(screen.queryByTestId('rdi-nav-config-error')).not.toBeInTheDocument()
+  })
 })

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/tab/Tab.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/tab/Tab.tsx
@@ -4,6 +4,7 @@ import { Text } from 'uiSrc/components/base/text'
 import { Loader } from 'uiSrc/components/base/display'
 
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
+import { RiTooltip } from 'uiSrc/components'
 import styles from './styles.module.scss'
 
 export interface IProps {
@@ -15,6 +16,7 @@ export interface IProps {
   testID?: string
   isLoading?: boolean
   isValid?: boolean
+  validationErrors?: string[]
 }
 
 const Tab = (props: IProps) => {
@@ -27,6 +29,7 @@ const Tab = (props: IProps) => {
     className,
     isLoading = false,
     isValid = true,
+    validationErrors = [],
   } = props
 
   return (
@@ -45,12 +48,27 @@ const Tab = (props: IProps) => {
           </Text>
 
           {!isValid && (
-            <RiIcon
-              type="InfoIcon"
-              className="rdi-pipeline-nav__error"
-              data-testid="rdi-nav-config-error"
-              color="danger500"
-            />
+            <RiTooltip
+              position="right"
+              content={
+                validationErrors?.length && (
+                  <Text size="s">
+                    <ul>
+                      {validationErrors.map((err) => (
+                        <li>{err}</li>
+                      ))}
+                    </ul>
+                  </Text>
+                )
+              }
+            >
+              <RiIcon
+                type="InfoIcon"
+                className="rdi-pipeline-nav__error"
+                data-testid="rdi-nav-config-error"
+                color="danger500"
+              />
+            </RiTooltip>
           )}
 
           {isLoading && (

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/tab/Tab.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/tab/Tab.tsx
@@ -5,6 +5,7 @@ import { Loader } from 'uiSrc/components/base/display'
 
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { RiTooltip } from 'uiSrc/components'
+import ValidationErrorsList from 'uiSrc/pages/rdi/pipeline-management/components/validation-errors-list/ValidationErrorsList'
 import styles from './styles.module.scss'
 
 export interface IProps {
@@ -51,15 +52,7 @@ const Tab = (props: IProps) => {
             <RiTooltip
               position="right"
               content={
-                validationErrors?.length && (
-                  <Text size="s">
-                    <ul>
-                      {validationErrors.map((err) => (
-                        <li>{err}</li>
-                      ))}
-                    </ul>
-                  </Text>
-                )
+                <ValidationErrorsList validationErrors={validationErrors} />
               }
             >
               <RiIcon

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/validation-errors-list/ValidationErrorsList.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/validation-errors-list/ValidationErrorsList.spec.tsx
@@ -1,0 +1,95 @@
+
+import React from 'react'
+import { render, screen } from 'uiSrc/utils/test-utils'
+
+import ValidationErrorsList, { Props } from './ValidationErrorsList'
+
+describe('ValidationErrorsList', () => {
+  it('should render', () => {
+    const props: Props = {
+      validationErrors: []
+    }
+    expect(render(<ValidationErrorsList {...props} />)).toBeTruthy()
+  })
+
+  it('should not render anything when validationErrors is undefined', () => {
+    const props: Props = {
+      validationErrors: undefined as any
+    }
+    const { container } = render(<ValidationErrorsList {...props} />)
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('should render a single validation error', () => {
+    const props: Props = {
+      validationErrors: ['Invalid configuration format']
+    }
+    render(<ValidationErrorsList {...props} />)
+
+    expect(screen.getByText('Invalid configuration format')).toBeInTheDocument()
+    expect(screen.getByRole('list')).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(1)
+  })
+
+  it('should render multiple validation errors', () => {
+    const props: Props = {
+      validationErrors: [
+        'Missing required field: name',
+        'Invalid data type for age',
+        'Email format is incorrect'
+      ]
+    }
+    render(<ValidationErrorsList {...props} />)
+
+    expect(screen.getByText('Missing required field: name')).toBeInTheDocument()
+    expect(screen.getByText('Invalid data type for age')).toBeInTheDocument()
+    expect(screen.getByText('Email format is incorrect')).toBeInTheDocument()
+    expect(screen.getByRole('list')).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(3)
+  })
+
+  it('should render validation errors as list items within a Text component', () => {
+    const props: Props = {
+      validationErrors: ['Error message 1', 'Error message 2']
+    }
+    render(<ValidationErrorsList {...props} />)
+
+    const list = screen.getByRole('list')
+    expect(list.tagName).toBe('UL')
+    expect(list.parentElement?.tagName).toBe('P') // Text component renders as p tag
+
+    const listItems = screen.getAllByRole('listitem')
+    expect(listItems).toHaveLength(2)
+    expect(listItems[0]).toHaveTextContent('Error message 1')
+    expect(listItems[1]).toHaveTextContent('Error message 2')
+  })
+
+  it('should handle special characters and HTML in error messages', () => {
+    const props: Props = {
+      validationErrors: [
+        'Error with <script>alert("xss")</script>',
+        'Error with & special characters',
+        'Error with "quotes" and \'apostrophes\''
+      ]
+    }
+    render(<ValidationErrorsList {...props} />)
+
+    expect(screen.getByText('Error with <script>alert("xss")</script>')).toBeInTheDocument()
+    expect(screen.getByText('Error with & special characters')).toBeInTheDocument()
+    expect(screen.getByText('Error with "quotes" and \'apostrophes\'')).toBeInTheDocument()
+  })
+
+  it('should handle empty string errors', () => {
+    const props: Props = {
+      validationErrors: ['', 'Valid error message', '']
+    }
+    render(<ValidationErrorsList {...props} />)
+
+    const listItems = screen.getAllByRole('listitem')
+    expect(listItems).toHaveLength(3)
+    expect(listItems[0]).toHaveTextContent('')
+    expect(listItems[1]).toHaveTextContent('Valid error message')
+    expect(listItems[2]).toHaveTextContent('')
+  })
+})

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/validation-errors-list/ValidationErrorsList.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/validation-errors-list/ValidationErrorsList.spec.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react'
 import { render, screen } from 'uiSrc/utils/test-utils'
 
@@ -57,7 +56,7 @@ describe('ValidationErrorsList', () => {
 
     const list = screen.getByRole('list')
     expect(list.tagName).toBe('UL')
-    expect(list.parentElement?.tagName).toBe('P') // Text component renders as p tag
+    expect(list.parentElement?.tagName).toBe('DIV')
 
     const listItems = screen.getAllByRole('listitem')
     expect(listItems).toHaveLength(2)

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/validation-errors-list/ValidationErrorsList.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/validation-errors-list/ValidationErrorsList.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Text } from 'uiSrc/components/base/text'
 
 export interface Props {
   validationErrors: string[]
@@ -8,19 +7,17 @@ export interface Props {
 const ValidationErrorsList = (props: Props) => {
   const { validationErrors } = props
 
-  return (
-    <>
-      {validationErrors?.length && (
-        <Text>
-          <ul>
-            {validationErrors.map((err, index) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <li key={index}>{err}</li>
-            ))}
-          </ul>
-        </Text>
-      )}
-    </>
+  if(!validationErrors?.length) {
+    return null
+  }
+
+  return  (
+    <ul>
+      {validationErrors.map((err, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <li key={index}>{err}</li>
+      ))}
+    </ul>
   )
 }
 

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/components/validation-errors-list/ValidationErrorsList.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/components/validation-errors-list/ValidationErrorsList.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Text } from 'uiSrc/components/base/text'
+
+export interface Props {
+  validationErrors: string[]
+}
+
+const ValidationErrorsList = (props: Props) => {
+  const { validationErrors } = props
+
+  return (
+    <>
+      {validationErrors?.length && (
+        <Text>
+          <ul>
+            {validationErrors.map((err, index) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <li key={index}>{err}</li>
+            ))}
+          </ul>
+        </Text>
+      )}
+    </>
+  )
+}
+
+export default ValidationErrorsList


### PR DESCRIPTION
Show validation errors in a tooltips and do not block deploy button in case of validation errors
<img width="644" height="574" alt="Screenshot 2025-08-06 at 09 40 38" src="https://github.com/user-attachments/assets/2f57919e-c165-4347-bf6b-699791ce3d69" />
<img width="602" height="503" alt="Screenshot 2025-08-06 at 09 41 01" src="https://github.com/user-attachments/assets/17f8a761-67ab-4d58-a7d9-c1dc3c507219" />
<img width="490" height="314" alt="Screenshot 2025-08-06 at 09 41 06" src="https://github.com/user-attachments/assets/24449aa9-0ab7-489c-b43f-77b1840f5426" />
