### PR TITLE
RI-7297: update vector search header action buttons style

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/query/HeaderActions.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/query/HeaderActions.styles.ts
@@ -1,4 +1,3 @@
-import { TextButton } from '@redis-ui/components'
 import styled from 'styled-components'
 import { FlexGroup } from 'uiSrc/components/base/layout/flex'
 
@@ -8,13 +7,4 @@ export const StyledHeaderAction = styled(FlexGroup)`
   justify-content: flex-end;
   gap: ${({ theme }) => theme.core.space.space100};
   margin-bottom: ${({ theme }) => theme.core.space.space100};
-`
-
-export const StyledTextButton = styled(TextButton)`
-  padding: 0px;
-  height: auto;
-  color: ${({ theme }) => theme.color.blue400};
-  &:hover {
-    color: ${({ theme }) => theme.color.blue500};
-  }
 `

--- a/redisinsight/ui/src/pages/vector-search/query/HeaderActions.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/HeaderActions.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
-import { StyledHeaderAction, StyledTextButton } from './HeaderActions.styles'
+import { StyledHeaderAction } from './HeaderActions.styles'
 import { ManageIndexesDrawer } from '../manage-indexes/ManageIndexesDrawer'
 import { collectSavedQueriesPanelToggleTelemetry } from '../telemetry'
+import { EmptyButton } from 'uiSrc/components/base/forms/buttons'
 
 export type HeaderActionsProps = {
   isManageIndexesDrawerOpen: boolean
@@ -31,12 +32,12 @@ export const HeaderActions = ({
   return (
     <>
       <StyledHeaderAction data-testid="vector-search-header-actions">
-        <StyledTextButton variant="primary" onClick={handleSavedQueriesClick}>
+        <EmptyButton onClick={handleSavedQueriesClick}>
           Saved queries
-        </StyledTextButton>
-        <StyledTextButton onClick={() => setIsManageIndexesDrawerOpen(true)}>
+        </EmptyButton>
+        <EmptyButton onClick={() => setIsManageIndexesDrawerOpen(true)}>
           Manage indexes
-        </StyledTextButton>
+        </EmptyButton>
       </StyledHeaderAction>
 
       <ManageIndexesDrawer


### PR DESCRIPTION
## Description

Updates style of the buttons to use default component.

| Before | After |
| --- | --- |
| <img width="440" height="432" alt="Screenshot 2025-08-12 at 15 55 24" src="https://github.com/user-attachments/assets/05507ab3-6e4c-409c-9cc8-4c99bdf7a5e1" /> |  <img width="498" height="362" alt="Screenshot 2025-08-12 at 15 55 11" src="https://github.com/user-attachments/assets/64626e6f-5b6a-436d-a58f-4a0fd26b55c3" /> |
