### PR TITLE
RI-7311 Resolve issue with disappearing changes in the RDI pipeline jobs

### DIFF
--- a/redisinsight/ui/src/pages/rdi/pipeline-management/PipelineManagementPageRouter.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/PipelineManagementPageRouter.tsx
@@ -9,8 +9,7 @@ export interface Props {
 const PipelineManagementPageRouter = ({ routes }: Props) => (
   <Switch>
     {routes.map((route, i) => (
-      // eslint-disable-next-line react/no-array-index-key
-      <RouteWithSubRoutes key={i} {...route} />
+      <RouteWithSubRoutes key={`pipeline-management-route-${i}`} {...route} />
     ))}
   </Switch>
 )

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.spec.tsx
@@ -7,7 +7,7 @@ import {
   rdiPipelineSelector,
   setChangedFile,
   deleteChangedFile,
-  setPipelineJobs,
+  updatePipelineJob,
 } from 'uiSrc/slices/rdi/pipeline'
 import {
   act,
@@ -121,56 +121,71 @@ describe('Job', () => {
   })
 
   it('should not call any updated file action if there is no deployed job', () => {
-    render(<Job {...instance(mockedProps)} name="jobName" />)
+    const mockJob = {
+      name: 'jobName',
+      value: '123',
+    }
+
+    render(<Job {...instance(mockedProps)} name={mockJob.name} />)
 
     const fieldName = screen.getByTestId('rdi-monaco-job')
-    fireEvent.change(fieldName, { target: { value: '123' } })
+    fireEvent.change(fieldName, { target: { value: mockJob.value } })
 
     const expectedActions = [
       getPipelineStrategies(),
-      setPipelineJobs(expect.any(Array)),
+      updatePipelineJob(mockJob),
     ]
 
     expect(store.getActions()).toEqual(expectedActions)
   })
 
   it('should set modified file', () => {
+    const mockJob = {
+      name: 'jobName',
+      value: '123',
+    }
+
     render(
       <Job
         {...instance(mockedProps)}
-        deployedJobValue="value"
-        name="jobName"
+        deployedJobValue={mockJob.value}
+        name={mockJob.name}
       />,
     )
 
     const fieldName = screen.getByTestId('rdi-monaco-job')
-    fireEvent.change(fieldName, { target: { value: '123' } })
+    fireEvent.change(fieldName, { target: { value: 'updated' } })
 
     const expectedActions = [
       getPipelineStrategies(),
-      setPipelineJobs(expect.any(Array)),
-      setChangedFile({ name: 'jobName', status: FileChangeType.Modified }),
+      updatePipelineJob({ name: mockJob.name, value: 'updated' }),
+      setChangedFile({ name: mockJob.name, status: FileChangeType.Modified }),
     ]
 
     expect(store.getActions()).toEqual(expectedActions)
   })
 
   it('should remove job from modified files', () => {
+    const mockJob = {
+      name: 'jobName',
+      value: '123',
+    }
+
     render(
       <Job
         {...instance(mockedProps)}
-        deployedJobValue="value"
-        name="jobName"
+        deployedJobValue={mockJob.value}
+        name={mockJob.name}
       />,
     )
 
     const fieldName = screen.getByTestId('rdi-monaco-job')
-    fireEvent.change(fieldName, { target: { value: 'value' } })
+    fireEvent.change(fieldName, { target: { value: mockJob.value } })
 
     const expectedActions = [
       getPipelineStrategies(),
-      setPipelineJobs(expect.any(Array)),
-      deleteChangedFile('jobName'),
+      updatePipelineJob(mockJob),
+      deleteChangedFile(mockJob.name),
     ]
 
     expect(store.getActions()).toEqual(expectedActions)
@@ -276,8 +291,8 @@ describe('Job', () => {
         properties: {
           source: { type: 'object' },
           transform: { type: 'object' },
-          output: { type: 'object' }
-        }
+          output: { type: 'object' },
+        },
       }
 
       const rdiPipelineSelectorMock = jest.fn().mockReturnValue({
@@ -288,15 +303,17 @@ describe('Job', () => {
         jobs: [
           {
             name: 'testJob',
-            value: 'test-value'
-          }
+            value: 'test-value',
+          },
         ],
       })
       ;(rdiPipelineSelector as jest.Mock).mockImplementation(
         rdiPipelineSelectorMock,
       )
 
-      render(<Job {...instance(mockedProps)} name="testJob" value="test-value" />)
+      render(
+        <Job {...instance(mockedProps)} name="testJob" value="test-value" />,
+      )
 
       // Verify the component renders and doesn't crash with schema
       expect(screen.getByTestId('rdi-monaco-job')).toBeInTheDocument()
@@ -311,15 +328,17 @@ describe('Job', () => {
         jobs: [
           {
             name: 'testJob',
-            value: 'test-value'
-          }
+            value: 'test-value',
+          },
         ],
       })
       ;(rdiPipelineSelector as jest.Mock).mockImplementation(
         rdiPipelineSelectorMock,
       )
 
-      render(<Job {...instance(mockedProps)} name="testJob" value="test-value" />)
+      render(
+        <Job {...instance(mockedProps)} name="testJob" value="test-value" />,
+      )
 
       // Verify the component renders without issues when schema is empty
       expect(screen.getByTestId('rdi-monaco-job')).toBeInTheDocument()
@@ -334,15 +353,17 @@ describe('Job', () => {
         jobs: [
           {
             name: 'testJob',
-            value: 'test-value'
-          }
+            value: 'test-value',
+          },
         ],
       })
       ;(rdiPipelineSelector as jest.Mock).mockImplementation(
         rdiPipelineSelectorMock,
       )
 
-      render(<Job {...instance(mockedProps)} name="testJob" value="test-value" />)
+      render(
+        <Job {...instance(mockedProps)} name="testJob" value="test-value" />,
+      )
 
       // Verify the component renders without issues when schema is undefined
       expect(screen.getByTestId('rdi-monaco-job')).toBeInTheDocument()
@@ -358,9 +379,9 @@ describe('Job', () => {
             properties: {
               server_name: { type: 'string' },
               schema: { type: 'string' },
-              table: { type: 'string' }
+              table: { type: 'string' },
             },
-            required: ['server_name', 'schema', 'table']
+            required: ['server_name', 'schema', 'table'],
           },
           transform: {
             type: 'array',
@@ -368,9 +389,9 @@ describe('Job', () => {
               type: 'object',
               properties: {
                 uses: { type: 'string' },
-                with: { type: 'object' }
-              }
-            }
+                with: { type: 'object' },
+              },
+            },
           },
           output: {
             type: 'array',
@@ -378,12 +399,12 @@ describe('Job', () => {
               type: 'object',
               properties: {
                 uses: { type: 'string' },
-                with: { type: 'object' }
-              }
-            }
-          }
+                with: { type: 'object' },
+              },
+            },
+          },
         },
