### PR TITLE
RI-7384: fix plugins imports to avoid riConfig or redux state initialization errors

### DIFF
--- a/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
+++ b/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
@@ -7,7 +7,7 @@ import { Table, ColumnDefinition } from 'uiSrc/components/base/layout/table'
 import { ColorText } from '../../../../../components/base/text/ColorText'
 import { IconButton } from '../../../../../components/base/forms/buttons'
 import { CopyIcon } from '../../../../../components/base/icons'
-import { RiTooltip } from '../../../../../components'
+import { RiTooltip } from '../../../../../components/base/tooltip/RITooltip'
 import { CommandArgument, Command } from '../../constants'
 import { formatLongName, replaceSpaces } from '../../utils'
 

--- a/redisinsight/ui/src/packages/redisgraph/src/Graph.tsx
+++ b/redisinsight/ui/src/packages/redisgraph/src/Graph.tsx
@@ -22,8 +22,8 @@ import {
 import { IconButton } from '../../../components/base/forms/buttons'
 import { CancelSlimIcon } from '../../../components/base/icons'
 import { SwitchInput } from 'uiSrc/components/base/inputs'
-import { RiTooltip } from 'uiSrc/components'
-import { TOOLTIP_DELAY_LONG } from 'uiSrc/constants'
+import { RiTooltip } from 'uiSrc/components/base/tooltip/RITooltip'
+import { TOOLTIP_DELAY_LONG } from 'uiSrc/constants/durationUnits'
 
 enum EntityType {
   Node = 'Node',

--- a/redisinsight/ui/src/packages/ri-explain/src/Explain.tsx
+++ b/redisinsight/ui/src/packages/ri-explain/src/Explain.tsx
@@ -6,7 +6,7 @@ import Hierarchy from '@antv/hierarchy'
 import { formatRedisReply } from 'redisinsight-plugin-sdk'
 
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
-import { RiTooltip } from 'uiSrc/components'
+import { RiTooltip } from 'uiSrc/components/base/tooltip/RITooltip'
 
 import {
   EDGE_COLOR_BODY_DARK,

--- a/redisinsight/ui/src/packages/ri-explain/src/Node.tsx
+++ b/redisinsight/ui/src/packages/ri-explain/src/Node.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
-import { RiTooltip } from 'uiSrc/components'
-import { TOOLTIP_DELAY_LONG } from 'uiSrc/constants'
+import { RiTooltip } from 'uiSrc/components/base/tooltip/RITooltip'
+import { TOOLTIP_DELAY_LONG } from 'uiSrc/constants/durationUnits'
 
 import { EntityInfo, EntityType } from './parser'
 


### PR DESCRIPTION
The main problem was related to how components imported to plugins.
e.g. `import { RiTooltip } from '../../../../../components'` will fail because bootstrap file in the components folder has more components which might require riConfig or redux state to be initialized
when change to `import { RiTooltip } from '../../../../../components/base/tooltip/RITooltip'` everything works since RiTooltip is stateless itself