### PR TITLE
RI-7242: Change the tooltip title size from S to XS

### DIFF
--- a/redisinsight/ui/src/components/base/tooltip/HoverContent.tsx
+++ b/redisinsight/ui/src/components/base/tooltip/HoverContent.tsx
@@ -9,7 +9,7 @@ interface RiTooltipContentProps {
 }
 
 export const HoverContent = ({ title, content }: RiTooltipContentProps) => (
-  <Col>
+  <Col gap="s">
     {title && <Title size="XS">{title}</Title>}
     {content}
   </Col>

--- a/redisinsight/ui/src/components/base/tooltip/HoverContent.tsx
+++ b/redisinsight/ui/src/components/base/tooltip/HoverContent.tsx
@@ -10,7 +10,7 @@ interface RiTooltipContentProps {
 
 export const HoverContent = ({ title, content }: RiTooltipContentProps) => (
   <Col>
-    {title && <Title size="S">{title}</Title>}
+    {title && <Title size="XS">{title}</Title>}
     {content}
   </Col>
 )

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/change-editor-type-button/ChangeEditorTypeButton.spec.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/change-editor-type-button/ChangeEditorTypeButton.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
 
-import { userEvent } from 'uiSrc/utils/test-utils'
+import { render, screen, userEvent } from 'uiSrc/utils/test-utils'
 import ChangeEditorTypeButton from './ChangeEditorTypeButton'
 
 const mockSwitchEditorType = jest.fn()


### PR DESCRIPTION
Tooltip size S seems a little too big for the content, so changing it to XS.

Before:
<img width="459" height="192" alt="image-20250812-083718" src="https://github.com/user-attachments/assets/e16a400f-aeaf-49cd-871c-23a7d9ca79d4" />

After:
<img width="459" height="192" alt="image" src="https://github.com/user-attachments/assets/231b3bb4-3f2a-46af-a17c-16be416b065a" />
