### PR TITLE
RI-7366: Saved Queries - show empty message when no indexes are available

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/create-index/VectorSearchCreateIndex.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/create-index/VectorSearchCreateIndex.spec.tsx
@@ -16,7 +16,12 @@ import {
   VectorSearchCreateIndex,
   VectorSearchCreateIndexProps,
 } from './VectorSearchCreateIndex'
-import { SampleDataContent, SampleDataType, SearchIndexType } from './types'
+import {
+  PresetDataType,
+  SampleDataContent,
+  SampleDataType,
+  SearchIndexType,
+} from './types'
 import { useCreateIndex } from './hooks/useCreateIndex'
 
 // Mock the telemetry module, so we don't send actual telemetry data during tests
@@ -93,7 +98,7 @@ describe('VectorSearchCreateIndex', () => {
     expect(pushMock).toHaveBeenCalledWith(
       Pages.vectorSearch(INSTANCE_ID_MOCK),
       {
-        openSavedQueriesPanel: true,
+        defaultSavedQueriesIndex: PresetDataType.BIKES,
       },
     )
   })

--- a/redisinsight/ui/src/pages/vector-search/create-index/VectorSearchCreateIndex.tsx
+++ b/redisinsight/ui/src/pages/vector-search/create-index/VectorSearchCreateIndex.tsx
@@ -98,7 +98,7 @@ export const VectorSearchCreateIndex = ({
       dispatch(addMessageNotification(successMessages.CREATE_INDEX()))
 
       history.push(Pages.vectorSearch(instanceId), {
-        openSavedQueriesPanel: true,
+        defaultSavedQueriesIndex: createSearchIndexParameters.indexName,
       })
     }
   }, [success, error])

