### PR TITLE
RI-6962: add support to switch between time units for TS plugin visualization

### DIFF
--- a/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/Chart.tsx
+++ b/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/Chart.tsx
@@ -1,20 +1,20 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import Plotly from 'plotly.js-dist-min'
 import {
-  Legend,
+  Layout,
   LayoutAxis,
+  Legend,
   PlotData,
   PlotMouseEvent,
-  Layout,
   PlotRelayoutEvent,
 } from 'plotly.js'
 import { format } from 'date-fns'
 import {
-  hexToRGBA,
-  IGoodColor,
-  GoodColorPicker,
   COLORS,
   COLORS_DARK,
+  GoodColorPicker,
+  hexToRGBA,
+  IGoodColor,
 } from './utils'
 
 import { Datapoint, GraphMode, ChartProps, PlotlyEvents } from './interfaces'
@@ -78,21 +78,15 @@ export default function Chart(props: ChartProps) {
   }, [props.chartConfig])
 
   function getData(props: ChartProps): Partial<PlotData>[] {
-    return props.data.map((timeSeries, i) => {
-      const currentData = chartContainer.current.data
-      const dataUnchanged = currentData && props.data === props.data
+    return props.data.map((timeSeries) => {
       /*
        * Time format for inclusion of milliseconds:
        * https://github.com/moment/moment/issues/4864#issuecomment-440142542
        */
-      const x = dataUnchanged
-        ? currentData[i].x
-        : selectCol(timeSeries.datapoints, 0).map((time: number) =>
-            format(time, 'yyyy-MM-dd HH:mm:ss.SSS'),
-          )
-      const y = dataUnchanged
-        ? currentData[i].y
-        : selectCol(timeSeries.datapoints, 1)
+      const x = selectCol(timeSeries.datapoints, 0).map((time: number) =>
+        format(time, 'yyyy-MM-dd HH:mm:ss.SSS'),
+      )
+      const y = selectCol(timeSeries.datapoints, 1)
 
       return {
         x,

--- a/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/ChartConfigForm.tsx
+++ b/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/ChartConfigForm.tsx
@@ -2,7 +2,12 @@ import React, { useState } from 'react'
 
 import { SwitchInput, TextInput } from 'uiSrc/components/base/inputs'
 import { FormFieldset } from 'uiSrc/components/base/forms/fieldset'
-import { AxisScale, GraphMode, ChartConfigFormProps } from './interfaces'
+import {
+  AxisScale,
+  GraphMode,
+  ChartConfigFormProps,
+  TimeUnit,
+} from './interfaces'
 import {
   X_LABEL_MAX_LENGTH,
   Y_LABEL_MAX_LENGTH,
@@ -61,6 +66,11 @@ export default function ChartConfigForm(props: ChartConfigFormProps) {
           selected={value.mode}
           onClick={(v) => onChange('mode', v)}
         />
+        <NewEnumSelect
+          values={Object.keys(TimeUnit)}
+          selected={value.timeUnit}
+          onClick={(v) => onChange('timeUnit', v)}
+        />
         <SwitchInput
           title="Staircase"
           checked={value.staircase}
@@ -88,7 +98,6 @@ export default function ChartConfigForm(props: ChartConfigFormProps) {
                   onChange={(value) => onChange('title', value)}
                   aria-label="Title"
                   maxLength={parseInt(TITLE_MAX_LENGTH)}
-
                 />
               </FormFieldset>
               <FormFieldset legend={{ children: 'X axis Label' }}>

--- a/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/ChartResultView.tsx
+++ b/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/ChartResultView.tsx
@@ -1,13 +1,17 @@
 import React, { useState } from 'react'
 import {
+  AxisScale,
+  ChartConfig,
+  GraphMode,
   TimeSeries,
   YAxisConfig,
-  ChartConfig,
-  AxisScale,
-  GraphMode,
 } from './interfaces'
 import ChartConfigForm from './ChartConfigForm'
 import Chart from './Chart'
+import {
+  determineDefaultTimeUnits,
+  normalizeDatapointUnits,
+} from 'uiSrc/packages/redistimeseries-app/src/components/Chart/utils'
 
 enum LAYOUT_STATE {
   INITIAL_STATE,
@@ -30,6 +34,7 @@ export default function ChartResultView(props: ChartResultViewProps) {
 
   const [chartConfig, setChartConfig] = useState<ChartConfig>({
     mode: GraphMode.line,
+    timeUnit: determineDefaultTimeUnits(props.data),
     title: '',
     xlabel: '',
     staircase: false,
@@ -77,7 +82,7 @@ export default function ChartResultView(props: ChartResultViewProps) {
       </div>
       <Chart
         chartConfig={chartConfig}
-        data={props.data}
+        data={normalizeDatapointUnits(props.data, chartConfig.timeUnit)}
         onRelayout={onRelayout}
         onDoubleClick={onDoubleClick}
       />

--- a/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/interfaces.ts
+++ b/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/interfaces.ts
@@ -17,6 +17,11 @@ export interface TimeSeriesError {
   alt?: string[]
 }
 
+export enum TimeUnit {
+  seconds = 'seconds',
+  milliseconds = 'milliseconds',
+}
+
 export enum GraphMode {
   line = 'line',
   points = 'points',
@@ -34,6 +39,7 @@ export interface YAxisConfig {
 
 export interface ChartConfig {
   mode: GraphMode
+  timeUnit: TimeUnit
   xlabel: string
   title: string
   staircase: boolean

--- a/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/utils.test.ts
+++ b/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/utils.test.ts
@@ -1,4 +1,5 @@
-import { hexToRGBA } from './utils'
+import { hexToRGBA, normalizeDatapointUnits, determineDefaultTimeUnits } from './utils'
+import { TimeSeries, TimeUnit } from './interfaces'
 
 const hexToRGBATests: [string, string][] = [
   ['#fbafff', 'rgb(251, 175, 255)'],
@@ -17,4 +18,198 @@ describe('hexToRGBA', () => {
       expect(result).toBe(expected)
     },
   )
+})
+
+
+const normalizeDatapointUnitsTests: [TimeSeries[], TimeUnit, TimeSeries[]][] = [
+  // Test with seconds - should multiply timestamps by 1000
+  [
+    [
+      {
+        key: 'test-key-1',
+        labels: { app: 'redis' },
+        datapoints: [[1690000000, 'value1'], [1690000001, 'value2']]
+      }
+    ],
+    TimeUnit.seconds,
+    [
+      {
+        key: 'test-key-1',
+        labels: { app: 'redis' },
+        datapoints: [[1690000000000, 'value1'], [1690000001000, 'value2']]
+      }
+    ]
+  ],
+  // Test with milliseconds - should return unchanged
+  [
+    [
+      {
+        key: 'test-key-2',
+        labels: { service: 'cache' },
+        datapoints: [[1690000000000, 'value1'], [1690000001000, 'value2']]
+      }
+    ],
+    TimeUnit.milliseconds,
+    [
+      {
+        key: 'test-key-2',
+        labels: { service: 'cache' },
+        datapoints: [[1690000000000, 'value1'], [1690000001000, 'value2']]
+      }
+    ]
+  ],
+  // Test with multiple time series and seconds
+  [
+    [
+      {
+        key: 'series-1',
+        labels: { type: 'memory' },
+        datapoints: [[1690000000, 'mem1'], [1690000002, 'mem2']]
+      },
+      {
+        key: 'series-2',
+        labels: { type: 'cpu' },
+        datapoints: [[1690000001, 'cpu1'], [1690000003, 'cpu2']]
+      }
+    ],
+    TimeUnit.seconds,
+    [
+      {
+        key: 'series-1',
+        labels: { type: 'memory' },
+        datapoints: [[1690000000000, 'mem1'], [1690000002000, 'mem2']]
+      },
+      {
+        key: 'series-2',
+        labels: { type: 'cpu' },
+        datapoints: [[1690000001000, 'cpu1'], [1690000003000, 'cpu2']]
+      }
+    ]
+  ],
+  // Test with empty datapoints
+  [
+    [
+      {
+        key: 'empty-series',
+        labels: {},
+        datapoints: []
+      }
+    ],
+    TimeUnit.seconds,
+    [
+      {
+        key: 'empty-series',
+        labels: {},
+        datapoints: []
+      }
+    ]
+  ]
+]
+
+describe('normalizeDatapointUnits', () => {
+  it.each(normalizeDatapointUnitsTests)(
+    'should normalize datapoint units for input: %j with unit: %s',
+    (timeSeries, unit, expected) => {
+      const result = normalizeDatapointUnits(timeSeries, unit)
+      expect(result).toEqual(expected)
+    },
+  )
+
+  it('should return original data when an error occurs', () => {
+    // Create a scenario that might cause an error by passing invalid data
+    const invalidTimeSeries = null as any
+    const result = normalizeDatapointUnits(invalidTimeSeries, TimeUnit.seconds)
+    
+    expect(result).toBe(invalidTimeSeries)
+  })
+})
+
+const determineDefaultTimeUnitsTests: [TimeSeries[], TimeUnit][] = [
+  // Test with timestamp in milliseconds (> 1e10)
+  [
+    [
+      {
+        key: 'test-key-1',
+        labels: { app: 'redis' },
+        datapoints: [[1690000000000, 'value1']]
+      }
+    ],
+    TimeUnit.milliseconds
+  ],
+  // Test with timestamp in seconds (< 1e10)
+  [
+    [
+      {
+        key: 'test-key-2',
+        labels: { app: 'redis' },
+        datapoints: [[1690000000, 'value1']]
+      }
+    ],
+    TimeUnit.seconds
+  ],
+  // Test with exactly 1e10 (boundary case - should be seconds)
+  [
+    [
+      {
+        key: 'boundary-key',
+        labels: { type: 'boundary' },
+        datapoints: [[1e10, 'boundary-value']]
+      }
+    ],
+    TimeUnit.seconds
+  ],
+  // Test with timestamp much larger than 1e10
+  [
+    [
+      {
+        key: 'large-timestamp',
+        labels: { type: 'large' },
+        datapoints: [[1690000000000000, 'large-value']]
+      }
+    ],
+    TimeUnit.milliseconds
+  ],
+  // Test with multiple time series - should use first one
+  [
+    [
+      {
+        key: 'first-series',
+        labels: { order: 'first' },
+        datapoints: [[1690000000000, 'first-value']]
+      },
+      {
+        key: 'second-series',
+        labels: { order: 'second' },
+        datapoints: [[1690000000, 'second-value']]
+      }
+    ],
+    TimeUnit.milliseconds
+  ]
+]
+
+describe('determineDefaultTimeUnits', () => {
+  it.each(determineDefaultTimeUnitsTests)(
+    'should determine time unit for input: %j to be: %s',
+    (timeSeries, expected) => {
+      const result = determineDefaultTimeUnits(timeSeries)
+      expect(result).toBe(expected)
+    },
+  )
+
+  it('should return seconds for empty or invalid data', () => {
+    expect(determineDefaultTimeUnits([])).toBe(TimeUnit.seconds)
+    expect(determineDefaultTimeUnits(null as any)).toBe(TimeUnit.seconds)
+    expect(determineDefaultTimeUnits(undefined as any)).toBe(TimeUnit.seconds)
+  })
+
+  it('should return seconds for time series with no datapoints', () => {
+    const timeSeries: TimeSeries[] = [
+      {
+        key: 'empty-datapoints',
+        labels: {},
+        datapoints: []
+      }
+    ]
+    expect(determineDefaultTimeUnits(timeSeries)).toBe(TimeUnit.seconds)
+  })
 })

--- a/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/utils.ts
+++ b/redisinsight/ui/src/packages/redistimeseries-app/src/components/Chart/utils.ts
@@ -1,3 +1,8 @@
+import {
+  TimeSeries,
+  TimeUnit,
+} from './interfaces'
+
 function charCodeSum(str: string) {
   let sum = 0
   for (let i = 0; i < str.length; i++) {
@@ -133,4 +138,33 @@ export function hexToRGBA(hex: string, alpha: number): string {
   } else {
     return 'rgb(' + r + ', ' + g + ', ' + b + ')'
   }
+}
+
+export function normalizeDatapointUnits(
+  timeSeries: TimeSeries[],
+  unit: TimeUnit,
+): TimeSeries[] {
+  try {
+    if (unit === TimeUnit.seconds) {
+      return timeSeries.map((ts) => {
+        return {
+          ...ts,
+          datapoints: ts.datapoints.map(([timestamp, label]) => [
+            timestamp * 1_000,
+            label,
+          ]),
+        }
+      })
+    }
+  } catch (e) {
+    // ignore an error to return original data
+  }
+
+  return timeSeries
+}
+
+export function determineDefaultTimeUnits(timeSeries: TimeSeries[]): TimeUnit {
+  return timeSeries?.[0]?.datapoints?.[0]?.[0] > 1e10
+    ? TimeUnit.milliseconds
+    : TimeUnit.seconds
 }

--- a/redisinsight/ui/src/packages/redistimeseries-app/src/styles/styles.scss
+++ b/redisinsight/ui/src/packages/redistimeseries-app/src/styles/styles.scss
@@ -119,18 +119,18 @@ body {
         &:not(:first-child) {
           margin-top: 10px;
         }
-  
+
         .right-y-axis {
           display: flex;
           justify-content: space-between;
           align-items: center;
           width: 100%;
-  
+
           .switch-wrapper {
             width: 100%;
           }
         }
-  
+
         .y-axis-2 {
           width: 100%;
           .y-axis-2-item {
@@ -202,7 +202,7 @@ body {
         padding: 0px;
         font-weight: normal;
         height: 30px;
-        width: 68px;
+        min-width: 68px;
     }
 
     div:first-child {


### PR DESCRIPTION
In scope of this task new switcher for time units was added below the chart
Based on data we will determine default time unit: seconds or milliseconds
Anyway user will be able to switch manually

<img width="1296" height="447" alt="Screenshot 2025-08-27 at 15 56 58" src="https://github.com/user-attachments/assets/8f26871b-bfbc-41c8-bea0-ec30781f87c8" />
