### PR TITLE
RI-7289: adjust Create Index wizard spacing to match style of Workbench/Browser

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/query/HeaderActions.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/query/HeaderActions.styles.ts
@@ -6,10 +6,13 @@ export const StyledHeaderAction = styled(FlexGroup)`
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  margin-bottom: ${({ theme }) => theme.core.space.space200};
+  gap: ${({ theme }) => theme.core.space.space100};
+  margin-bottom: ${({ theme }) => theme.core.space.space100};
 `
 
 export const StyledTextButton = styled(TextButton)`
+  padding: 0px;
+  height: auto;
   color: ${({ theme }) => theme.color.blue400};
   &:hover {
     color: ${({ theme }) => theme.color.blue500};

--- a/redisinsight/ui/src/pages/vector-search/styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/styles.ts
@@ -4,7 +4,8 @@ import { FlexGroup, FlexItem } from 'uiSrc/components/base/layout/flex'
 export const VectorSearchPageWrapper = styled.div`
   background-color: ${({ theme }) =>
     theme.semantic?.color.background.neutral100};
-  padding: ${({ theme }) => theme.core?.space.space200};
+  padding-left: ${({ theme }) => theme.core?.space.space200};
+  padding-right: ${({ theme }) => theme.core?.space.space200};
 
   display: flex;
   height: 100%;


### PR DESCRIPTION
## Description

| Before    | After |
| -------- | ------- |
| <img width="1085" height="541" alt="Screenshot 2025-08-07 at 14 13 04" src="https://github.com/user-attachments/assets/041b83a0-3293-4e5a-ba6f-f39f53a12037" /> | <img width="1076" height="500" alt="Screenshot 2025-08-07 at 14 11 10" src="https://github.com/user-attachments/assets/d8a3114e-0546-439a-9b50-fd2764377e45" /> |
| <img width="1076" height="520" alt="Screenshot 2025-08-07 at 14 13 13" src="https://github.com/user-attachments/assets/32e9db4d-094d-44e9-8617-49e8e12a8c90" /> | <img width="1077" height="428" alt="Screenshot 2025-08-07 at 14 11 27" src="https://github.com/user-attachments/assets/4c5a833f-9270-4b4e-be2d-c0033994b28a" /> |
