### PR TITLE
Fe/feature/RI-7351 and RI-7350 and RI-7349

### DIFF
--- a/.github/build/release-docker.sh
+++ b/.github/build/release-docker.sh
@@ -2,7 +2,7 @@
 set -e
 
 HELP="Args:
--v - Semver (2.70.1)
+-v - Semver (2.72.0)
 -d - Build image repository (Ex: -d redisinsight)
 -r - Target repository (Ex: -r redis/redisinsight)
 "

--- a/redisinsight/api/config/default.ts
+++ b/redisinsight/api/config/default.ts
@@ -107,7 +107,7 @@ export default {
       : true,
     buildType: process.env.RI_BUILD_TYPE || 'DOCKER_ON_PREMISE',
     appType: process.env.RI_APP_TYPE,
-    appVersion: process.env.RI_APP_VERSION || '2.70.1',
+    appVersion: process.env.RI_APP_VERSION || '2.72.0',
     requestTimeout: parseInt(process.env.RI_REQUEST_TIMEOUT, 10) || 25000,
     excludeRoutes: [],
     excludeAuthRoutes: [],

--- a/redisinsight/api/config/swagger.ts
+++ b/redisinsight/api/config/swagger.ts
@@ -5,7 +5,7 @@ const SWAGGER_CONFIG: Omit<OpenAPIObject, 'paths'> = {
   info: {
     title: 'Redis Insight Backend API',
     description: 'Redis Insight Backend API',
-    version: '2.70.1',
+    version: '2.72.0',
   },
   tags: [],
 };

--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redisinsight-api",
-  "version": "2.70.1",
+  "version": "2.72.0",
   "description": "Redis Insight API",
   "private": true,
   "author": {

--- a/redisinsight/desktop/src/lib/aboutPanel/aboutPanel.ts
+++ b/redisinsight/desktop/src/lib/aboutPanel/aboutPanel.ts
@@ -7,7 +7,7 @@ const ICON_PATH = app.isPackaged
   : path.join(__dirname, '../resources', 'icon.png')
 
 const appVersionPrefix = config.isEnterprise ? 'Enterprise - ' : ''
-const appVersion = app.getVersion() || '2.70.1'
+const appVersion = app.getVersion() || '2.72.0'
 const appVersionSuffix = !config.isProduction
   ? `-dev-${process.getCreationTime()}`
   : ''

--- a/redisinsight/package.json
+++ b/redisinsight/package.json
@@ -3,7 +3,7 @@
   "appName": "Redis Insight",
   "productName": "RedisInsight",
   "private": true,
-  "version": "2.70.1",
+  "version": "2.72.0",
   "description": "Redis Insight",
   "main": "./dist/main/main.js",
   "author": {

--- a/redisinsight/ui/src/components/side-panels/components/copilot-panel/CopilotPanel.tsx
+++ b/redisinsight/ui/src/components/side-panels/components/copilot-panel/CopilotPanel.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react'
-import { EuiBadge } from '@elastic/eui'
 import { Header } from 'uiSrc/components/side-panels/components'
 import styles from 'uiSrc/components/side-panels/styles.module.scss'
 import AiAssistant from 'uiSrc/components/side-panels/panels/ai-assistant'

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/chats-wrapper/ChatsWrapper.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/chats-wrapper/ChatsWrapper.tsx
@@ -89,6 +89,7 @@ const ChatsWrapper = () => {
       {chats.length > 1 && (
         <Tabs
           tabs={tabs}
+          className={styles.tabs}
           value={activeTab}
           onChange={selectTab}
           data-testid="ai-tabs"

--- a/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/texts.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/ai-assistant/components/texts.tsx
@@ -1,4 +1,3 @@
-import { EuiLink } from '@elastic/eui'
 import React from 'react'
 
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
@@ -20,6 +19,7 @@ export const ASSISTANCE_CHAT_AGREEMENTS = (
       By accessing and/or using Redis Copilot, you acknowledge that you agree to
       the{' '}
       <Link
+        variant="small-inline"
         color="subdued"
         target="_blank"
         href="https://redis.io/legal/redis-copilot-terms-of-use/"
@@ -28,6 +28,7 @@ export const ASSISTANCE_CHAT_AGREEMENTS = (
       </Link>{' '}
       and{' '}
       <Link
+        variant="small-inline"
         color="subdued"
         target="_blank"
         href="https://redis.com/legal/privacy-policy/"
@@ -56,6 +57,7 @@ export const EXPERT_CHAT_AGREEMENTS = (
       By accepting these terms, you consent to the processing of any information
       included in your database, and you agree to the{' '}
       <Link
+        variant="small-inline"
         color="subdued"
         target="_blank"
         href="https://redis.io/legal/redis-copilot-terms-of-use/"
@@ -64,6 +66,7 @@ export const EXPERT_CHAT_AGREEMENTS = (
       </Link>{' '}
       and{' '}
       <Link
+        variant="small-inline"
         color="subdued"
         target="_blank"
         href="https://redis.com/legal/privacy-policy/"

--- a/redisinsight/ui/src/pages/pub-sub/PubSubPage.tsx
+++ b/redisinsight/ui/src/pages/pub-sub/PubSubPage.tsx
@@ -14,7 +14,6 @@ import { formatLongName, getDbIndex, setTitle } from 'uiSrc/utils'
 import { OnboardingTour } from 'uiSrc/components'
 import { ONBOARDING_FEATURES } from 'uiSrc/components/onboarding-features'
 import { incrementOnboardStepAction } from 'uiSrc/slices/app/features'
-import { Title } from 'uiSrc/components/base/text/Title'
 import { OnboardingSteps } from 'uiSrc/constants/onboarding'
 import {
   MessagesListWrapper,
@@ -32,6 +31,12 @@ const MainContainer = styled.div<React.HTMLAttributes<HTMLDivElement>>`
 
 const ContentPanel = styled.div`
   flex-grow: 1;
+`
+
+const HeaderPanel = styled.div`
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--separatorColor);
+  border-color: ${({ theme }) => theme.semantic.color.border.neutral500};
 `
 
 const FooterPanel = styled.div`
@@ -89,12 +94,9 @@ const PubSubPage = () => {
   return (
     <MainContainer className={styles.main} data-testid="pub-sub-page">
       <ContentPanel>
-        <div className={styles.header}>
-          <Title size="XXL" className={styles.title}>
-            Pub/Sub
-          </Title>
+        <HeaderPanel>
           <SubscriptionPanel />
-        </div>
+        </HeaderPanel>
         <div className={styles.tableWrapper}>
           <MessagesListWrapper />
         </div>

--- a/redisinsight/ui/src/pages/pub-sub/styles.module.scss
+++ b/redisinsight/ui/src/pages/pub-sub/styles.module.scss
@@ -4,17 +4,6 @@
   display: flex;
   flex-direction: column;
 
-  .header {
-    padding: 24px 18px 12px;
-    border-bottom: 1px solid var(--separatorColor);
-  }
-
-  .title {
-    font-size: 16px;
-    line-height: 24px;
-    margin-bottom: 18px;
-  }
-
   .tableWrapper {
     width: 100%;
     height: calc(100% - 125px);


### PR DESCRIPTION
Added the same style the tips/insights have to the copilot tabs
Added the same fix for links Same fix as https://github.com/redis/RedisInsight/pull/4805/files#diff-05f1210823b0f8c65973870768a5927f7100cd30283d35b5b8041015444d9d73
Removed the Pub/Sub title altogether as it was not used anywhere.
Refactored the header to use styled components as well, instead of sass, with the proper theme border, instead of eui color.
