### PR TITLE
fix add multiple keys layout and styling

### DIFF
--- a/redisinsight/ui/src/pages/browser/components/add-multiple-fields/AddMultipleFields.tsx
+++ b/redisinsight/ui/src/pages/browser/components/add-multiple-fields/AddMultipleFields.tsx
@@ -1,15 +1,13 @@
 import React from 'react'
-import cx from 'classnames'
 
 import { DeleteIcon, PlusIcon } from 'uiSrc/components/base/icons'
-import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import {
   ActionIconButton,
   IconButton,
 } from 'uiSrc/components/base/forms/buttons'
 import { RiTooltip } from 'uiSrc/components'
-import styles from './styles.module.scss'
 
 export interface Props<T> {
   items: T[]
@@ -23,11 +21,7 @@ const AddMultipleFields = <T,>(props: Props<T>) => {
   const { items, children, isClearDisabled, onClickRemove, onClickAdd } = props
 
   const renderItem = (child: React.ReactNode, item: T, index?: number) => (
-    <FlexItem
-      key={index}
-      className={cx('flexItemNoFullWidth', 'inlineFieldsNoSpace', styles.row)}
-      grow
-    >
+    <FlexItem key={index} grow>
       <Row align="center" gap="m">
         <FlexItem grow>{child}</FlexItem>
         <FlexItem>
@@ -46,25 +40,28 @@ const AddMultipleFields = <T,>(props: Props<T>) => {
   )
 
   return (
-    <>
-      {items.map((item, index) =>
-        renderItem(children(item, index), item, index),
-      )}
-      <Spacer size="s" />
+    <Col gap="m">
+      <Col
+        gap="m"
+        style={{ overflow: 'auto', maxHeight: 'calc(234px - 60px)' }}
+      >
+        {items.map((item, index) =>
+          renderItem(children(item, index), item, index),
+        )}
+      </Col>
       <Row align="center" justify="end">
-        <FlexItem>
-          <RiTooltip content="Add" position="left">
-            <ActionIconButton
-              variant="secondary"
-              icon={PlusIcon}
-              aria-label="Add new item"
-              onClick={onClickAdd}
-              data-testid="add-item"
-            />
-          </RiTooltip>
-        </FlexItem>
+        <RiTooltip content="Add" position="left">
+          <ActionIconButton
+            variant="secondary"
+            icon={PlusIcon}
+            aria-label="Add new item"
+            onClick={onClickAdd}
+            data-testid="add-item"
+          />
+        </RiTooltip>
       </Row>
-    </>
+      <Spacer size="s" />
+    </Col>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/common/AddKeysContainer.styled.ts
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/common/AddKeysContainer.styled.ts
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Theme } from 'uiSrc/components/base/theme/types'
+
+export const AddKeysContainer = styled.div<
+  React.HTMLAttributes<HTMLDivElement> & {
+    theme: Theme
+  }
+>`
+  padding: ${({ theme }) => theme.core.space.space150};
+  position: absolute;
+  bottom: 0;
+  background: ${({ theme }) => theme.semantic.color.background.neutral300};
+  border-style: solid;
+  border-width: 0;
+  border-color: ${({ theme }: { theme: Theme }) =>
+    theme.semantic.color.border.neutral500};
+  border-top-width: 1px;
+  width: 100%;
+
+  z-index: 2;
+
+  max-height: 100%;
+  overflow-y: auto;
+
+  &.contentActive {
+    border-color: ${({ theme }: { theme: Theme }) =>
+      theme.semantic.color.border.neutral500};
+    border-bottom-width: 1px;
+  }
+`

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/HashDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/HashDetails.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
-import cx from 'classnames'
 
 import { useParams } from 'react-router-dom'
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
@@ -22,6 +21,7 @@ import { HashDetailsTable } from './hash-details-table'
 import { KeyDetailsSubheader } from '../key-details-subheader/KeyDetailsSubheader'
 import { AddItemsAction } from '../key-details-actions'
 import styles from './styles.module.scss'
+import { AddKeysContainer } from '../common/AddKeysContainer.styled'
 
 export interface Props extends KeyDetailsHeaderProps {
   onRemoveKey: () => void
@@ -110,12 +110,12 @@ const HashDetails = (props: Props) => {
           </div>
         )}
         {isAddItemPanelOpen && (
-          <div className={cx('formFooterBar', 'contentActive')}>
+          <AddKeysContainer>
             <AddHashFields
               isExpireFieldsAvailable={isExpireFieldsAvailable}
               closePanel={closeAddItemPanel}
             />
-          </div>
+          </AddKeysContainer>
         )}
       </div>
     </div>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/AddHashFields.tsx
@@ -24,7 +24,7 @@ import {
   IHashFieldState,
   INITIAL_HASH_FIELD_STATE,
 } from 'uiSrc/pages/browser/components/add-key/AddKeyHash/interfaces'
-import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import {
   PrimaryButton,
   SecondaryButton,
@@ -164,7 +164,7 @@ const AddHashFields = (props: Props) => {
     !(item.fieldName.length || item.fieldValue.length || item.fieldTTL?.length)
 
   return (
-    <>
+    <Col gap="m">
       <div className={styles.container}>
         <AddMultipleFields
           items={fields}
@@ -182,7 +182,7 @@ const AddHashFields = (props: Props) => {
                     placeholder="Enter Field"
                     value={item.fieldName}
                     disabled={loading}
-                    onChange={value =>
+                    onChange={(value) =>
                       handleFieldChange('fieldName', item.id, value)
                     }
                     ref={
@@ -200,7 +200,7 @@ const AddHashFields = (props: Props) => {
                     placeholder="Enter Value"
                     value={item.fieldValue}
                     disabled={loading}
-                    onChange={value =>
+                    onChange={(value) =>
                       handleFieldChange('fieldValue', item.id, value)
                     }
                     data-testid="hash-value"
@@ -216,7 +216,7 @@ const AddHashFields = (props: Props) => {
                       placeholder="Enter TTL"
                       value={item.fieldTTL || ''}
                       disabled={loading}
-                      onChange={value =>
+                      onChange={(value) =>
                         handleFieldChange(
                           'fieldTTL',
                           item.id,
@@ -232,33 +232,31 @@ const AddHashFields = (props: Props) => {
           )}
         </AddMultipleFields>
       </div>
-      <>
-        <Row justify="end" gap="m">
-          <FlexItem>
-            <div>
-              <SecondaryButton
-                onClick={() => closePanel(true)}
-                data-testid="cancel-fields-btn"
-              >
-                Cancel
-              </SecondaryButton>
-            </div>
-          </FlexItem>
-          <FlexItem>
-            <div>
-              <PrimaryButton
-                disabled={loading}
-                loading={loading}
-                onClick={submitData}
-                data-testid="save-fields-btn"
-              >
-                Save
-              </PrimaryButton>
-            </div>
-          </FlexItem>
-        </Row>
-      </>
-    </>
+      <Row justify="end" gap="m">
+        <FlexItem>
+          <div>
+            <SecondaryButton
+              onClick={() => closePanel(true)}
+              data-testid="cancel-fields-btn"
+            >
+              Cancel
+            </SecondaryButton>
+          </div>
+        </FlexItem>
+        <FlexItem>
+          <div>
+            <PrimaryButton
+              disabled={loading}
+              loading={loading}
+              onClick={submitData}
+              data-testid="save-fields-btn"
+            >
+              Save
+            </PrimaryButton>
+          </div>
+        </FlexItem>
+      </Row>
+    </Col>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/hash-details/add-hash-fields/styles.module.scss
@@ -1,5 +1,4 @@
 .container {
   max-height: 234px;
   scroll-padding-bottom: 60px;
-  padding: 18px;
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/ListDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/ListDetails.tsx
@@ -17,6 +17,7 @@ import AddListElements from './add-list-elements/AddListElements'
 import { AddItemsAction, RemoveItemsAction } from '../key-details-actions'
 import { KeyDetailsSubheader } from '../key-details-subheader/KeyDetailsSubheader'
 import styles from './styles.module.scss'
+import { AddKeysContainer } from '../common/AddKeysContainer.styled'
 
 export interface Props extends KeyDetailsHeaderProps {
   onRemoveKey: () => void
@@ -82,9 +83,9 @@ const ListDetails = (props: Props) => {
           </div>
         )}
         {isAddItemPanelOpen && (
-          <div className={cx('formFooterBar', 'contentActive')}>
+          <AddKeysContainer>
             <AddListElements closePanel={closeAddItemPanel} />
-          </div>
+          </AddKeysContainer>
         )}
         {isRemoveItemPanelOpen && (
           <div className={cx('formFooterBar', styles.contentActive)}>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
@@ -16,7 +16,7 @@ import {
 import { KeyTypes } from 'uiSrc/constants'
 import { stringToBuffer } from 'uiSrc/utils'
 import { AddListFormConfig as config } from 'uiSrc/pages/browser/components/add-key/constants/fields-config'
-import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import {
   PrimaryButton,
   SecondaryButton,
@@ -122,8 +122,8 @@ const AddListElements = (props: Props) => {
   }
 
   return (
-    <>
-      <div className={styles.container}>
+    <Col gap="m">
+      <Col gap="m" className={styles.container}>
         <RiSelect
           value={destination}
           options={optionsDestinations}
@@ -147,8 +147,8 @@ const AddListElements = (props: Props) => {
             />
           )}
         </AddMultipleFields>
-      </div>
-      <Row justify="end" gap="m" style={{ padding: 18 }}>
+      </Col>
+      <Row justify="end" gap="m">
         <FlexItem>
           <div>
             <SecondaryButton
@@ -167,7 +167,7 @@ const AddListElements = (props: Props) => {
           </div>
         </FlexItem>
       </Row>
-    </>
+    </Col>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/add-list-elements/AddListElements.tsx
@@ -142,38 +142,31 @@ const AddListElements = (props: Props) => {
               id={`element-${index}`}
               placeholder={config.element.placeholder}
               value={item}
-              onChange={value =>
-                handleElementChange(value, index)
-              }
+              onChange={(value) => handleElementChange(value, index)}
               data-testid={`element-${index}`}
             />
           )}
         </AddMultipleFields>
       </div>
-      <>
-        <Row justify="end" gap="m" style={{ padding: 18 }}>
-          <FlexItem>
-            <div>
-              <SecondaryButton
-                onClick={() => closePanel(true)}
-                data-testid="cancel-members-btn"
-              >
-                Cancel
-              </SecondaryButton>
-            </div>
-          </FlexItem>
-          <FlexItem>
-            <div>
-              <PrimaryButton
-                onClick={submitData}
-                data-testid="save-elements-btn"
-              >
-                Save
-              </PrimaryButton>
-            </div>
-          </FlexItem>
-        </Row>
-      </>
+      <Row justify="end" gap="m" style={{ padding: 18 }}>
+        <FlexItem>
+          <div>
+            <SecondaryButton
+              onClick={() => closePanel(true)}
+              data-testid="cancel-members-btn"
+            >
+              Cancel
+            </SecondaryButton>
+          </div>
+        </FlexItem>
+        <FlexItem>
+          <div>
+            <PrimaryButton onClick={submitData} data-testid="save-elements-btn">
+              Save
+            </PrimaryButton>
+          </div>
+        </FlexItem>
+      </Row>
     </>
   )
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/styles.module.scss
@@ -10,5 +10,4 @@
 .container {
   max-height: 234px;
   scroll-padding-bottom: 60px;
-  padding: 18px;
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/SetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/SetDetails.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
-import cx from 'classnames'
 
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 import { KeyTypes } from 'uiSrc/constants'
@@ -13,6 +12,7 @@ import { SetDetailsTable } from './set-details-table'
 import { AddSetMembers } from './add-set-members'
 import { AddItemsAction } from '../key-details-actions'
 import { KeyDetailsSubheader } from '../key-details-subheader/KeyDetailsSubheader'
+import { AddKeysContainer } from 'uiSrc/pages/browser/modules/key-details/components/common/AddKeysContainer.styled'
 
 export interface Props extends KeyDetailsHeaderProps {
   onRemoveKey: () => void
@@ -59,9 +59,9 @@ const SetDetails = (props: Props) => {
           </div>
         )}
         {isAddItemPanelOpen && (
-          <div className={cx('formFooterBar', 'contentActive')}>
+          <AddKeysContainer>
             <AddSetMembers closePanel={closeAddItemPanel} />
-          </div>
+          </AddKeysContainer>
         )}
       </div>
     </div>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/AddSetMembers.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { ColorText } from 'uiSrc/components/base/text'
 
@@ -27,7 +27,7 @@ import {
   PrimaryButton,
   SecondaryButton,
 } from 'uiSrc/components/base/forms/buttons'
-import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { TextInput } from 'uiSrc/components/base/inputs'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
 import styles from './styles.module.scss'
@@ -134,7 +134,7 @@ const AddSetMembers = (props: Props) => {
     members.length === 1 && !item.name.length
 
   return (
-    <>
+    <Col gap="m">
       <div className={styles.container}>
         <AddMultipleFields
           items={members}
@@ -166,29 +166,27 @@ const AddSetMembers = (props: Props) => {
           )}
         </AddMultipleFields>
       </div>
-      <>
-        <Row justify="end" gap="xl" style={{ padding: 18 }}>
-          <FlexItem>
-            <SecondaryButton
-              onClick={() => closePanel(true)}
-              data-testid="cancel-members-btn"
-            >
-              <ColorText color="default">Cancel</ColorText>
-            </SecondaryButton>
-          </FlexItem>
-          <FlexItem>
-            <PrimaryButton
-              disabled={loading}
-              loading={loading}
-              onClick={submitData}
-              data-testid="save-members-btn"
-            >
-              Save
-            </PrimaryButton>
-          </FlexItem>
-        </Row>
-      </>
-    </>
+      <Row justify="end" gap="xl">
+        <FlexItem>
+          <SecondaryButton
+            onClick={() => closePanel(true)}
+            data-testid="cancel-members-btn"
+          >
+            <ColorText color="default">Cancel</ColorText>
+          </SecondaryButton>
+        </FlexItem>
+        <FlexItem>
+          <PrimaryButton
+            disabled={loading}
+            loading={loading}
+            onClick={submitData}
+            data-testid="save-members-btn"
+          >
+            Save
+          </PrimaryButton>
+        </FlexItem>
+      </Row>
+    </Col>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/set-details/add-set-members/styles.module.scss
@@ -1,5 +1,4 @@
 .container {
   max-height: 234px;
   scroll-padding-bottom: 60px;
-  padding: 18px;
 }

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/StreamDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/StreamDetails.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
-import cx from 'classnames'
 
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 import {
@@ -20,6 +19,7 @@ import AddStreamEntries from './add-stream-entity'
 import AddStreamGroup from './add-stream-group'
 import { StreamItemsAction } from '../key-details-actions'
 import { KeyDetailsSubheader } from '../key-details-subheader/KeyDetailsSubheader'
+import { AddKeysContainer } from '../common/AddKeysContainer.styled'
 
 export interface Props extends KeyDetailsHeaderProps {
   onRemoveKey: () => void
@@ -74,14 +74,14 @@ const StreamDetails = (props: Props) => {
           </div>
         )}
         {isAddItemPanelOpen && (
-          <div className={cx('formFooterBar', 'contentActive')}>
+          <AddKeysContainer>
             {streamViewType === StreamViewType.Data && (
               <AddStreamEntries closePanel={closeAddItemPanel} />
             )}
             {STREAM_ADD_GROUP_VIEW_TYPES.includes(streamViewType!) && (
               <AddStreamGroup closePanel={closeAddItemPanel} />
             )}
-          </div>
+          </AddKeysContainer>
         )}
       </div>
     </div>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/AddStreamEntries.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/AddStreamEntries.tsx
@@ -19,7 +19,7 @@ import {
   sendEventTelemetry,
   TelemetryEvent,
 } from 'uiSrc/telemetry'
-import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import {
   PrimaryButton,
   SecondaryButton,
@@ -131,7 +131,7 @@ const AddStreamEntries = (props: Props) => {
   }
 
   return (
-    <>
+    <Col gap="m">
       <div className={styles.content} data-test-subj="add-stream-field-panel">
         <StreamEntryFields
           entryIdError={entryIdError}
@@ -141,34 +141,32 @@ const AddStreamEntries = (props: Props) => {
           setFields={setFields}
         />
       </div>
-      <>
-        <Row justify="end" gap="m" style={{ padding: 18 }}>
-          <FlexItem>
-            <div>
-              <SecondaryButton
-                onClick={() => closePanel(true)}
-                data-testid="cancel-members-btn"
-              >
-                Cancel
-              </SecondaryButton>
-            </div>
-          </FlexItem>
-          <FlexItem>
-            <div>
-              <PrimaryButton
-                size="m"
-                color="secondary"
-                onClick={submitData}
-                disabled={!isFormValid}
-                data-testid="save-elements-btn"
-              >
-                Save
-              </PrimaryButton>
-            </div>
-          </FlexItem>
-        </Row>
-      </>
-    </>
+      <Row justify="end" gap="m" style={{ padding: 18 }}>
+        <FlexItem>
+          <div>
+            <SecondaryButton
+              onClick={() => closePanel(true)}
+              data-testid="cancel-members-btn"
+            >
+              Cancel
+            </SecondaryButton>
+          </div>
+        </FlexItem>
+        <FlexItem>
+          <div>
+            <PrimaryButton
+              size="m"
+              color="secondary"
+              onClick={submitData}
+              disabled={!isFormValid}
+              data-testid="save-elements-btn"
+            >
+              Save
+            </PrimaryButton>
+          </div>
+        </FlexItem>
+      </Row>
+    </Col>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/StreamEntryFields/StreamEntryFields.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/StreamEntryFields/StreamEntryFields.tsx
@@ -113,7 +113,8 @@ const StreamEntryFields = (props: Props) => {
         <FormField
           label={config.entryId.label}
           additionalText={
-            <RiTooltip
+            <Row align="center" gap="s">
+              <RiTooltip
                 anchorClassName="inputAppendIcon"
                 className={styles.entryIdTooltip}
                 position="left"
@@ -130,6 +131,17 @@ const StreamEntryFields = (props: Props) => {
               >
                 <RiIcon type="InfoIcon" style={{ cursor: 'pointer' }} />
               </RiTooltip>
+              {!showEntryError && (
+                <span className={styles.timestampText}>
+                  Timestamp - Sequence Number or *
+                </span>
+              )}
+              {showEntryError && (
+                <span className={styles.error} data-testid="stream-entry-error">
+                  {entryIdError}
+                </span>
+              )}
+            </Row>
           }
         >
           <TextInput
@@ -146,16 +158,6 @@ const StreamEntryFields = (props: Props) => {
             data-testid={config.entryId.id}
           />
         </FormField>
-        {!showEntryError && (
-          <span className={styles.timestampText}>
-            Timestamp - Sequence Number or *
-          </span>
-        )}
-        {showEntryError && (
-          <span className={styles.error} data-testid="stream-entry-error">
-            {entryIdError}
-          </span>
-        )}
       </div>
 
       <div className={styles.fieldsWrapper}>
@@ -167,7 +169,7 @@ const StreamEntryFields = (props: Props) => {
             onClickAdd={addField}
           >
             {(item, index) => (
-              <Row align="center" gap='m'>
+              <Row align="center" gap="m">
                 <FlexItem className={styles.fieldItemWrapper} grow>
                   <FormField>
                     <TextInput
@@ -175,7 +177,7 @@ const StreamEntryFields = (props: Props) => {
                       id={`fieldName-${item.id}`}
                       placeholder={config.name.placeholder}
                       value={item.name}
-                      onChange={value =>
+                      onChange={(value) =>
                         handleFieldChange('name', item.id, value)
                       }
                       ref={
@@ -194,7 +196,7 @@ const StreamEntryFields = (props: Props) => {
                       id={`fieldValue-${item.id}`}
                       placeholder={config.value.placeholder}
                       value={item.value}
-                      onChange={value =>
+                      onChange={(value) =>
                         handleFieldChange('value', item.id, value)
                       }
                       autoComplete="off"

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-entity/styles.module.scss
@@ -6,7 +6,6 @@ $rowHeight: 43px;
   width: 100%;
   border: none !important;
   border-top: 1px solid var(--euiColorPrimary);
-  padding: 12px 20px;
   max-height: 234px;
   scroll-padding-bottom: 60px;
 }
@@ -45,8 +44,6 @@ $rowHeight: 43px;
       font:
         normal normal normal 12px/18px Graphik,
         sans-serif;
-      margin-top: 6px;
-      padding-right: 6px;
     }
   }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-group/AddStreamGroup.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-group/AddStreamGroup.tsx
@@ -12,7 +12,7 @@ import {
   validateConsumerGroupId,
 } from 'uiSrc/utils'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
-import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import {
   PrimaryButton,
   SecondaryButton,
@@ -86,7 +86,7 @@ const AddStreamGroup = (props: Props) => {
   const showIdError = !isIdFocused && idError
 
   return (
-    <>
+    <Col gap="m">
       <div
         className={styles.content}
         data-test-subj="add-stream-groups-field-panel"
@@ -95,19 +95,17 @@ const AddStreamGroup = (props: Props) => {
           className={cx('flexItemNoFullWidth', 'inlineFieldsNoSpace')}
           grow
         >
-          <Row>
+          <Row gap="m">
             <FlexItem grow>
-              <Row align="start">
-                <FlexItem className={styles.groupNameWrapper} grow>
+              <Row align="start" gap="m">
+                <FlexItem grow={2}>
                   <FormField>
                     <TextInput
                       name="group-name"
                       id="group-name"
                       placeholder="Enter Group Name*"
                       value={groupName}
-                      onChange={value =>
-                        setGroupName(value)
-                      }
+                      onChange={(value) => setGroupName(value)}
                       autoComplete="off"
                       data-testid="group-name-field"
                     />
@@ -116,19 +114,34 @@ const AddStreamGroup = (props: Props) => {
                 <FlexItem className={styles.timestampWrapper} grow>
                   <FormField
                     additionalText={
-                      <RiTooltip
-                        anchorClassName="inputAppendIcon"
-                        className={styles.entryIdTooltip}
-                        position="left"
-                        title="Enter Valid ID, 0 or $"
-                        content={lastDeliveredIDTooltipText}
-                      >
-                        <RiIcon
-                          type="InfoIcon"
-                          style={{ cursor: 'pointer' }}
-                          data-testid="entry-id-info-icon"
-                        />
-                      </RiTooltip>
+                      <Row align="center" gap="s">
+                        <RiTooltip
+                          anchorClassName="inputAppendIcon"
+                          className={styles.entryIdTooltip}
+                          position="left"
+                          title="Enter Valid ID, 0 or $"
+                          content={lastDeliveredIDTooltipText}
+                        >
+                          <RiIcon
+                            type="InfoIcon"
+                            style={{ cursor: 'pointer' }}
+                            data-testid="entry-id-info-icon"
+                          />
+                        </RiTooltip>
+                        {!showIdError && (
+                          <span
+                            className={styles.idText}
+                            data-testid="id-help-text"
+                          >
+                            Timestamp - Sequence Number or $
+                          </span>
+                        )}
+                        {showIdError && (
+                          <span className={styles.error} data-testid="id-error">
+                            {idError}
+                          </span>
+                        )}
+                      </Row>
                     }
                   >
                     <TextInput
@@ -136,7 +149,7 @@ const AddStreamGroup = (props: Props) => {
                       id="id"
                       placeholder="ID*"
                       value={id}
-                      onChange={value =>
+                      onChange={(value) =>
                         setId(validateConsumerGroupId(value))
                       }
                       onBlur={() => setIsIdFocused(false)}
@@ -145,48 +158,36 @@ const AddStreamGroup = (props: Props) => {
                       data-testid="id-field"
                     />
                   </FormField>
-                  {!showIdError && (
-                    <span className={styles.idText} data-testid="id-help-text">
-                      Timestamp - Sequence Number or $
-                    </span>
-                  )}
-                  {showIdError && (
-                    <span className={styles.error} data-testid="id-error">
-                      {idError}
-                    </span>
-                  )}
                 </FlexItem>
               </Row>
             </FlexItem>
           </Row>
         </FlexItem>
       </div>
-      <>
-        <Row justify="end" gap="l" style={{ padding: 18 }}>
-          <FlexItem>
-            <div>
-              <SecondaryButton
-                onClick={() => closePanel(true)}
-                data-testid="cancel-stream-groups-btn"
-              >
-                Cancel
-              </SecondaryButton>
-            </div>
-          </FlexItem>
-          <FlexItem>
-            <div>
-              <PrimaryButton
-                onClick={submitData}
-                disabled={!isFormValid}
-                data-testid="save-groups-btn"
-              >
-                Save
-              </PrimaryButton>
-            </div>
-          </FlexItem>
-        </Row>
-      </>
-    </>
+      <Row justify="end" gap="l" style={{ padding: 18 }}>
+        <FlexItem>
+          <div>
+            <SecondaryButton
+              onClick={() => closePanel(true)}
+              data-testid="cancel-stream-groups-btn"
+            >
+              Cancel
+            </SecondaryButton>
+          </div>
+        </FlexItem>
+        <FlexItem>
+          <div>
+            <PrimaryButton
+              onClick={submitData}
+              disabled={!isFormValid}
+              data-testid="save-groups-btn"
+            >
+              Save
+            </PrimaryButton>
+          </div>
+        </FlexItem>
+      </Row>
+    </Col>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-group/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/add-stream-group/styles.module.scss
@@ -4,7 +4,6 @@
   width: 100%;
   border: none !important;
   border-top: 1px solid var(--euiColorPrimary);
-  padding: 12px 20px;
   max-height: 234px;
   scroll-padding-bottom: 30px;
 
@@ -20,8 +19,6 @@
     display: inline-block;
     color: var(--euiColorMediumShade);
     font: normal normal normal 12px/18px Graphik, sans-serif;
-    margin-top: 6px;
-    padding-right: 6px;
   }
 
   .error {

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/ZSetDetails.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/ZSetDetails.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
-import cx from 'classnames'
 
 import { selectedKeySelector } from 'uiSrc/slices/browser/keys'
 import { KeyTypes } from 'uiSrc/constants'
@@ -14,6 +13,7 @@ import { ZSetDetailsTable } from './zset-details-table'
 import AddZsetMembers from './add-zset-members/AddZsetMembers'
 import { AddItemsAction } from '../key-details-actions'
 import { KeyDetailsSubheader } from '../key-details-subheader/KeyDetailsSubheader'
+import { AddKeysContainer } from '../common/AddKeysContainer.styled'
 
 export interface Props extends KeyDetailsHeaderProps {
   onRemoveKey: () => void
@@ -66,9 +66,9 @@ const ZSetDetails = (props: Props) => {
           </FlexItem>
         )}
         {isAddItemPanelOpen && (
-          <div className={cx('formFooterBar', 'contentActive')}>
+          <AddKeysContainer>
             <AddZsetMembers closePanel={closeAddItemPanel} />
-          </div>
+          </AddKeysContainer>
         )}
       </FlexItem>
     </Col>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/AddZsetMembers.tsx
@@ -19,7 +19,7 @@ import {
 import AddMultipleFields from 'uiSrc/pages/browser/components/add-multiple-fields'
 import { ISetMemberState } from 'uiSrc/pages/browser/components/add-key/AddKeySet/interfaces'
 
-import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { Col, FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import {
   PrimaryButton,
   SecondaryButton,
@@ -175,7 +175,7 @@ const AddZsetMembers = (props: Props) => {
     members.length === 1 && !(item.name.length || item.score.length)
 
   return (
-    <>
+    <Col gap="m">
       <div className={styles.container}>
         <AddMultipleFields
           items={members}
@@ -184,7 +184,7 @@ const AddZsetMembers = (props: Props) => {
           onClickAdd={addMember}
         >
           {(item, index) => (
-            <Row align="center">
+            <Row align="center" gap="m">
               <FlexItem grow>
                 <FormField>
                   <TextInput
@@ -192,7 +192,7 @@ const AddZsetMembers = (props: Props) => {
                     id={`member-${item.id}`}
                     placeholder={config.member.placeholder}
                     value={item.name}
-                    onChange={value =>
+                    onChange={(value) =>
                       handleMemberChange('name', item.id, value)
                     }
                     ref={
@@ -211,7 +211,7 @@ const AddZsetMembers = (props: Props) => {
                     maxLength={200}
                     placeholder={config.score.placeholder}
                     value={item.score}
-                    onChange={value =>
+                    onChange={(value) =>
                       handleMemberChange('score', item.id, value)
                     }
                     onBlur={() => {
@@ -226,33 +226,31 @@ const AddZsetMembers = (props: Props) => {
           )}
         </AddMultipleFields>
       </div>
-      <>
-        <Row justify="end" gap="l" style={{ padding: 18 }}>
-          <FlexItem>
-            <div>
-              <SecondaryButton
-                onClick={() => closePanel(true)}
-                data-testid="cancel-members-btn"
-              >
-                Cancel
-              </SecondaryButton>
-            </div>
-          </FlexItem>
-          <FlexItem>
-            <div>
-              <PrimaryButton
-                disabled={loading || !isFormValid}
-                loading={loading}
-                onClick={submitData}
-                data-testid="save-members-btn"
-              >
-                Save
-              </PrimaryButton>
-            </div>
-          </FlexItem>
-        </Row>
-      </>
-    </>
+      <Row justify="end" gap="l">
+        <FlexItem>
+          <div>
+            <SecondaryButton
+              onClick={() => closePanel(true)}
+              data-testid="cancel-members-btn"
+            >
+              Cancel
+            </SecondaryButton>
+          </div>
+        </FlexItem>
+        <FlexItem>
+          <div>
+            <PrimaryButton
+              disabled={loading || !isFormValid}
+              loading={loading}
+              onClick={submitData}
+              data-testid="save-members-btn"
+            >
+              Save
+            </PrimaryButton>
+          </div>
+        </FlexItem>
+      </Row>
+    </Col>
   )
 }
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/zset-details/add-zset-members/styles.module.scss
@@ -1,5 +1,4 @@
 .container {
   max-height: 234px;
   scroll-padding-bottom: 60px;
-  padding: 18px;
 }


### PR DESCRIPTION
Fix styling of add key for multi key types

Before:
<img width="1216" height="1069" alt="image" src="https://github.com/user-attachments/assets/9637d916-329a-4ef0-8e7c-dd150598e376" />
<img width="914" height="631" alt="image" src="https://github.com/user-attachments/assets/43b063b1-118b-4c7d-8906-c231cfd834c4" />
<img width="905" height="634" alt="image" src="https://github.com/user-attachments/assets/84dd0d4b-e796-4762-9d2e-156d32755852" />
<img width="899" height="620" alt="image" src="https://github.com/user-attachments/assets/f5bb090c-bc5a-4346-9544-1c3de7f90697" />
<img width="886" height="376" alt="image" src="https://github.com/user-attachments/assets/170b18dd-160c-401c-b1cb-fc248c0c48d1" />

After:
<img width="1226" height="243" alt="image" src="https://github.com/user-attachments/assets/9a7c8a02-03d2-4731-9ef3-f825db3416f7" />
<img width="1248" height="296" alt="image" src="https://github.com/user-attachments/assets/b1d72686-1455-4920-accb-42196ed1e0a4" />
<img width="1214" height="1060" alt="image" src="https://github.com/user-attachments/assets/1b8b0fa9-89eb-4da9-a06f-b7e0e7854f90" />
<img width="1225" height="1062" alt="image" src="https://github.com/user-attachments/assets/7d489fbd-798c-4dda-be01-d9250944ab79" />
<img width="1226" height="1096" alt="image" src="https://github.com/user-attachments/assets/9a227f51-49fc-4e57-8736-90102f28d1e2" />
<img width="1217" height="1052" alt="image" src="https://github.com/user-attachments/assets/d1996b93-1d45-4ba3-be21-8f20538e4811" />
