### PR TITLE
[RI-7374] [RI-7373]: update Saved Queries layout to match new design

### DIFF
--- a/redisinsight/ui/src/components/base/forms/buttons/EmptyButton.tsx
+++ b/redisinsight/ui/src/components/base/forms/buttons/EmptyButton.tsx
@@ -22,9 +22,7 @@ export const EmptyButton = ({
   ...rest
 }: ButtonProps) => (
   <TextButton {...rest}>
-    <Row
-      justify={justify}
-    >  
+    <Row justify={justify} gap="xs">
       <ButtonIcon
         buttonSide="left"
         icon={icon}

--- a/redisinsight/ui/src/pages/vector-search/create-index/VectorSearchCreateIndex.tsx
+++ b/redisinsight/ui/src/pages/vector-search/create-index/VectorSearchCreateIndex.tsx
@@ -105,7 +105,7 @@ export const VectorSearchCreateIndex = ({
 
   return (
     <VectorSearchScreenWrapper direction="column" justify="between">
-      <VectorSearchScreenHeader direction="row">
+      <VectorSearchScreenHeader direction="row" padding={8}>
         <Title size="M" data-testid="title">
           New vector search
         </Title>
@@ -115,13 +115,13 @@ export const VectorSearchCreateIndex = ({
           <Stepper.Step>Create Index</Stepper.Step>
         </Stepper>
       </VectorSearchScreenHeader>
-      <VectorSearchScreenContent direction="column" grow={1}>
+      <VectorSearchScreenContent direction="column" grow={1} padding={8}>
         <StepContent
           parameters={createSearchIndexParameters}
           setParameters={setParameters}
         />
       </VectorSearchScreenContent>
-      <VectorSearchScreenFooter direction="row">
+      <VectorSearchScreenFooter direction="row" padding={8}>
         {showBackButton && (
           <SecondaryButton
             iconSide="left"

--- a/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesScreen.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesScreen.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { cleanup, render, screen } from 'uiSrc/utils/test-utils'
+import { cleanup, fireEvent, render, screen } from 'uiSrc/utils/test-utils'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 
 import { ManageIndexesScreen } from './ManageIndexesScreen'
@@ -15,6 +15,12 @@ jest.mock('./ManageIndexesList', () => ({
   ManageIndexesList: jest.fn().mockReturnValue(null),
 }))
 
+const mockOnClose = jest.fn()
+
+const defaultProps = {
+  onClose: mockOnClose,
+}
+
 describe('ManageIndexesScreen', () => {
   beforeEach(() => {
     cleanup()
@@ -22,7 +28,7 @@ describe('ManageIndexesScreen', () => {
   })
 
   it('renders correctly', () => {
-    const { container } = render(<ManageIndexesScreen />)
+    const { container } = render(<ManageIndexesScreen {...defaultProps} />)
 
     expect(container).toBeTruthy()
 
@@ -31,9 +37,18 @@ describe('ManageIndexesScreen', () => {
     expect(screen.getByTestId('title')).toHaveTextContent('Manage indexes')
   })
 
+  it('should call onClose when close button is clicked', () => {
+    render(<ManageIndexesScreen {...defaultProps} />)
+
+    const closeButton = screen.getByTestId('close-saved-queries-btn')
+    fireEvent.click(closeButton)
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1)
+  })
+
   describe('telemetry', () => {
     it('should send telemetry event on mount', () => {
-      render(<ManageIndexesScreen />)
+      render(<ManageIndexesScreen {...defaultProps} />)
 
       expect(sendEventTelemetry).toHaveBeenCalledWith({
         event: TelemetryEvent.SEARCH_MANAGE_INDEXES_DRAWER_OPENED,
@@ -42,7 +57,7 @@ describe('ManageIndexesScreen', () => {
     })
 
     it('should send telemetry event on unmount', () => {
-      const { unmount } = render(<ManageIndexesScreen />)
+      const { unmount } = render(<ManageIndexesScreen {...defaultProps} />)
 
       // Unmount component to trigger the onUnmount event
       unmount()

--- a/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesScreen.tsx
+++ b/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesScreen.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import { Title } from 'uiSrc/components/base/text'
 import { TelemetryEvent } from 'uiSrc/telemetry'
+import { CancelSlimIcon } from 'uiSrc/components/base/icons'
+import { IconButton } from 'uiSrc/components/base/forms/buttons'
 
 import { useTelemetryMountEvent } from '../hooks/useTelemetryMountEvent'
 import {
@@ -11,7 +13,11 @@ import {
 } from '../styles'
 import { ManageIndexesList } from './ManageIndexesList'
 
-export const ManageIndexesScreen = () => {
+export type ManageIndexesScreenProps = {
+  onClose: () => void
+}
+
+export const ManageIndexesScreen = ({ onClose }: ManageIndexesScreenProps) => {
   useTelemetryMountEvent(
     TelemetryEvent.SEARCH_MANAGE_INDEXES_DRAWER_OPENED,
     TelemetryEvent.SEARCH_MANAGE_INDEXES_DRAWER_CLOSED,
@@ -22,14 +28,22 @@ export const ManageIndexesScreen = () => {
       direction="column"
       data-testid="manage-indexes-screen"
     >
-      <VectorSearchScreenHeader>
-        <Title size="M" data-testid="title">
+      <VectorSearchScreenHeader padding={6}>
+        <Title size="S" data-testid="title">
           Manage indexes
         </Title>
+        <IconButton
+          size="XS"
+          icon={CancelSlimIcon}
+          aria-label="Close"
+          data-testid={'close-saved-queries-btn'}
+          onClick={() => onClose()}
+        />
       </VectorSearchScreenHeader>
       <VectorSearchScreenFooter
         data-testid="manage-indexes-screen-body"
         grow={1}
+        padding={6}
       >
         <ManageIndexesList />
       </VectorSearchScreenFooter>

--- a/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
@@ -123,6 +123,10 @@ export const VectorSearchQuery = ({
     })
   }
 
+  const closeRightPanel = () => {
+    setRightPanel(null)
+  }
+
   const toggleManageIndexesScreen = () => {
     setRightPanel(
       rightPanel === RightPanelType.MANAGE_INDEXES
@@ -219,7 +223,7 @@ export const VectorSearchQuery = ({
                 defaultSize={30}
               >
                 {rightPanel === RightPanelType.MANAGE_INDEXES && (
-                  <ManageIndexesScreen />
+                  <ManageIndexesScreen onClose={closeRightPanel} />
                 )}
 
                 {rightPanel === RightPanelType.SAVED_QUERIES && (
@@ -228,6 +232,7 @@ export const VectorSearchQuery = ({
                     onQueryInsert={handleQueryInsert}
                     savedIndexes={mockSavedIndexes}
                     selectedIndex={selectedIndex}
+                    onClose={closeRightPanel}
                   />
                 )}
               </ResizablePanel>

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
@@ -16,6 +16,7 @@ jest.mock('uiSrc/telemetry', () => ({
 
 const mockOnIndexChange = jest.fn()
 const mockOnQueryInsert = jest.fn()
+const mockOnClose = jest.fn()
 
 const mockSavedIndexes: SavedIndex[] = [
   {
@@ -49,6 +50,7 @@ const defaultProps = {
   selectedIndex: mockSavedIndexes[0],
   onIndexChange: mockOnIndexChange,
   onQueryInsert: mockOnQueryInsert,
+  onClose: mockOnClose,
 }
 
 describe('SavedQueriesScreen', () => {
@@ -76,6 +78,15 @@ describe('SavedQueriesScreen', () => {
 
     const insertButtons = screen.getAllByText('Insert')
     expect(insertButtons).toHaveLength(2) // 2 queries in the selected index
+  })
+
+  it('should call onClose when close button is clicked', () => {
+    render(<SavedQueriesScreen {...defaultProps} />)
+
+    const closeButton = screen.getByTestId('close-saved-queries-btn')
+    fireEvent.click(closeButton)
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1)
   })
 
   it('should call onQueryInsert when insert button is clicked', () => {

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
@@ -3,19 +3,19 @@ import React from 'react'
 import { Title, Text } from 'uiSrc/components/base/text'
 
 import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
-import { EmptyButton } from 'uiSrc/components/base/forms/buttons'
+import { EmptyButton, IconButton } from 'uiSrc/components/base/forms/buttons'
 import { FieldTag } from 'uiSrc/components/new-index/create-index-step/field-box/FieldTag'
 
-import { PlayFilledIcon } from 'uiSrc/components/base/icons'
+import { CancelSlimIcon, PlayFilledIcon } from 'uiSrc/components/base/icons'
 import {
   RightAlignedWrapper,
   TagsWrapper,
   VectorSearchSavedQueriesContentWrapper,
   VectorSearchSavedQueriesSelectWrapper,
-  VectorSearchSavedQueryCardWrapper,
 } from './styles'
 import { SavedIndex } from './types'
 import {
+  VectorSearchScreenBlockWrapper,
   VectorSearchScreenFooter,
   VectorSearchScreenHeader,
   VectorSearchScreenWrapper,
@@ -28,6 +28,7 @@ type SavedQueriesScreenProps = {
   selectedIndex?: SavedIndex
   onIndexChange: (value: string) => void
   onQueryInsert: (value: string) => void
+  onClose: () => void
 }
 
 export const SavedQueriesScreen = ({
@@ -35,6 +36,7 @@ export const SavedQueriesScreen = ({
   selectedIndex,
   onIndexChange,
   onQueryInsert,
+  onClose,
 }: SavedQueriesScreenProps) => {
   useTelemetryMountEvent(
     TelemetryEvent.SEARCH_SAVED_QUERIES_PANEL_OPENED,
@@ -46,12 +48,19 @@ export const SavedQueriesScreen = ({
       direction="column"
       data-testid="saved-queries-screen"
     >
-      <VectorSearchScreenHeader>
-        <Title size="M" data-testid="title">
+      <VectorSearchScreenHeader padding={6}>
+        <Title size="S" data-testid="title">
           Saved queries
         </Title>
+        <IconButton
+          size="XS"
+          icon={CancelSlimIcon}
+          aria-label="Close"
+          data-testid={'close-saved-queries-btn'}
+          onClick={() => onClose()}
+        />
       </VectorSearchScreenHeader>
-      <VectorSearchScreenFooter grow={1}>
+      <VectorSearchScreenFooter grow={1} padding={6}>
         <VectorSearchSavedQueriesContentWrapper>
           <VectorSearchSavedQueriesSelectWrapper>
             <Title size="S">Index:</Title>
@@ -77,7 +86,11 @@ export const SavedQueriesScreen = ({
             />
           </VectorSearchSavedQueriesSelectWrapper>
           {selectedIndex?.queries.map((query) => (
-            <VectorSearchSavedQueryCardWrapper key={query.value} as="div">
+            <VectorSearchScreenBlockWrapper
+              key={query.value}
+              // as="div"
+              padding={6}
+            >
               <Text>{query.label}</Text>
               <RightAlignedWrapper>
                 <EmptyButton
@@ -88,7 +101,7 @@ export const SavedQueriesScreen = ({
                   Insert
                 </EmptyButton>
               </RightAlignedWrapper>
-            </VectorSearchSavedQueryCardWrapper>
+            </VectorSearchScreenBlockWrapper>
           ))}
         </VectorSearchSavedQueriesContentWrapper>
       </VectorSearchScreenFooter>

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Title, Text } from 'uiSrc/components/base/text'
 
 import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
-import { Button } from 'uiSrc/components/base/forms/buttons'
+import { EmptyButton } from 'uiSrc/components/base/forms/buttons'
 import { FieldTag } from 'uiSrc/components/new-index/create-index-step/field-box/FieldTag'
 
 import { PlayFilledIcon } from 'uiSrc/components/base/icons'
@@ -12,10 +12,10 @@ import {
   TagsWrapper,
   VectorSearchSavedQueriesContentWrapper,
   VectorSearchSavedQueriesSelectWrapper,
+  VectorSearchSavedQueryCardWrapper,
 } from './styles'
 import { SavedIndex } from './types'
 import {
-  VectorSearchScreenBlockWrapper,
   VectorSearchScreenFooter,
   VectorSearchScreenHeader,
   VectorSearchScreenWrapper,
@@ -77,20 +77,18 @@ export const SavedQueriesScreen = ({
             />
           </VectorSearchSavedQueriesSelectWrapper>
           {selectedIndex?.queries.map((query) => (
-            <VectorSearchScreenBlockWrapper key={query.value} as="div">
+            <VectorSearchSavedQueryCardWrapper key={query.value} as="div">
               <Text>{query.label}</Text>
               <RightAlignedWrapper>
-                <Button
-                  variant="secondary-invert"
+                <EmptyButton
                   icon={PlayFilledIcon}
-                  size="s"
                   onClick={() => onQueryInsert(query.value)}
                   data-testid="btn-insert-query"
                 >
                   Insert
-                </Button>
+                </EmptyButton>
               </RightAlignedWrapper>
-            </VectorSearchScreenBlockWrapper>
+            </VectorSearchSavedQueryCardWrapper>
           ))}
         </VectorSearchSavedQueriesContentWrapper>
       </VectorSearchScreenFooter>

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/styles.ts
@@ -14,18 +14,6 @@ export const VectorSearchSavedQueriesSelectWrapper = styled.div`
   align-items: center;
 `
 
-export const VectorSearchSavedQueryCardWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  border: 1px solid;
-  border-color: ${({ theme }) => theme.color?.dusk200};
-  border-radius: ${({ theme }) => theme.core?.space.space100};
-  padding: ${({ theme }) => theme.core?.space.space200};
-  gap: ${({ theme }) => theme.core?.space.space200};
-`
-
 export const RightAlignedWrapper = styled.div`
   display: flex;
   align-self: flex-end;

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/styles.ts
@@ -14,6 +14,18 @@ export const VectorSearchSavedQueriesSelectWrapper = styled.div`
   align-items: center;
 `
 
+export const VectorSearchSavedQueryCardWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid;
+  border-color: ${({ theme }) => theme.color?.dusk200};
+  border-radius: ${({ theme }) => theme.core?.space.space100};
+  padding: ${({ theme }) => theme.core?.space.space200};
+  gap: ${({ theme }) => theme.core?.space.space200};
+`
+
 export const RightAlignedWrapper = styled.div`
   display: flex;
   align-self: flex-end;

--- a/redisinsight/ui/src/pages/vector-search/styles.ts
+++ b/redisinsight/ui/src/pages/vector-search/styles.ts
@@ -26,8 +26,9 @@ export const VectorSearchScreenWrapper = styled(FlexGroup)`
 `
 
 export const VectorSearchScreenHeader = styled(FlexItem)`
-  padding: ${({ theme }) => theme.core?.space.space300};
+  flex-direction: row;
   justify-content: space-between;
+  align-items: center;
   border: 1px solid;
   border-color: ${({ theme }) => theme.color?.dusk200};
   border-top-left-radius: 8px;
@@ -35,7 +36,6 @@ export const VectorSearchScreenHeader = styled(FlexItem)`
 `
 
 export const VectorSearchScreenContent = styled(FlexItem)`
-  padding: ${({ theme }) => theme.core?.space.space300};
   gap: ${({ theme }) => theme.core?.space.space550};
   border: 1px solid;
   border-top: none;
@@ -43,7 +43,6 @@ export const VectorSearchScreenContent = styled(FlexItem)`
 `
 
 export const VectorSearchScreenFooter = styled(FlexItem)`
-  padding: ${({ theme }) => theme.core?.space.space300};
   border: 1px solid;
   border-color: ${({ theme }) => theme.color?.dusk200};
   border-top: none;
@@ -52,12 +51,12 @@ export const VectorSearchScreenFooter = styled(FlexItem)`
   border-bottom-right-radius: 8px;
 `
 
-export const VectorSearchScreenBlockWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
+export const VectorSearchScreenBlockWrapper = styled(FlexItem)`
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
   border: 1px solid;
   border-color: ${({ theme }) => theme.color?.dusk200};
   border-radius: ${({ theme }) => theme.core?.space.space100};
-  padding: ${({ theme }) => theme.core?.space.space200};
   gap: ${({ theme }) => theme.core?.space.space200};
 `


### PR DESCRIPTION
## Description 

This PR addresses two issues related to the same sections 
- RI-7374 - adjusts the Saved Queries wrapper to match the new design
- RI-7373 - adds close button to Saved Queries & Manage indexes
- adjusts paddings for Saved Queries & Manage indexes to match the new design

| Before | After |
| --- | --- |
| <img width="730" height="554" alt="Screenshot 2025-08-20 at 16 47 48" src="https://github.com/user-attachments/assets/4a3453d0-beb2-490c-8b9b-a957f4de416d" /> | <img width="710" height="496" alt="Screenshot 2025-08-20 at 16 47 20" src="https://github.com/user-attachments/assets/d3f2583e-bec8-45df-8c56-8d93c038c15b" /> |