--- a/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesList.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesList.spec.tsx
@@ -93,10 +93,7 @@ describe('ManageIndexesList', () => {
   })
 
   it('should render indexes boxes when data is available', () => {
-    const mockIndexes = [
-      Buffer.from('test-index-1'),
-      Buffer.from('test-index-2'),
-    ]
+    const mockIndexes = ['test-index-1', 'test-index-2']
 
     mockedRedisearchListSelector.mockReturnValue({
       data: mockIndexes,

--- a/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesList.tsx
+++ b/redisinsight/ui/src/pages/vector-search/manage-indexes/ManageIndexesList.tsx
@@ -1,14 +1,13 @@
 import { Loader } from '@redis-ui/components'
 import React from 'react'
 
-import { bufferToString } from 'uiSrc/utils'
 import { StyledManageIndexesListAction } from './ManageIndexesList.styles'
 import { IndexSection } from './IndexSection'
 import { useRedisearchListData } from '../useRedisearchListData'
 import NoIndexesMessage from './NoIndexesMessage'
 
 export const ManageIndexesList = () => {
-  const { data, loading } = useRedisearchListData()
+  const { stringData: data, loading } = useRedisearchListData()
   const hasIndexes = !!data?.length
 
   return (
@@ -18,7 +17,7 @@ export const ManageIndexesList = () => {
       {!loading && !hasIndexes && <NoIndexesMessage />}
 
       {data.map((index) => (
-        <IndexSection index={index} key={`index-${bufferToString(index)}`} />
+        <IndexSection index={index} key={`index-${index}`} />
       ))}
     </StyledManageIndexesListAction>
   )

--- a/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage.tsx
+++ b/redisinsight/ui/src/pages/vector-search/pages/VectorSearchPage.tsx
@@ -11,7 +11,7 @@ type Params = {
   instanceId: string
 }
 type LocationState = {
-  openSavedQueriesPanel: boolean
+  defaultSavedQueriesIndex?: string
 }
 
 const VectorSearchPage = () => {
@@ -30,7 +30,7 @@ const VectorSearchPage = () => {
     <VectorSearchPageWrapper>
       <VectorSearchQuery
         instanceId={instanceId}
-        openSavedQueriesPanel={state?.openSavedQueriesPanel}
+        defaultSavedQueriesIndex={state?.defaultSavedQueriesIndex}
       />
     </VectorSearchPageWrapper>
   )

--- a/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.spec.tsx
@@ -26,7 +26,7 @@ jest.mock('uiSrc/slices/browser/redisearch', () => ({
 
 const DEFAULT_PROPS: VectorSearchQueryProps = {
   instanceId: INSTANCE_ID_MOCK,
-  openSavedQueriesPanel: false,
+  defaultSavedQueriesIndex: undefined,
 }
 
 const renderVectorSearchQueryComponent = (
@@ -55,7 +55,7 @@ describe('VectorSearchQuery', () => {
   it('can close the Saved Queries screen', () => {
     renderVectorSearchQueryComponent({
       ...DEFAULT_PROPS,
-      openSavedQueriesPanel: true,
+      defaultSavedQueriesIndex: faker.string.uuid(),
     })
 
     // Verify the saved queries screen is open by default

--- a/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.spec.tsx
@@ -12,6 +12,18 @@ jest.mock('uiSrc/telemetry', () => ({
   sendEventTelemetry: jest.fn(),
 }))
 
+jest.mock('uiSrc/slices/browser/redisearch', () => ({
+  ...jest.requireActual('uiSrc/slices/browser/redisearch'),
+  redisearchListSelector: jest.fn().mockReturnValue({
+    data: [Buffer.from('idx:bikes_vss')],
+    loading: false,
+    error: '',
+  }),
+  fetchRedisearchListAction: jest
+    .fn()
+    .mockReturnValue({ type: 'FETCH_REDISEARCH_LIST' }),
+}))
+
 const DEFAULT_PROPS: VectorSearchQueryProps = {
   instanceId: INSTANCE_ID_MOCK,
   openSavedQueriesPanel: false,

--- a/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
@@ -32,12 +32,12 @@ enum RightPanelType {
 
 export type VectorSearchQueryProps = {
   instanceId: string
-  openSavedQueriesPanel?: boolean
+  defaultSavedQueriesIndex?: string
 }
 
 export const VectorSearchQuery = ({
   instanceId,
-  openSavedQueriesPanel = false,
+  defaultSavedQueriesIndex,
 }: VectorSearchQueryProps) => {
   const {
     query,
@@ -60,7 +60,7 @@ export const VectorSearchQuery = ({
   } = useQuery()
 
   const [rightPanel, setRightPanel] = useState<RightPanelType | null>(
-    openSavedQueriesPanel ? RightPanelType.SAVED_QUERIES : null,
+    defaultSavedQueriesIndex ? RightPanelType.SAVED_QUERIES : null,
   )
   const isSavedQueriesOpen = rightPanel === RightPanelType.SAVED_QUERIES
 
@@ -197,6 +197,7 @@ export const VectorSearchQuery = ({
                 {rightPanel === RightPanelType.SAVED_QUERIES && (
                   <SavedQueriesScreen
                     instanceId={instanceId}
+                    defaultSavedQueriesIndex={defaultSavedQueriesIndex}
                     onQueryInsert={handleQueryInsert}
                     onClose={closeRightPanel}
                   />

--- a/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
@@ -14,10 +14,7 @@ import CommandsViewWrapper from '../components/commands-view'
 import { VectorSearchScreenWrapper } from '../styles'
 import { SavedQueriesScreen } from '../saved-queries/SavedQueriesScreen'
 import { ManageIndexesScreen } from '../manage-indexes/ManageIndexesScreen'
-import { SavedIndex } from '../saved-queries/types'
-import { PresetDataType } from '../create-index/types'
 import {
-  collectChangedSavedQueryIndexTelemetry,
   collectInsertSavedQueryTelemetry,
   collectTelemetryQueryClear,
   collectTelemetryQueryClearAll,
@@ -27,23 +24,6 @@ import {
   ViewMode,
   ViewModeContextProvider,
 } from 'uiSrc/components/query/context/view-mode.context'
-
-const mockSavedIndexes: SavedIndex[] = [
-  {
-    value: PresetDataType.BIKES,
-    tags: ['tag', 'text', 'vector'],
-    queries: [
-      {
-        label: 'Search for "Nord" bikes ordered by price',
-        value: 'FT.SEARCH idx:bikes_vss "@brand:Nord" SORTBY price ASC',
-      },
-      {
-        label: 'Find road alloy bikes under 20kg',
-        value: 'FT.SEARCH idx:bikes_vss "@material:{alloy} @weight:[0 20]"',
-      },
-    ],
-  },
-]
 
 enum RightPanelType {
   SAVED_QUERIES = 'saved-queries',
@@ -83,10 +63,6 @@ export const VectorSearchQuery = ({
     openSavedQueriesPanel ? RightPanelType.SAVED_QUERIES : null,
   )
   const isSavedQueriesOpen = rightPanel === RightPanelType.SAVED_QUERIES
-  const [queryIndex, setQueryIndex] = useState(mockSavedIndexes[0].value)
-  const selectedIndex = mockSavedIndexes.find(
-    (index) => index.value === queryIndex,
-  )
 
   const onQuerySubmit = () => {
     onSubmit()
@@ -105,14 +81,6 @@ export const VectorSearchQuery = ({
 
   const onQueryClear = () => {
     collectTelemetryQueryClear({ instanceId })
-  }
-
-  const handleIndexChange = (value: string) => {
-    setQueryIndex(value)
-
-    collectChangedSavedQueryIndexTelemetry({
-      instanceId,
-    })
   }
 
   const handleQueryInsert = (query: string) => {
@@ -228,10 +196,8 @@ export const VectorSearchQuery = ({
 
                 {rightPanel === RightPanelType.SAVED_QUERIES && (
                   <SavedQueriesScreen
-                    onIndexChange={handleIndexChange}
+                    instanceId={instanceId}
                     onQueryInsert={handleQueryInsert}
-                    savedIndexes={mockSavedIndexes}
-                    selectedIndex={selectedIndex}
                     onClose={closeRightPanel}
                   />
                 )}

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/IndexSelect.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/IndexSelect.spec.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+
+import { IndexSelect } from './IndexSelect'
+
+// Mock RiSelect to a simple native select so we can simulate change easily
+jest.mock('uiSrc/components/base/forms/select/RiSelect', () => {
+  const React = require('react')
+  return {
+    RiSelect: ({ options, value, onChange, ...rest }: any) =>
+      React.createElement(
+        'select',
+        {
+          'data-testid': 'select-saved-index',
+          value,
+          onChange: (e: any) => onChange(e.target.value),
+          ...rest,
+        },
+        options?.map((o: any) =>
+          React.createElement(
+            'option',
+            { key: o.value, value: o.value },
+            o.value,
+          ),
+        ),
+      ),
+  }
+})
+
+const mockIndexes = [
+  { value: 'idx:bikes_vss', tags: ['tag', 'text'], queries: [] },
+  { value: 'idx:restaurants_vss', tags: ['vector'], queries: [] },
+]
+
+describe('IndexSelect', () => {
+  it('renders label and select', () => {
+    const onIndexChange = jest.fn()
+    const { container } = render(
+      <IndexSelect
+        savedIndexes={mockIndexes as any}
+        selectedIndex={mockIndexes[0].value}
+        onIndexChange={onIndexChange}
+      />,
+    )
+
+    expect(container).toBeTruthy()
+    expect(screen.getByText('Index:')).toBeInTheDocument()
+    expect(screen.getByTestId('select-saved-index')).toBeInTheDocument()
+  })
+
+  it('calls onIndexChange when selection changes', () => {
+    const onIndexChange = jest.fn()
+    render(
+      <IndexSelect
+        savedIndexes={mockIndexes as any}
+        selectedIndex={mockIndexes[0].value}
+        onIndexChange={onIndexChange}
+      />,
+    )
+
+    const select = screen.getByTestId('select-saved-index') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: mockIndexes[1].value } })
+
+    expect(onIndexChange).toHaveBeenCalledTimes(1)
+    expect(onIndexChange).toHaveBeenCalledWith('idx:restaurants_vss')
+  })
+})

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/IndexSelect.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/IndexSelect.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
+import { FieldTag } from 'uiSrc/components/new-index/create-index-step/field-box/FieldTag'
+import { Title } from '../manage-indexes/styles'
+import { VectorSearchSavedQueriesSelectWrapper, TagsWrapper } from './styles'
+import { SavedIndex } from './types'
+
+type IndexSelectProps = {
+  savedIndexes: SavedIndex[]
+  selectedIndex?: string
+  onIndexChange: (value: string) => void
+}
+
+export const IndexSelect = ({
+  savedIndexes,
+  selectedIndex,
+  onIndexChange,
+}: IndexSelectProps) => (
+  <VectorSearchSavedQueriesSelectWrapper>
+    <Title size="S">Index:</Title>
+    <RiSelect
+      loading={false}
+      disabled={false}
+      options={savedIndexes}
+      value={selectedIndex}
+      data-testid="select-saved-index"
+      onChange={onIndexChange}
+      valueRender={({ option, isOptionValue }) =>
+        isOptionValue ? (
+          option.value
+        ) : (
+          <TagsWrapper>
+            {option.value}
+            {option.tags.map((tag) => (
+              <FieldTag key={tag} tag={tag} />
+            ))}
+          </TagsWrapper>
+        )
+      }
+    />
+  </VectorSearchSavedQueriesSelectWrapper>
+)

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/QueryCard.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/QueryCard.spec.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { fireEvent, render, screen } from 'uiSrc/utils/test-utils'
+
+import { QueryCard } from './QueryCard'
+
+describe('SavedQueries/QueryCard', () => {
+  const onQueryInsert = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders label and button', () => {
+    const { container } = render(
+      <QueryCard
+        label={'Search for "Nord" bikes ordered by price'}
+        value={'FT.SEARCH idx:bikes_vss "@brand:Nord" SORTBY price ASC'}
+        onQueryInsert={onQueryInsert}
+      />,
+    )
+
+    expect(container).toBeTruthy()
+    expect(
+      screen.getByText('Search for "Nord" bikes ordered by price'),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('btn-insert-query')).toBeInTheDocument()
+  })
+
+  it('calls onQueryInsert with value when Insert is clicked', () => {
+    render(
+      <QueryCard
+        label="Find road alloy bikes under 20kg"
+        value={'FT.SEARCH idx:bikes_vss "@material:{alloy} @weight:[0 20]"'}
+        onQueryInsert={onQueryInsert}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('btn-insert-query'))
+
+    expect(onQueryInsert).toHaveBeenCalledTimes(1)
+    expect(onQueryInsert).toHaveBeenCalledWith(
+      'FT.SEARCH idx:bikes_vss "@material:{alloy} @weight:[0 20]"',
+    )
+  })
+})

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/QueryCard.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/QueryCard.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+import { Text } from 'uiSrc/components/base/text'
+import { EmptyButton } from 'uiSrc/components/base/forms/buttons'
+import { PlayFilledIcon } from 'uiSrc/components/base/icons'
+import { VectorSearchScreenBlockWrapper } from '../styles'
+import { RightAlignedWrapper } from './styles'
+
+type QueryCardProps = {
+  label: string
+  value: string
+  onQueryInsert: (value: string) => void
+}
+
+export const QueryCard = ({ label, value, onQueryInsert }: QueryCardProps) => (
+  <VectorSearchScreenBlockWrapper key={value} padding={6}>
+    <Text>{label}</Text>
+    <RightAlignedWrapper>
+      <EmptyButton
+        icon={PlayFilledIcon}
+        onClick={() => onQueryInsert(value)}
+        data-testid="btn-insert-query"
+      >
+        Insert
+      </EmptyButton>
+    </RightAlignedWrapper>
+  </VectorSearchScreenBlockWrapper>
+)

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
@@ -5,8 +5,8 @@ import React from 'react'
 import { render, screen, fireEvent } from 'uiSrc/utils/test-utils'
 
 import { SavedQueriesScreen } from './SavedQueriesScreen'
-import { SavedIndex } from './types'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
+import { useRedisearchListData } from '../useRedisearchListData'
 
 // Mock the telemetry sender once for this spec file
 jest.mock('uiSrc/telemetry', () => ({
@@ -14,172 +14,110 @@ jest.mock('uiSrc/telemetry', () => ({
   sendEventTelemetry: jest.fn(),
 }))
 
-const mockOnIndexChange = jest.fn()
+// Mock the redisearch list data hook
+jest.mock('../useRedisearchListData', () => ({
+  useRedisearchListData: jest.fn(),
+}))
+
 const mockOnQueryInsert = jest.fn()
 const mockOnClose = jest.fn()
 
-const mockSavedIndexes: SavedIndex[] = [
-  {
-    value: 'bicycle_index',
-    tags: ['tag', 'text', 'vector'],
-    queries: [
-      {
-        label: 'Search for bikes',
-        value: 'FT.SEARCH idx:bike "@category:mountain"',
-      },
-      {
-        label: 'Find road bikes',
-        value: 'FT.SEARCH idx:bike "@type:road"',
-      },
-    ],
-  },
-  {
-    value: 'restaurant_index',
-    tags: ['text', 'vector'],
-    queries: [
-      {
-        label: 'Search for restaurants',
-        value: 'FT.SEARCH idx:restaurant "@cuisine:Italian"',
-      },
-    ],
-  },
-]
-
-const defaultProps = {
-  savedIndexes: mockSavedIndexes,
-  selectedIndex: mockSavedIndexes[0],
-  onIndexChange: mockOnIndexChange,
-  onQueryInsert: mockOnQueryInsert,
-  onClose: mockOnClose,
-}
-
 describe('SavedQueriesScreen', () => {
+  const instanceId = 'instanceId'
+  const renderComponent = () =>
+    render(
+      <SavedQueriesScreen
+        instanceId={instanceId}
+        onQueryInsert={mockOnQueryInsert}
+        onClose={mockOnClose}
+      />,
+    )
+
   beforeEach(() => {
     jest.clearAllMocks()
+    ;(useRedisearchListData as jest.Mock).mockReturnValue({
+      loading: false,
+      data: [],
+      stringData: ['idx:bikes_vss'],
+    })
   })
 
   it('should render', () => {
-    expect(render(<SavedQueriesScreen {...defaultProps} />)).toBeTruthy()
+    const { container } = renderComponent()
+    expect(container).toBeTruthy()
   })
 
   it('should render the main content', () => {
-    render(<SavedQueriesScreen {...defaultProps} />)
+    renderComponent()
 
     expect(screen.getByText('Saved queries')).toBeInTheDocument()
     expect(screen.getByText('Index:')).toBeInTheDocument()
 
-    // Check that all queries from the selected index are rendered
-    expect(screen.getByText('Search for bikes')).toBeInTheDocument()
-    expect(screen.getByText('Find road bikes')).toBeInTheDocument()
+    // Check that preset queries are rendered for bikes index
+    expect(
+      screen.getByText('Search for "Nord" bikes ordered by price'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Find road alloy bikes under 20kg'),
+    ).toBeInTheDocument()
   })
 
   it('should render insert buttons for each query', () => {
-    render(<SavedQueriesScreen {...defaultProps} />)
-
+    renderComponent()
     const insertButtons = screen.getAllByText('Insert')
-    expect(insertButtons).toHaveLength(2) // 2 queries in the selected index
+    expect(insertButtons).toHaveLength(2)
   })
 
   it('should call onClose when close button is clicked', () => {
-    render(<SavedQueriesScreen {...defaultProps} />)
-
+    renderComponent()
     const closeButton = screen.getByTestId('close-saved-queries-btn')
     fireEvent.click(closeButton)
-
     expect(mockOnClose).toHaveBeenCalledTimes(1)
   })
 
-  it('should call onQueryInsert when insert button is clicked', () => {
-    render(<SavedQueriesScreen {...defaultProps} />)
-
+  it('should call onQueryInsert for the first query', () => {
+    renderComponent()
     const firstInsertButton = screen.getAllByText('Insert')[0]
     fireEvent.click(firstInsertButton)
-
-    expect(mockOnQueryInsert).toHaveBeenCalledTimes(1)
     expect(mockOnQueryInsert).toHaveBeenCalledWith(
-      'FT.SEARCH idx:bike "@category:mountain"',
+      'FT.SEARCH idx:bikes_vss "@brand:Nord" SORTBY price ASC',
     )
   })
 
-  it('should call onQueryInsert with correct query value for second button', () => {
-    render(<SavedQueriesScreen {...defaultProps} />)
-
-    const insertButtons = screen.getAllByText('Insert')
-
-    // Click second insert button
-    fireEvent.click(insertButtons[1])
+  it('should call onQueryInsert for the second query', () => {
+    renderComponent()
+    const secondInsertButton = screen.getAllByText('Insert')[1]
+    fireEvent.click(secondInsertButton)
     expect(mockOnQueryInsert).toHaveBeenCalledWith(
-      'FT.SEARCH idx:bike "@type:road"',
+      'FT.SEARCH idx:bikes_vss "@material:{alloy} @weight:[0 20]"',
     )
   })
 
-  it('should render field tags for the selected index', () => {
-    render(<SavedQueriesScreen {...defaultProps} />)
-
-    // The tags should be rendered
-    defaultProps.selectedIndex.tags
-      .map((tag) => tag.toUpperCase())
-      .forEach((tag) => {
-        expect(screen.getByText(tag)).toBeInTheDocument()
-      })
+  it('should render loader when loading is true', () => {
+    ;(useRedisearchListData as jest.Mock).mockReturnValue({
+      loading: true,
+      data: [],
+      stringData: [],
+    })
+    renderComponent()
+    expect(
+      screen.getByTestId('manage-indexes-list--loader'),
+    ).toBeInTheDocument()
   })
 
-  describe('with different selected index', () => {
-    it('should render queries for restaurant index when selected', () => {
-      const propsWithRestaurantIndex = {
-        ...defaultProps,
-        selectedIndex: mockSavedIndexes[1], // restaurant_index
-      }
-
-      render(<SavedQueriesScreen {...propsWithRestaurantIndex} />)
-
-      expect(screen.getByText('Search for restaurants')).toBeInTheDocument()
-
-      const insertButtons = screen.getAllByText('Insert')
-      expect(insertButtons).toHaveLength(1) // 1 query in restaurant index
+  it('should render "No indexes" message when there are no indexes', () => {
+    ;(useRedisearchListData as jest.Mock).mockReturnValue({
+      loading: false,
+      data: [],
+      stringData: [],
     })
-
-    it('should call onQueryInsert with restaurant query values', () => {
-      const propsWithRestaurantIndex = {
-        ...defaultProps,
-        selectedIndex: mockSavedIndexes[1], // restaurant_index
-      }
-
-      render(<SavedQueriesScreen {...propsWithRestaurantIndex} />)
-
-      const insertButtons = screen.getAllByText('Insert')
-
-      fireEvent.click(insertButtons[0])
-      expect(mockOnQueryInsert).toHaveBeenCalledWith(
-        'FT.SEARCH idx:restaurant "@cuisine:Italian"',
-      )
-    })
-  })
-
-  describe('with empty queries', () => {
-    it('should handle index with no queries', () => {
-      const indexWithNoQueries: SavedIndex = {
-        value: 'empty_index',
-        tags: ['text'],
-        queries: [],
-      }
-
-      const propsWithEmptyQueries = {
-        ...defaultProps,
-        savedIndexes: [indexWithNoQueries],
-        selectedIndex: indexWithNoQueries,
-      }
-
-      render(<SavedQueriesScreen {...propsWithEmptyQueries} />)
-
-      expect(screen.queryByText('Insert')).not.toBeInTheDocument()
-    })
+    renderComponent()
+    expect(screen.getByText('No indexes to display yet.')).toBeInTheDocument()
   })
 
   describe('Telemetry', () => {
     it('should send telemetry event on mount', () => {
-      render(<SavedQueriesScreen {...defaultProps} />)
-
+      renderComponent()
       expect(sendEventTelemetry).toHaveBeenCalledWith({
         event: TelemetryEvent.SEARCH_SAVED_QUERIES_PANEL_OPENED,
         eventData: { databaseId: 'instanceId' },
@@ -187,13 +125,9 @@ describe('SavedQueriesScreen', () => {
     })
 
     it('should send telemetry event on unmount', () => {
-      const { unmount } = render(<SavedQueriesScreen {...defaultProps} />)
-
-      // clear mount call
+      const { unmount } = renderComponent()
       ;(sendEventTelemetry as jest.Mock).mockClear()
-
       unmount()
-
       expect(sendEventTelemetry).toHaveBeenCalledWith({
         event: TelemetryEvent.SEARCH_SAVED_QUERIES_PANEL_CLOSED,
         eventData: { databaseId: 'instanceId' },

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
@@ -24,12 +24,13 @@ const mockOnClose = jest.fn()
 
 describe('SavedQueriesScreen', () => {
   const instanceId = 'instanceId'
-  const renderComponent = () =>
+  const renderComponent = (defaultSavedQueriesIndex?: string) =>
     render(
       <SavedQueriesScreen
         instanceId={instanceId}
         onQueryInsert={mockOnQueryInsert}
         onClose={mockOnClose}
+        defaultSavedQueriesIndex={defaultSavedQueriesIndex}
       />,
     )
 
@@ -38,7 +39,7 @@ describe('SavedQueriesScreen', () => {
     ;(useRedisearchListData as jest.Mock).mockReturnValue({
       loading: false,
       data: [],
-      stringData: ['idx:bikes_vss'],
+      stringData: ['idx:bikes_vss', 'idx:restaurants_vss'],
     })
   })
 
@@ -66,6 +67,18 @@ describe('SavedQueriesScreen', () => {
     renderComponent()
     const insertButtons = screen.getAllByText('Insert')
     expect(insertButtons).toHaveLength(2)
+  })
+
+  it('should select the first index by default', () => {
+    renderComponent()
+    expect(screen.queryByText('idx:bikes_vss')).toBeInTheDocument()
+  })
+
+  it('should select the default index if provided', () => {
+    renderComponent('idx:restaurants_vss')
+    // The Select component isn't a native <select>, so assert by displayed text
+    expect(screen.queryByText('idx:bikes_vss')).not.toBeInTheDocument()
+    expect(screen.queryByText('idx:restaurants_vss')).toBeInTheDocument()
   })
 
   it('should call onClose when close button is clicked', () => {

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
@@ -1,23 +1,15 @@
 import React, { useState, useMemo, useEffect } from 'react'
 
-import { Title, Text } from 'uiSrc/components/base/text'
+import { Title } from 'uiSrc/components/base/text'
 
-import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
-import { EmptyButton, IconButton } from 'uiSrc/components/base/forms/buttons'
-import { FieldTag } from 'uiSrc/components/new-index/create-index-step/field-box/FieldTag'
+import { IconButton } from 'uiSrc/components/base/forms/buttons'
 import { FieldTypes } from 'uiSrc/pages/browser/components/create-redisearch-index/constants'
 import { Loader } from 'uiSrc/components/base/display'
 
-import { CancelSlimIcon, PlayFilledIcon } from 'uiSrc/components/base/icons'
-import {
-  RightAlignedWrapper,
-  TagsWrapper,
-  VectorSearchSavedQueriesContentWrapper,
-  VectorSearchSavedQueriesSelectWrapper,
-} from './styles'
+import { CancelSlimIcon } from 'uiSrc/components/base/icons'
+import { VectorSearchSavedQueriesContentWrapper } from './styles'
 import { SavedIndex } from './types'
 import {
-  VectorSearchScreenBlockWrapper,
   VectorSearchScreenFooter,
   VectorSearchScreenHeader,
   VectorSearchScreenWrapper,
@@ -28,6 +20,8 @@ import { useRedisearchListData } from '../useRedisearchListData'
 import { collectChangedSavedQueryIndexTelemetry } from '../telemetry'
 import { PresetDataType } from '../create-index/types'
 import NoIndexesMessage from '../manage-indexes/NoIndexesMessage'
+import { QueryCard } from './QueryCard'
+import { IndexSelect } from './IndexSelect'
 
 const mockSavedIndexes: SavedIndex[] = [
   {
@@ -82,6 +76,7 @@ export const SavedQueriesScreen = ({
   const selectedIndexItem = savedIndexes.find(
     (index) => index.value === selectedIndex,
   )
+  const hasIndexes = savedIndexes.length > 0
 
   useEffect(() => {
     if (selectedIndex) return
@@ -98,10 +93,6 @@ export const SavedQueriesScreen = ({
     collectChangedSavedQueryIndexTelemetry({
       instanceId,
     })
-  }
-
-  if (loading) {
-    return <Loader data-testid="manage-indexes-list--loader" />
   }
 
   return (
@@ -123,46 +114,25 @@ export const SavedQueriesScreen = ({
       </VectorSearchScreenHeader>
       <VectorSearchScreenFooter grow={1} padding={6}>
         <VectorSearchSavedQueriesContentWrapper>
-          {savedIndexes.length > 0 ? (
-            <VectorSearchSavedQueriesSelectWrapper>
-              <Title size="S">Index:</Title>
-              <RiSelect
-                loading={false}
-                disabled={false}
-                options={savedIndexes}
-                value={selectedIndexItem?.value}
-                data-testid="select-saved-index"
-                onChange={onIndexChange}
-                valueRender={({ option, isOptionValue }) =>
-                  isOptionValue ? (
-                    option.value
-                  ) : (
-                    <TagsWrapper>
-                      {option.value}
-                      {option.tags.map((tag) => (
-                        <FieldTag key={tag} tag={tag} />
-                      ))}
-                    </TagsWrapper>
-                  )
-                }
-              />
-            </VectorSearchSavedQueriesSelectWrapper>
-          ) : (
-            <NoIndexesMessage />
+          {loading && <Loader data-testid="manage-indexes-list--loader" />}
+
+          {!loading && hasIndexes && (
+            <IndexSelect
+              savedIndexes={savedIndexes}
+              selectedIndex={selectedIndexItem?.value}
+              onIndexChange={onIndexChange}
+            />
           )}
+
+          {!loading && !hasIndexes && <NoIndexesMessage />}
+
           {selectedIndexItem?.queries.map((query) => (
-            <VectorSearchScreenBlockWrapper key={query.value} padding={6}>
-              <Text>{query.label}</Text>
-              <RightAlignedWrapper>
-                <EmptyButton
-                  icon={PlayFilledIcon}
-                  onClick={() => onQueryInsert(query.value)}
-                  data-testid="btn-insert-query"
-                >
-                  Insert
-                </EmptyButton>
-              </RightAlignedWrapper>
-            </VectorSearchScreenBlockWrapper>
+            <QueryCard
+              key={query.value}
+              label={query.label}
+              value={query.value}
+              onQueryInsert={onQueryInsert}
+            />
           ))}
         </VectorSearchSavedQueriesContentWrapper>
       </VectorSearchScreenFooter>

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useMemo, useEffect } from 'react'
 
 import { Title, Text } from 'uiSrc/components/base/text'
 
@@ -22,19 +22,37 @@ import {
 } from '../styles'
 import { useTelemetryMountEvent } from '../hooks/useTelemetryMountEvent'
 import { TelemetryEvent } from 'uiSrc/telemetry'
+import { useRedisearchListData } from '../useRedisearchListData'
+import { collectChangedSavedQueryIndexTelemetry } from '../telemetry'
+import { PresetDataType } from '../create-index/types'
+import { Loader } from '@redis-ui/components'
+import NoIndexesMessage from '../manage-indexes/NoIndexesMessage'
+
+const mockSavedIndexes: SavedIndex[] = [
+  {
+    value: PresetDataType.BIKES,
+    tags: ['tag', 'text', 'vector'],
+    queries: [
+      {
+        label: 'Search for "Nord" bikes ordered by price',
+        value: 'FT.SEARCH idx:bikes_vss "@brand:Nord" SORTBY price ASC',
+      },
+      {
+        label: 'Find road alloy bikes under 20kg',
+        value: 'FT.SEARCH idx:bikes_vss "@material:{alloy} @weight:[0 20]"',
+      },
+    ],
+  },
+]
 
 type SavedQueriesScreenProps = {
-  savedIndexes: SavedIndex[]
-  selectedIndex?: SavedIndex
-  onIndexChange: (value: string) => void
+  instanceId: string
   onQueryInsert: (value: string) => void
   onClose: () => void
 }
 
 export const SavedQueriesScreen = ({
-  savedIndexes,
-  selectedIndex,
-  onIndexChange,
+  instanceId,
   onQueryInsert,
   onClose,
 }: SavedQueriesScreenProps) => {
@@ -42,6 +60,43 @@ export const SavedQueriesScreen = ({
     TelemetryEvent.SEARCH_SAVED_QUERIES_PANEL_OPENED,
     TelemetryEvent.SEARCH_SAVED_QUERIES_PANEL_CLOSED,
   )
+  const [selectedIndex, setSelectedIndex] = useState('')
+  const { stringData, loading } = useRedisearchListData()
+  const savedIndexes = useMemo(
+    () =>
+      stringData.map(
+        (index) =>
+          ({
+            value: index,
+            // Hardcoded values for the preset index, else empty arrays:
+            tags: mockSavedIndexes.find((i) => i.value === index)?.tags || [],
+            queries:
+              mockSavedIndexes.find((i) => i.value === index)?.queries || [],
+          }) as SavedIndex,
+      ),
+    [stringData],
+  )
+  const selectedIndexItem = savedIndexes.find(
+    (index) => index.value === selectedIndex,
+  )
+
+  useEffect(() => {
+    const firstIndex = savedIndexes[0]?.value
+
+    firstIndex && setSelectedIndex(firstIndex)
+  }, [savedIndexes])
+
+  const onIndexChange = (value: string) => {
+    setSelectedIndex(value)
+
+    collectChangedSavedQueryIndexTelemetry({
+      instanceId,
+    })
+  }
+
+  if (loading) {
+    return <Loader data-testid="manage-indexes-list--loader" />
+  }
 
   return (
     <VectorSearchScreenWrapper
@@ -62,35 +117,35 @@ export const SavedQueriesScreen = ({
       </VectorSearchScreenHeader>
       <VectorSearchScreenFooter grow={1} padding={6}>
         <VectorSearchSavedQueriesContentWrapper>
-          <VectorSearchSavedQueriesSelectWrapper>
-            <Title size="S">Index:</Title>
-            <RiSelect
-              loading={false}
-              disabled={false}
-              options={savedIndexes}
-              value={selectedIndex?.value}
-              data-testid="select-saved-index"
-              onChange={onIndexChange}
-              valueRender={({ option, isOptionValue }) =>
-                isOptionValue ? (
-                  option.value
-                ) : (
-                  <TagsWrapper>
-                    {option.value}
-                    {option.tags.map((tag) => (
-                      <FieldTag key={tag} tag={tag as any} />
-                    ))}
-                  </TagsWrapper>
-                )
-              }
-            />
-          </VectorSearchSavedQueriesSelectWrapper>
-          {selectedIndex?.queries.map((query) => (
-            <VectorSearchScreenBlockWrapper
-              key={query.value}
-              // as="div"
-              padding={6}
-            >
+          {savedIndexes.length > 0 ? (
+            <VectorSearchSavedQueriesSelectWrapper>
+              <Title size="S">Index:</Title>
+              <RiSelect
+                loading={false}
+                disabled={false}
+                options={savedIndexes}
+                value={selectedIndexItem?.value}
+                data-testid="select-saved-index"
+                onChange={onIndexChange}
+                valueRender={({ option, isOptionValue }) =>
+                  isOptionValue ? (
+                    option.value
+                  ) : (
+                    <TagsWrapper>
+                      {option.value}
+                      {option.tags.map((tag) => (
+                        <FieldTag key={tag} tag={tag as any} />
+                      ))}
+                    </TagsWrapper>
+                  )
+                }
+              />
+            </VectorSearchSavedQueriesSelectWrapper>
+          ) : (
+            <NoIndexesMessage />
+          )}
+          {selectedIndexItem?.queries.map((query) => (
+            <VectorSearchScreenBlockWrapper key={query.value} padding={6}>
               <Text>{query.label}</Text>
               <RightAlignedWrapper>
                 <EmptyButton

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
@@ -47,12 +47,14 @@ const mockSavedIndexes: SavedIndex[] = [
 
 type SavedQueriesScreenProps = {
   instanceId: string
+  defaultSavedQueriesIndex?: string
   onQueryInsert: (value: string) => void
   onClose: () => void
 }
 
 export const SavedQueriesScreen = ({
   instanceId,
+  defaultSavedQueriesIndex,
   onQueryInsert,
   onClose,
 }: SavedQueriesScreenProps) => {
@@ -60,7 +62,7 @@ export const SavedQueriesScreen = ({
     TelemetryEvent.SEARCH_SAVED_QUERIES_PANEL_OPENED,
     TelemetryEvent.SEARCH_SAVED_QUERIES_PANEL_CLOSED,
   )
-  const [selectedIndex, setSelectedIndex] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(defaultSavedQueriesIndex)
   const { stringData, loading } = useRedisearchListData()
   const savedIndexes = useMemo(
     () =>
@@ -81,10 +83,13 @@ export const SavedQueriesScreen = ({
   )
 
   useEffect(() => {
+    if (selectedIndex) return
+
+    // Select the first index by default if none is selected yet
     const firstIndex = savedIndexes[0]?.value
 
     firstIndex && setSelectedIndex(firstIndex)
-  }, [savedIndexes])
+  }, [selectedIndex, savedIndexes])
 
   const onIndexChange = (value: string) => {
     setSelectedIndex(value)

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
@@ -5,6 +5,8 @@ import { Title, Text } from 'uiSrc/components/base/text'
 import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
 import { EmptyButton, IconButton } from 'uiSrc/components/base/forms/buttons'
 import { FieldTag } from 'uiSrc/components/new-index/create-index-step/field-box/FieldTag'
+import { FieldTypes } from 'uiSrc/pages/browser/components/create-redisearch-index/constants'
+import { Loader } from 'uiSrc/components/base/display'
 
 import { CancelSlimIcon, PlayFilledIcon } from 'uiSrc/components/base/icons'
 import {
@@ -25,13 +27,12 @@ import { TelemetryEvent } from 'uiSrc/telemetry'
 import { useRedisearchListData } from '../useRedisearchListData'
 import { collectChangedSavedQueryIndexTelemetry } from '../telemetry'
 import { PresetDataType } from '../create-index/types'
-import { Loader } from '@redis-ui/components'
 import NoIndexesMessage from '../manage-indexes/NoIndexesMessage'
 
 const mockSavedIndexes: SavedIndex[] = [
   {
     value: PresetDataType.BIKES,
-    tags: ['tag', 'text', 'vector'],
+    tags: [FieldTypes.TAG, FieldTypes.TEXT, FieldTypes.VECTOR],
     queries: [
       {
         label: 'Search for "Nord" bikes ordered by price',
@@ -139,7 +140,7 @@ export const SavedQueriesScreen = ({
                     <TagsWrapper>
                       {option.value}
                       {option.tags.map((tag) => (
-                        <FieldTag key={tag} tag={tag as any} />
+                        <FieldTag key={tag} tag={tag} />
                       ))}
                     </TagsWrapper>
                   )

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/types.ts
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/types.ts
@@ -1,6 +1,8 @@
+import { FieldTypes } from 'uiSrc/pages/browser/components/create-redisearch-index/constants'
+
 export type SavedIndex = {
   value: string
-  tags: string[]
+  tags: FieldTypes[]
   queries: {
     label: string
     value: string

--- a/redisinsight/ui/src/pages/vector-search/useRedisearchListData.ts
+++ b/redisinsight/ui/src/pages/vector-search/useRedisearchListData.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 
 import {
@@ -6,12 +6,16 @@ import {
   fetchRedisearchListAction,
 } from 'uiSrc/slices/browser/redisearch'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
-import { isRedisearchAvailable } from 'uiSrc/utils'
+import { bufferToString, isRedisearchAvailable } from 'uiSrc/utils'
 
 export const useRedisearchListData = () => {
   const dispatch = useDispatch()
   const { loading, data } = useSelector(redisearchListSelector)
   const { modules, host: instanceHost } = useSelector(connectedInstanceSelector)
+  const stringData = useMemo(
+    () => data.map((index) => bufferToString(index)),
+    [data],
+  )
 
   useEffect(() => {
     if (!instanceHost) {
@@ -27,5 +31,6 @@ export const useRedisearchListData = () => {
   return {
     loading,
     data,
+    stringData,
   }
 }


### PR DESCRIPTION
### Description

- After creating a new index, automatically selects that index in saved queries panel and expands it
- When no indexes are available, Saved Queries shows a placeholder component

| Before | After |
| --- | --- |
| always showing the preset queries, even when no index has been inserted | when no index is available, show the same component used as in Manage Indexes |
| <img width="539" height="511" alt="Screenshot 2025-08-21 at 15 38 30" src="https://github.com/user-attachments/assets/ef7a3aaa-a799-4354-a1e1-ead719a7a8a1" /> | <img width="642" height="516" alt="Screenshot 2025-08-21 at 14 27 04" src="https://github.com/user-attachments/assets/63897e06-8e10-4379-93b7-0b0e529450b4" /> |

There is a new design for the "No indexes" component which will be addressed in another ticket 