### PR TITLE
RI-7354: fix the control + enter button to run the query in on Search Page

### DIFF
--- a/redisinsight/ui/src/components/query/query-lite-actions/QueryLiteActions.tsx
+++ b/redisinsight/ui/src/components/query/query-lite-actions/QueryLiteActions.tsx
@@ -60,7 +60,7 @@ const QueryLiteActions = (props: Props) => {
         data-testid="run-query-tooltip"
       >
         <Button
-          onClick={onSubmit}
+          onClick={() => onSubmit()}
           loading={isLoading}
           disabled={isLoading}
           icon={PlayFilledIcon}

--- a/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.tsx
@@ -64,8 +64,8 @@ export const VectorSearchQuery = ({
   )
   const isSavedQueriesOpen = rightPanel === RightPanelType.SAVED_QUERIES
 
-  const onQuerySubmit = () => {
-    onSubmit()
+  const onQuerySubmit = (value?: string) => {
+    onSubmit(value)
     collectTelemetryQueryRun({
       instanceId,
       query,


### PR DESCRIPTION
<img width="850" height="324" alt="image" src="https://github.com/user-attachments/assets/45ec2739-ebff-4104-8408-740a23fcadbb" />

On the Vector Search page, clicking **Control + Enter** should do the same as the **Run** button. This did not work as the value was not passed to to the onQuerySubmit method. Also, changed the onClick event for the button in QueryLiteActions, as it was passing an event which is not desired scenario. 
