### PR TITLE
RI-7332---Authentication-options-are-not-centered-with-their-corresponding-icons

### DIFF
--- a/redisinsight/ui/src/components/oauth/shared/oauth-social-buttons/OAuthSocialButtons.tsx
+++ b/redisinsight/ui/src/components/oauth/shared/oauth-social-buttons/OAuthSocialButtons.tsx
@@ -71,11 +71,9 @@ const OAuthSocialButtons = (props: Props) => {
             data-testid={label}
             aria-labelledby={label}
           >
-            <FlexGroup align="center">
-              <FlexItem direction={inline ? 'row' : 'column'}>
-                <RiIcon type={icon as AllIconsType} />
-                <Text className={styles.label}>{text}</Text>
-              </FlexItem>
+            <FlexGroup direction={inline ? 'row' : 'column'} align="center" justify="center">
+              <RiIcon type={icon as AllIconsType} />
+              <Text className={styles.label}>{text}</Text>
             </FlexGroup>
           </EmptyButton>
         </RiTooltip>


### PR DESCRIPTION
I've replaced the FlexItem with FlexGroup so the children can be center aligned