### PR TITLE
RI-7282 - Inline editting of the TTL for hashes has the buttons not aligned

### DIFF
--- a/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.styles.tsx
+++ b/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.styles.tsx
@@ -150,7 +150,7 @@ export const ActionsContainer = styled(Row)<ActionsContainerProps>`
   width: ${({ $width }) => $width || '80px'};
   height: ${({ $height }) => $height || '33px'};
   padding: ${({ theme }: { theme: Theme }) => theme.core.space.space050};
-
+  align-items: center;
   z-index: 3;
   ${({ $position }) => positions[$position || 'inside']}
   ${({ $design }) => designs[$design || 'default']}

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/hash-details-table/HashDetailsTable.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/hash-details-table/HashDetailsTable.tsx
@@ -575,6 +575,7 @@ const HashDetailsTable = (props: Props) => {
             validation={validateTTLNumber}
             isEditDisabled={isTruncatedFieldName}
             editToolTipContent={editTooltipContent}
+            
           >
             <div className="innerCellAsCell">
               {expire === -1 ? (

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/styles.module.scss
@@ -118,7 +118,6 @@
 }
 
 .row {
-  min-height: 25px;
   position: relative;
   display: flex;
   align-items: center;
@@ -145,10 +144,6 @@
 
   > div, span, button {
     z-index: 1;
-  }
-
-  div {
-    min-height: 25px;
   }
 }
 


### PR DESCRIPTION
Turned out that a simple align-items: center can solve a lot of issues.

Removed some obsolete styles from the json inline editing that were interfering with this fix (plus that general styling of divs is a terrible practice)