### PR TITLE
RI-7362 Added support for dark theme for the "Command Preview" drawer

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/create-index/steps/styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/create-index/steps/styles.ts
@@ -39,7 +39,7 @@ export const CodeBlocKWrapper = styled.div`
   border-color: ${({ theme }) => theme.color.dusk200};
   border-radius: 8px;
 
-  background: ${({ theme }) => theme.color.dusk100};
+  background: ${({ theme }) => theme.semantic.color.background.neutral200};
   word-wrap: break-word;
   white-space: break-spaces;
 `


### PR DESCRIPTION
# Description

Make the background of the code snippet block in the "**Command Preview**" drawer to support dark theme.

| Old | New |
|-|-|
<img width="1182" height="908" alt="image" src="https://github.com/user-attachments/assets/ec845c8f-7c87-4001-bdcb-bc7775bd12c0" />|<img width="1183" height="906" alt="image" src="https://github.com/user-attachments/assets/14f4b261-1da4-4eb1-9e8d-dc6b58940ab2" />
<img width="1182" height="902" alt="image" src="https://github.com/user-attachments/assets/e2db3a49-e9cc-4f70-b848-4da5a17eda48" />|<img width="1179" height="898" alt="image" src="https://github.com/user-attachments/assets/ac0d9d81-5bc3-4cf7-9998-89b3ccd7619e" />

# How it was tested

1. Open a connection to a new or existing Database
2. Go to the **Search** page from the top navbar
- If you don't have any indexes yet, you'll see the "**Create Index**" wizard
- Otherwise, you should trigger the creation process by clicking "**Get Started**" from the alert below the top navbar
- Or simply, go to the following URL manually: http://localhost:8080/:databaseId/vector-search/create-index

3. On the first step of the creation process, click on the "**Proceed to index**" button in the bottom right corner of the page
4. On the second step of the flow, click on the "**Command preview**" button under the index attributes to see the command that will be executed

_PS: You can toggle the appearance from **Settings** -> **General** -> **Color Theme**_