### PR TITLE
RI-7378: Missing icons fix

### DIFF
--- a/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
+++ b/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
@@ -46,7 +46,7 @@ const ExploreGuides = () => {
       </Title>
       <Spacer size="s" />
       <Text color="primary">
-        Explore the amazing world of Redis Stack with our interactive guides
+        Explore the amazing world of Redis with our interactive guides
       </Text>
       <Spacer size="xl" />
       {!!data.length && (

--- a/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
+++ b/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
@@ -41,10 +41,11 @@ const ExploreGuides = () => {
 
   return (
     <div data-testid="explore-guides">
-      <Title size="XS">
+      <Title color="primary" size="S">
         <span>Here&apos;s a good starting point</span>
       </Title>
-      <Text>
+      <Spacer size="s" />
+      <Text color="primary">
         Explore the amazing world of Redis Stack with our interactive guides
       </Text>
       <Spacer size="xl" />

--- a/redisinsight/ui/src/components/explore-guides/icons.ts
+++ b/redisinsight/ui/src/components/explore-guides/icons.ts
@@ -2,8 +2,8 @@ import { AllIconsType } from 'uiSrc/components/base/icons/RiIcon'
 
 const GUIDE_ICONS: Record<string, AllIconsType> = {
   search: 'QuerySearchIcon',
-  json: 'JSONIcon',
-  'probabilistic-data-structures': 'ProbabilisticDataIcon',
+  json: 'JsonIcon',
+  'probabilistic-data-structures': 'ProbabilisticIcon',
   'time-series': 'TimeSeriesIcon',
   'vector-similarity-search': 'VectorSimilarityIcon',
 }

--- a/redisinsight/ui/src/pages/browser/components/no-keys-found/NoKeysFound.tsx
+++ b/redisinsight/ui/src/pages/browser/components/no-keys-found/NoKeysFound.tsx
@@ -67,7 +67,7 @@ const NoKeysFound = (props: Props) => {
         alt="no results"
       />
       <Spacer />
-      <Title className={styles.title} size="S">
+      <Title color="primary" className={styles.title} size="S">
         Let&apos;s start working
       </Title>
       <Spacer />


### PR DESCRIPTION
- Fix the missing icons for JSON and Probabilistic types by changing the icon name in the GUIDE to match the names in Redis Component icons. 
- Apply some changes to the text and the title above to look nicer
- Replace `... amazing world of Redis Stack ...` with only `... amazing world of Redis ...`

| Before | After | 
|----------|----------|
| <img width="613" height="627" alt="image" src="https://github.com/user-attachments/assets/99be96a1-ebd4-480c-a9f7-9d2ffe538638" />   | <img width="613" height="627" alt="image" src="https://github.com/user-attachments/assets/16c5550e-c32f-4dd5-a9f5-c31bddb334bf" />  |
| <img width="613" height="627" alt="image" src="https://github.com/user-attachments/assets/00ae741f-4438-4c3b-89cb-e2fb34eefc0c" />   | <img width="613" height="627" alt="image" src="https://github.com/user-attachments/assets/a705fec7-38bb-459e-baad-e98637e469a8" />   | 
| <img width="613" height="627" alt="image" src="https://github.com/user-attachments/assets/b270847c-282a-427e-8f2e-5e63d72649a3" /> | <img width="613" height="627" alt="image" src="https://github.com/user-attachments/assets/59558cf4-22f7-4859-9846-94ba9d1dceef" /> |