-        required: ['source']
+        required: ['source'],
       }
 
       const rdiPipelineSelectorMock = jest.fn().mockReturnValue({
@@ -393,15 +414,21 @@ describe('Job', () => {
         jobs: [
           {
             name: 'complexJob',
-            value: 'source:\n  server_name: test'
-          }
+            value: 'source:\n  server_name: test',
+          },
         ],
       })
       ;(rdiPipelineSelector as jest.Mock).mockImplementation(
         rdiPipelineSelectorMock,
       )
 
-      render(<Job {...instance(mockedProps)} name="complexJob" value="source:\n  server_name: test" />)
+      render(
+        <Job
+          {...instance(mockedProps)}
+          name="complexJob"
+          value="source:\n  server_name: test"
+        />,
+      )
 
       // Verify the component renders with complex schema structure
       expect(screen.getByTestId('rdi-monaco-job')).toBeInTheDocument()

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.tsx
@@ -12,6 +12,7 @@ import {
   rdiPipelineSelector,
   setChangedFile,
   setPipelineJobs,
+  updatePipelineJob,
 } from 'uiSrc/slices/rdi/pipeline'
 import { FileChangeType } from 'uiSrc/slices/interfaces'
 import MonacoYaml from 'uiSrc/components/monaco-editor/components/monaco-yaml'
@@ -125,13 +126,7 @@ const Job = (props: Props) => {
   )
 
   const handleChange = (value: string) => {
-    const newJobs = jobs.map((job, index) => {
-      if (index === jobIndexRef.current) {
-        return { ...job, value }
-      }
-      return job
-    })
-    dispatch(setPipelineJobs(newJobs))
+    dispatch(updatePipelineJob({ name: jobNameRef.current, value }))
     checkIsFileUpdated(value)
   }
 

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/JobsWrapper.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/JobsWrapper.spec.tsx
@@ -10,6 +10,7 @@ import {
   rdiPipelineSelector,
   setChangedFile,
   setPipelineJobs,
+  updatePipelineJob,
 } from 'uiSrc/slices/rdi/pipeline'
 import {
   cleanup,
@@ -26,8 +27,6 @@ import {
 } from 'uiSrc/telemetry'
 import {
   MOCK_RDI_PIPELINE_CONFIG,
-  MOCK_RDI_PIPELINE_DATA,
-  MOCK_RDI_PIPELINE_JOB1,
   MOCK_RDI_PIPELINE_JOB2,
 } from 'uiSrc/mocks/data/rdi'
 import { FileChangeType } from 'uiSrc/slices/interfaces'
@@ -189,7 +188,7 @@ describe('JobWrapper', () => {
 
     const expectedActions = [
       getPipelineStrategies(),
-      setPipelineJobs(expect.any(Array)),
+      updatePipelineJob({ name: 'jobName', value: '123' }),
       setChangedFile({ name: 'jobName', status: FileChangeType.Modified }),
     ]
 
@@ -214,7 +213,7 @@ describe('JobWrapper', () => {
 
     const expectedActions = [
       getPipelineStrategies(),
-      setPipelineJobs([{ name: 'jobName', value: '123' }]),
+      updatePipelineJob({ name: 'jobName', value: '123' }),
       deleteChangedFile('jobName'),
     ]
 

--- a/redisinsight/ui/src/slices/tests/rdi/pipeline.spec.ts
+++ b/redisinsight/ui/src/slices/tests/rdi/pipeline.spec.ts
@@ -9,6 +9,8 @@ import {
 } from 'uiSrc/utils/test-utils'
 import {
   MOCK_RDI_PIPELINE_DATA,
+  MOCK_RDI_PIPELINE_JOB1,
+  MOCK_RDI_PIPELINE_JOB2,
   MOCK_RDI_PIPELINE_JSON_DATA,
   MOCK_RDI_PIPELINE_STATUS_DATA,
 } from 'uiSrc/mocks/data/rdi'
@@ -52,6 +54,7 @@ import reducer, {
   setPipelineJobs,
   setMonacoJobsSchema,
   setJobNameSchema,
+  updatePipelineJob,
 } from 'uiSrc/slices/rdi/pipeline'
 import { apiService } from 'uiSrc/services'
 import {
@@ -63,6 +66,7 @@ import { INFINITE_MESSAGES } from 'uiSrc/components/notifications/components'
 import { FileChangeType, PipelineAction } from 'uiSrc/slices/interfaces'
 import { parseJMESPathFunctions } from 'uiSrc/utils'
 import successMessages from 'uiSrc/components/notifications/success-messages'
+import { value } from 'jsonpath'
 
 let store: typeof mockedStore
 
@@ -176,6 +180,41 @@ describe('rdi pipe slice', () => {
         },
       })
       expect(rdiPipelineSelector(rootState)).toEqual(state)
+    })
+  })
+
+  describe('updatePipelineJob', () => {
+    it('should properly update job by name', () => {
+      // Arrange - preload state with existing jobs
+      const baseState = {
+        ...initialState,
+        jobs: MOCK_RDI_PIPELINE_DATA.jobs,
+      }
+
+      const expectedState = {
+        ...initialState,
+        jobs: [
+          MOCK_RDI_PIPELINE_JOB1,
+          { ...MOCK_RDI_PIPELINE_JOB2, value: 'newValue2' },
+        ],
+      }
+
+      // Act - update second job value
+      const nextState = reducer(
+        baseState,
+        updatePipelineJob({
+          name: MOCK_RDI_PIPELINE_JOB2.name,
+          value: 'newValue2',
+        }),
+      )
+
+      // Assert
+      const rootState = Object.assign(initialStateDefault, {
+        rdi: {
+          pipeline: nextState,
+        },
+      })
+      expect(rdiPipelineSelector(rootState)).toEqual(expectedState)
     })
   })
 
@@ -864,19 +903,19 @@ describe('rdi pipe slice', () => {
             properties: {
               name: {
                 type: 'string',
-                pattern: '^[a-zA-Z][a-zA-Z0-9_]*$'
+                pattern: '^[a-zA-Z][a-zA-Z0-9_]*$',
               },
               source: {
                 type: 'object',
                 properties: {
                   server_name: { type: 'string' },
                   schema: { type: 'string' },
-                  table: { type: 'string' }
-                }
-              }
+                  table: { type: 'string' },
+                },
+              },
             },
-            required: ['name', 'source']
-          }
+            required: ['name', 'source'],
+          },
         }
         const responsePayload = { data, status: 200 }
 
