### PR TITLE
RI-7377: fix command helper styles

### DIFF
--- a/redisinsight/ui/src/components/command-helper/CommandHelper/CommandHelper.tsx
+++ b/redisinsight/ui/src/components/command-helper/CommandHelper/CommandHelper.tsx
@@ -119,14 +119,14 @@ const CommandHelper = (props: Props) => {
             </div>
           )}
           {!commandLine && (
-            <ColorText
-              color="subdued"
+            <Text
+              color="primary"
               className={styles.defaultScreen}
               data-testid="cli-helper-default"
             >
               Enter any command in CLI or use search to see detailed
               information.
-            </ColorText>
+            </Text>
           )}
         </div>
       )}

--- a/redisinsight/ui/src/components/command-helper/components/command-helper-search-output/CHSearchOutput.tsx
+++ b/redisinsight/ui/src/components/command-helper/components/command-helper-search-output/CHSearchOutput.tsx
@@ -47,7 +47,7 @@ const CHSearchOutput = ({ searchedCommands }: Props) => {
       return (
         <Text
           size="s"
-          color="subdued"
+          color="primary"
           className={styles.description}
           data-testid={`cli-helper-output-args-${command}`}
         >
@@ -72,7 +72,7 @@ const CHSearchOutput = ({ searchedCommands }: Props) => {
       {searchedCommands.length > 0 && (
         <div style={{ width: '100%' }}>
           {searchedCommands.map((command: string) => (
-            <Row gap="m" key={command}>
+            <Row gap="m" key={command} align="center">
               <FlexItem style={{ flexShrink: 0 }}>
                 <Text
                   key={command}
@@ -82,7 +82,7 @@ const CHSearchOutput = ({ searchedCommands }: Props) => {
                     handleClickCommand(e, command)
                   }}
                 >
-                  <Link className={styles.title}>
+                  <Link color="subdued">
                     {command}
                   </Link>
                 </Text>

--- a/redisinsight/ui/src/components/command-helper/components/command-helper-search-output/styles.module.scss
+++ b/redisinsight/ui/src/components/command-helper/components/command-helper-search-output/styles.module.scss
@@ -13,10 +13,6 @@
   text-overflow: ellipsis;
 }
 
-.title {
-  color: var(--euiTextSubduedColorHover) !important;
-}
-
 .summary, .summary div {
   color: var(--inputPlaceholderColor) !important;
 }


### PR DESCRIPTION
| Before | After |
| -----| ------|
| <img width="1600" height="282" alt="before" src="https://github.com/user-attachments/assets/016e23cc-add2-4b94-a580-5cfde2e125ea" /> | <img width="505" height="286" alt="image" src="https://github.com/user-attachments/assets/0b0f282e-865a-4f5f-8813-378136c925a6" /> |