### PR TITLE
RI-7266: add formatter field to telemetry events

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/KeyDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/KeyDetails.spec.tsx
@@ -19,6 +19,7 @@ import { apiService } from 'uiSrc/services'
 import { INSTANCE_ID_MOCK } from 'uiSrc/mocks/handlers/instances/instancesHandlers'
 import { MOCK_TRUNCATED_BUFFER_VALUE } from 'uiSrc/mocks/data/bigString'
 import KeyDetails, { Props as KeyDetailsProps } from './KeyDetails'
+import { KeyValueFormat } from 'uiSrc/constants'
 
 jest.mock('uiSrc/telemetry', () => ({
   ...jest.requireActual('uiSrc/telemetry'),
@@ -120,6 +121,7 @@ describe('KeyDetails', () => {
         databaseId: INSTANCE_ID_MOCK,
         length: 1,
         keyType: 'hash',
+        formatter: KeyValueFormat.Unicode,
       },
     })
   })

--- a/redisinsight/ui/src/pages/browser/modules/key-details/KeyDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/KeyDetails.tsx
@@ -43,7 +43,7 @@ const KeyDetails = (props: Props) => {
 
   const { instanceId } = useParams<{ instanceId: string }>()
   const { viewType } = useSelector(keysSelector)
-  const { loading, error = '', data } = useSelector(selectedKeySelector)
+  const { loading, error = '', data, viewFormat } = useSelector(selectedKeySelector)
   const isKeySelected = !isNull(useSelector(selectedKeyDataSelector))
   const { type: keyType } = useSelector(selectedKeyDataSelector) ?? {
     type: KeyTypes.String,
@@ -73,6 +73,7 @@ const KeyDetails = (props: Props) => {
             keyType: data.type,
             databaseId: instanceId,
             length: data.length,
+            formatter: viewFormat,
           },
         })
       }),


### PR DESCRIPTION
Add the “Formatter” parameter to the following telemetry events:
1. TREE_VIEW_KEY_VALUE_VIEWED
2. BROWSER_KEY_VALUE_VIEWED