@@ -894,16 +933,16 @@ describe('rdi pipe slice', () => {
               properties: {
                 server_name: { type: 'string' },
                 schema: { type: 'string' },
-                table: { type: 'string' }
-              }
-            }
+                table: { type: 'string' },
+              },
+            },
           },
-          required: ['source'] // 'name' is filtered out
+          required: ['source'], // 'name' is filtered out
         }
 
         const expectedJobNameSchema = {
           type: 'string',
-          pattern: '^[a-zA-Z][a-zA-Z0-9_]*$'
+          pattern: '^[a-zA-Z][a-zA-Z0-9_]*$',
         }
 
         const expectedActions = [
@@ -922,10 +961,10 @@ describe('rdi pipe slice', () => {
             type: 'object',
             properties: {
               source: { type: 'object' },
-              transform: { type: 'array' }
+              transform: { type: 'array' },
             },
-            required: ['source', 'transform']
-          }
+            required: ['source', 'transform'],
+          },
         }
         const responsePayload = { data, status: 200 }
 
@@ -939,9 +978,9 @@ describe('rdi pipe slice', () => {
           type: 'object',
           properties: {
             source: { type: 'object' },
-            transform: { type: 'array' }
+            transform: { type: 'array' },
           },
-          required: ['source', 'transform']
+          required: ['source', 'transform'],
         }
 
         const expectedActions = [
@@ -956,7 +995,7 @@ describe('rdi pipe slice', () => {
       it('succeed to fetch data with empty jobs schema', async () => {
         const data = {
           config: 'string',
-          jobs: {}
+          jobs: {},
         }
         const responsePayload = { data, status: 200 }
 


### PR DESCRIPTION
# Description

Make sure to preserve the changes entered in the editor of the different RDI pipeline jobs when switching between them
- introduce a new Redux action to update a single Pipeline Job

https://github.com/user-attachments/assets/378ecf52-dc01-4020-af2b-30d4b357cd08

## Root Cause Analysis

The issue that we observed was related to the fact that we lose the changes of the users when they toggle between the different pipeline jobs. It was caused by a stale Redux update, which was the cause of the lost changes. What we had in place was a complex Redux action that was updating all the jobs once we entered changes in the text editor. 

As a solution, I have introduced a new, simpler redux action that is meant to update the value of a single pipeline job (when you enter changes in the editor), instead of providing all jobs, updating them at the same time, and having this side effect of missing information.

# How it was tested

1. Open Redis Insight and click on the "**Redis Data Integration**" tab from the top navbar
2. Click on the "**+ Endpoint**" button below the top navbar, fill in the form, and submit it to add a new RDI endpoint
3. Click on the newly added instance from the list of existing endpoints to reach the **Pipeline Management** screen
4. Add a new transformation job, fill in some info in the text editor
5. Click on another existing job, fill in some info in the text editor
6. Go back to the previous job and see if the info you just entered (step 4) is still there

Basically, from now on, toggling between the different jobs should preserve the changes you enter in the editor.