### PR TITLE
RI-7338: Fix text and links on RDI page, Settings and EULA screen

### DIFF
--- a/redisinsight/ui/src/components/consents-settings/ConsentOption/ConsentOption.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentOption/ConsentOption.tsx
@@ -33,19 +33,19 @@ const ConsentOption = (props: Props) => {
     <FlexItem key={consent.agreementName} grow>
       {isSettingsPage && consent.description && (
         <>
-          <Text
-            size="s"
-            className={styles.smallText}
-            color="subdued"
-            style={{ marginTop: '12px' }}
-          >
-            <ItemDescription description={consent.description} withLink={consent.linkToPrivacyPolicy} />
+          <Spacer size="s" />
+          <Text size="s" className={styles.smallText} color="primary">
+            <ItemDescription
+              description={consent.description}
+              withLink={consent.linkToPrivacyPolicy}
+            />
           </Text>
           <Spacer size="m" />
         </>
       )}
       <Row gap="m">
         <FlexItem>
+          <Spacer size="xxs" />
           <SwitchInput
             checked={checked}
             onCheckedChange={(checked) =>
@@ -58,14 +58,15 @@ const ConsentOption = (props: Props) => {
         <FlexItem>
           <Text className={styles.smallText}>{parse(consent.label)}</Text>
           {!isSettingsPage && consent.description && (
-            <Text
-              size="s"
-              className={styles.smallText}
-              color="subdued"
-              style={{ marginTop: '12px' }}
-            >
-              <ItemDescription description={consent.description} withLink={consent.linkToPrivacyPolicy} />
-            </Text>
+            <>
+              <Spacer size="s" />
+              <Text size="s" className={styles.smallText} color="primary">
+                <ItemDescription
+                  description={consent.description}
+                  withLink={consent.linkToPrivacyPolicy}
+                />
+              </Text>
+            </>
           )}
         </FlexItem>
       </Row>

--- a/redisinsight/ui/src/components/consents-settings/ConsentOption/components/ItemDescription.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentOption/components/ItemDescription.tsx
@@ -1,6 +1,8 @@
 import parse from 'html-react-parser'
 import React from 'react'
 import { Link } from 'uiSrc/components/base/link/Link'
+import { EXTERNAL_LINKS, UTM_MEDIUMS } from 'uiSrc/constants/links'
+import { getUtmExternalLink } from 'uiSrc/utils/links'
 
 interface ItemDescriptionProps {
   description: string
@@ -18,7 +20,10 @@ export const ItemDescription = ({
         <Link
           color="primary"
           target="_blank"
-          href="https://redis.io/legal/privacy-policy/?utm_source=redisinsight&utm_medium=app&utm_campaign=telemetry"
+          href={getUtmExternalLink(EXTERNAL_LINKS.legalPrivacyPolicy, {
+            medium: UTM_MEDIUMS.App,
+            campaign: 'telemetry',
+          })}
         >
           Privacy Policy
         </Link>

--- a/redisinsight/ui/src/components/consents-settings/ConsentOption/components/ItemDescription.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentOption/components/ItemDescription.tsx
@@ -1,26 +1,29 @@
-import { EuiLink } from '@elastic/eui'
 import parse from 'html-react-parser'
 import React from 'react'
+import { Link } from 'uiSrc/components/base/link/Link'
 
 interface ItemDescriptionProps {
-  description: string;
-  withLink: boolean;
+  description: string
+  withLink: boolean
 }
 
-export const ItemDescription = ({ description, withLink }: ItemDescriptionProps) => (
-    <>
-      {description && parse(description)}
-      {withLink && (
-        <>
-          <EuiLink
-            external={false}
-            target="_blank"
-            href="https://redis.io/legal/privacy-policy/?utm_source=redisinsight&utm_medium=app&utm_campaign=telemetry"
-          >
-            Privacy Policy
-          </EuiLink>
-          .
-        </>
-      )}
-    </>
+export const ItemDescription = ({
+  description,
+  withLink,
+}: ItemDescriptionProps) => (
+  <>
+    {description && parse(description)}
+    {withLink && (
+      <>
+        <Link
+          color="primary"
+          target="_blank"
+          href="https://redis.io/legal/privacy-policy/?utm_source=redisinsight&utm_medium=app&utm_campaign=telemetry"
+        >
+          Privacy Policy
+        </Link>
+        .
+      </>
+    )}
+  </>
 )

--- a/redisinsight/ui/src/components/consents-settings/ConsentsPrivacy/ConsentsPrivacy.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsPrivacy/ConsentsPrivacy.tsx
@@ -80,7 +80,7 @@ const ConsentsPrivacy = () => {
   return (
     <form onSubmit={formik.handleSubmit} data-testid="consents-settings-form">
       <div className={styles.consentsWrapper}>
-        <Text size="s" className={styles.smallText} color="subdued">
+        <Text size="s" className={styles.smallText} color="primary">
           To optimize your experience, Redis Insight uses third-party tools.
         </Text>
         <Spacer />

--- a/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
+++ b/redisinsight/ui/src/components/consents-settings/ConsentsSettings.tsx
@@ -217,6 +217,7 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
             <FlexItem>
               <Row gap="m">
                 <FlexItem>
+                  <Spacer size="xxs" />
                   <SwitchInput
                     checked={isRecommended}
                     onCheckedChange={selectAll}
@@ -225,12 +226,8 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
                 </FlexItem>
                 <FlexItem>
                   <Text className={styles.label}>Use recommended settings</Text>
-                  <Text
-                    size="s"
-                    className={styles.smallText}
-                    color="subdued"
-                    style={{ marginTop: '12px' }}
-                  >
+                  <Spacer size="s" />
+                  <Text size="s" className={styles.smallText} color="primary">
                     Select to activate all listed options.
                   </Text>
                 </FlexItem>
@@ -251,7 +248,7 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
               Privacy Settings
             </Title>
             <Spacer size="m" />
-            <Text className={styles.smallText} size="s" color="subdued">
+            <Text className={styles.smallText} size="s" color="primary">
               To optimize your experience, Redis Insight uses third-party tools.
             </Text>
             <Spacer />
@@ -287,7 +284,7 @@ const ConsentsSettings = ({ onSubmitted }: Props) => {
         <>
           <HorizontalRule margin="l" className={styles.requiredHR} />
           <Spacer size="m" />
-          <Text color="subdued" size="s" className={styles.smallText}>
+          <Text color="primary" size="s" className={styles.smallText}>
             Use of Redis Insight is governed by your signed agreement with
             Redis, or, if none, by the{' '}
             <Link

--- a/redisinsight/ui/src/components/consents-settings/styles.module.scss
+++ b/redisinsight/ui/src/components/consents-settings/styles.module.scss
@@ -8,14 +8,6 @@
   border: 1px solid var(--euiColorPrimary) !important;
   max-height: calc(100vh - 60px) !important;
   height: auto;
-
-  a {
-    color: currentColor !important;
-    text-decoration: underline;
-    &:hover {
-      text-decoration: none !important;
-    }
-  }
 }
 
 .modalHeader {

--- a/redisinsight/ui/src/constants/links.ts
+++ b/redisinsight/ui/src/constants/links.ts
@@ -21,6 +21,7 @@ export const EXTERNAL_LINKS = {
   rdiPipelineTransforms:
     'https://redis.io/docs/latest/integrate/redis-data-integration/ingest/data-pipelines/transform-examples/',
   pubSub: 'https://redis.io/docs/latest/commands/psubscribe/',
+  legalPrivacyPolicy: 'https://redis.io/legal/privacy-policy/',
 }
 
 export const UTM_CAMPAINGS: Record<any, string> = {

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/config/Config.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/config/Config.tsx
@@ -158,7 +158,7 @@ const Config = () => {
             source={RdiPipelineTabs.Config}
           />
         </div>
-        <Text className="rdi__text" color="primary">
+        <Text color="primary">
           {'Provide '}
           <Link
             data-testid="rdi-pipeline-config-link"

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/config/Config.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/config/Config.tsx
@@ -158,7 +158,7 @@ const Config = () => {
             source={RdiPipelineTabs.Config}
           />
         </div>
-        <Text className="rdi__text" color="subdued">
+        <Text className="rdi__text" color="primary">
           {'Provide '}
           <Link
             data-testid="rdi-pipeline-config-link"

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.tsx
@@ -215,7 +215,7 @@ const Job = (props: Props) => {
             />
           </div>
         </div>
-        <Text className="rdi__text" color="subdued">
+        <Text className="rdi__text" color="primary">
           {'Create a job per source table to filter, transform, and '}
           <Link
             data-testid="rdi-pipeline-transformation-link"

--- a/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management/pages/job/Job.tsx
@@ -215,7 +215,7 @@ const Job = (props: Props) => {
             />
           </div>
         </div>
-        <Text className="rdi__text" color="primary">
+        <Text color="primary">
           {'Create a job per source table to filter, transform, and '}
           <Link
             data-testid="rdi-pipeline-transformation-link"

--- a/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/DateTimeFormatter.tsx
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/DateTimeFormatter.tsx
@@ -4,7 +4,7 @@ import { formatTimestamp } from 'uiSrc/utils'
 import { DATETIME_FORMATTER_DEFAULT, TimezoneOption } from 'uiSrc/constants'
 import { userSettingsConfigSelector } from 'uiSrc/slices/user/user-settings'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
-import { Spacer } from 'uiSrc/components/base/layout/spacer'
+import { HorizontalSpacer, Spacer } from 'uiSrc/components/base/layout'
 import { Title } from 'uiSrc/components/base/text/Title'
 import { Text } from 'uiSrc/components/base/text'
 import TimezoneForm from './components/timezone-form/TimezoneForm'
@@ -29,13 +29,13 @@ const DateTimeFormatter = () => {
     <>
       <Title size="M">Date and Time Format</Title>
       <Spacer size="m" />
-      <Text color="subdued" className={styles.dateTimeSubtitle}>
+      <Text color="primary" className={styles.dateTimeSubtitle}>
         Specifies the date and time format to be used in Redis Insight:
       </Text>
       <Spacer size="m" />
       <DatetimeForm onFormatChange={(newPreview) => setPreview(newPreview)} />
       <Spacer size="m" />
-      <Text className={styles.dateTimeSubtitle} color="subdued">
+      <Text color="primary" className={styles.dateTimeSubtitle}>
         Specifies the time zone to be used in Redis Insight:
       </Text>
       <Spacer size="s" />
@@ -44,16 +44,15 @@ const DateTimeFormatter = () => {
           <FlexItem grow={1}>
             <TimezoneForm />
           </FlexItem>
-          <FlexItem grow={2}>
-            <div className={styles.previewContainer}>
-              <Text className={styles.dateTimeSubtitle} color="subdued">
-                Preview:
-              </Text>
-              <Text className={styles.preview} data-testid="data-preview">
-                {preview}
-              </Text>
-            </div>
-          </FlexItem>
+          <Row align="center">
+            <Text color="primary" size="m">
+              Preview:
+            </Text>
+            <HorizontalSpacer size="s" />
+            <Text data-testid="data-preview" size="m">
+              {preview}
+            </Text>
+          </Row>
         </Row>
       </div>
       <Spacer />

--- a/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/styles.module.scss
+++ b/redisinsight/ui/src/pages/settings/components/general-settings/datetime-formatter/styles.module.scss
@@ -6,21 +6,3 @@
   font-style: normal;
   letter-spacing: -0.14px;
 }
-
-.previewContainer {
-  display: flex;
-}
-
-.preview {
-  font-family: 'SourceCodePro',sans-serif;
-  font-size: 14px !important;
-  font-weight: 400;
-  line-height: 17.6px !important;
-  text-align: left;
-  background-color: var(--euiPageBackgroundColor);
-  padding: 4px;
-  margin-left: 4px;
-  overflow-x: hidden;
-  text-overflow: ellipsis;
-  max-width: 330px;
-}


### PR DESCRIPTION
#### Fix text and links on RDI page, Settings and EULA screen
- change text color from subdued (blueish) to primary
- remove custom and unneeded styles which automatically fix some alignments
- use theme variables and redis components where possible
- replace leftover EuiLink component

| Before | After |
| ----- | ------ |
| <img width="568" height="84" alt="image" src="https://github.com/user-attachments/assets/0506cc3d-2836-4074-af8c-861ad2b64e0e" /> | <img width="709" height="113" alt="image" src="https://github.com/user-attachments/assets/7ca4dec1-95b6-4deb-93b6-1e2c2779db56" /> |
| <img width="855" height="84" alt="image" src="https://github.com/user-attachments/assets/65a5e57c-a366-4c5e-a86a-0f0b7d185acf" /> | <img width="855" height="113" alt="image" src="https://github.com/user-attachments/assets/3371d959-aa5e-407e-ac10-29a1543e8f3f" /> |
| <img width="615" height="786" alt="image-20250826-212519" src="https://github.com/user-attachments/assets/d20be661-b08a-48cf-8d60-6181e028be77" /> | <img width="615" height="786" alt="image-20250826-212009" src="https://github.com/user-attachments/assets/d5820abd-635b-4b82-b4c4-4813b445e3bb" /> |
| <img width="855" height="732" alt="image" src="https://github.com/user-attachments/assets/fba77614-950e-40b8-b114-73686221827b" /> | <img width="810" height="715" alt="image" src="https://github.com/user-attachments/assets/72f4148f-5ff0-4157-a2dd-9cb219009c8c" /> |
| <img width="855" height="353" alt="image" src="https://github.com/user-attachments/assets/d94fff3c-970b-44be-84be-9517aead0500" /> | <img width="810" height="356" alt="image" src="https://github.com/user-attachments/assets/67aaa147-bd2f-4a10-8d46-488a11380b23" /> |