### PR TITLE
RI-7295: Fix Search screen buttons alignment

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/query/HeaderActions.styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/query/HeaderActions.styles.ts
@@ -9,5 +9,6 @@ export const StyledHeaderAction = styled(FlexGroup)`
 `
 
 export const StyledWrapper = styled(FlexGroup)`
+  align-items: center;
   margin-bottom: ${({ theme }) => theme.core.space.space100};
 `


### PR DESCRIPTION
# Before

<img width="1519" height="91" alt="Screenshot 2025-08-13 at 11 14 31" src="https://github.com/user-attachments/assets/efbb362a-2c99-4ba9-a84b-6912a1b38a71" />

# After

<img width="1507" height="90" alt="Screenshot 2025-08-13 at 11 19 59" src="https://github.com/user-attachments/assets/cdbf1d3f-b631-45b5-8fff-b86c236b87c8" />
