### PR TITLE
RI-7241: Fix Force Standalone Connection checkbox alignment

### DIFF
--- a/redisinsight/ui/src/pages/home/components/form/ForceStandalone.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/ForceStandalone.tsx
@@ -14,7 +14,7 @@ export interface Props {
 }
 
 const ForceStandaloneLabel = () => (
-  <p>
+  <>
     <span>Force Standalone Connection</span>
     <RiTooltip
       className="homePage_tooltip"
@@ -34,7 +34,7 @@ const ForceStandaloneLabel = () => (
         }}
       />
     </RiTooltip>
-  </p>
+  </>
 )
 const ForceStandalone = (props: Props) => {
   const { formik } = props


### PR DESCRIPTION
### Remove the paragraph tag around the Force Standalone Connection checkbox label, which was causing unwanted styling issues and making the checkbox appear misaligned.

Before:
<img width="255" height="92" alt="image" src="https://github.com/user-attachments/assets/7d256e0e-26ce-4261-b816-6396c3457bf7" />

After:
<img width="255" height="92" alt="image" src="https://github.com/user-attachments/assets/1856222d-0bfc-48aa-aef3-5b93d4c89d71" />
