### PR TITLE
RI-6855: Adjust default values for resizable Search containers

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
@@ -124,6 +124,7 @@ export const VectorSearchQuery = () => {
           <ResizablePanel
             id="left-panel"
             minSize={20}
+            order={1}
             defaultSize={leftPanelDefault}
           >
             <ResizableContainer direction="vertical">
@@ -184,7 +185,12 @@ export const VectorSearchQuery = () => {
                 data-test-subj="resize-btn-scripting-area-and-results"
               />
 
-              <ResizablePanel id="right-panel" minSize={20} defaultSize={30}>
+              <ResizablePanel
+                id="right-panel"
+                order={2}
+                minSize={20}
+                defaultSize={30}
+              >
                 <SavedQueriesScreen
                   onIndexChange={handleIndexChange}
                   onQueryInsert={handleQueryInsert}

--- a/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
@@ -108,6 +108,8 @@ export const VectorSearchQuery = () => {
     })
   }
 
+  const leftPanelDefault = isSavedQueriesOpen ? 70 : 100
+
   return (
     <ViewModeContextProvider viewMode={ViewMode.VectorSearch}>
       <VectorSearchScreenWrapper direction="column" justify="between">
@@ -119,9 +121,13 @@ export const VectorSearchQuery = () => {
         />
 
         <ResizableContainer direction="horizontal">
-          <ResizablePanel id="left-panel" minSize={20} defaultSize={30}>
+          <ResizablePanel
+            id="left-panel"
+            minSize={20}
+            defaultSize={leftPanelDefault}
+          >
             <ResizableContainer direction="vertical">
-              <ResizablePanel id="top-panel" minSize={20} defaultSize={30}>
+              <ResizablePanel id="top-panel" minSize={10} defaultSize={30}>
                 <QueryWrapper
                   query={query}
                   activeMode={activeMode}
@@ -144,8 +150,8 @@ export const VectorSearchQuery = () => {
               <ResizablePanel
                 id="bottom-panel"
                 minSize={10}
-                maxSize={70}
-                defaultSize={80}
+                maxSize={80}
+                defaultSize={70}
               >
                 <CommandsViewWrapper
                   items={items}

--- a/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
@@ -108,8 +108,6 @@ export const VectorSearchQuery = () => {
     })
   }
 
-  const leftPanelDefault = isSavedQueriesOpen ? 70 : 100
-
   return (
     <ViewModeContextProvider viewMode={ViewMode.VectorSearch}>
       <VectorSearchScreenWrapper direction="column" justify="between">
@@ -125,7 +123,7 @@ export const VectorSearchQuery = () => {
             id="left-panel"
             minSize={20}
             order={1}
-            defaultSize={leftPanelDefault}
+            defaultSize={isSavedQueriesOpen ? 70 : 100}
           >
             <ResizableContainer direction="vertical">
               <ResizablePanel id="top-panel" minSize={10} defaultSize={30}>


### PR DESCRIPTION
- to remove a warning (max size should be more than the default size)
- to adjust for better UX

# Before

<img width="2239" height="1066" alt="Screenshot 2025-08-13 at 18 01 07" src="https://github.com/user-attachments/assets/7d131ace-297c-4057-b1b2-c6f450f37ef4" />

# After

<img width="2235" height="1098" alt="Screenshot 2025-08-13 at 18 00 52" src="https://github.com/user-attachments/assets/e3854e43-930d-4471-8954-99e2f26c8f0e" />
