### PR TITLE
RI-7330: remove show/hide for the password

### DIFF
--- a/redisinsight/ui/src/components/base/inputs/PasswordInput.tsx
+++ b/redisinsight/ui/src/components/base/inputs/PasswordInput.tsx
@@ -5,5 +5,5 @@ import { PasswordInput as RedisPasswordInput } from '@redis-ui/components'
 export type RedisPasswordInputProps = ComponentProps<typeof RedisPasswordInput>
 
 export default function PasswordInput(props: RedisPasswordInputProps) {
-  return <RedisPasswordInput {...props} />
+  return <RedisPasswordInput showExposureToggle="never" {...props} />
 }

--- a/redisinsight/ui/src/pages/home/components/form/DatabaseForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/DatabaseForm.tsx
@@ -201,7 +201,6 @@ const DatabaseForm = (props: Props) => {
               }}
               autoComplete="new-password"
               disabled={isFieldDisabled('password')}
-              showExposureToggle="never"
             />
           </FormField>
         </FlexItem>

--- a/redisinsight/ui/src/pages/home/components/form/DatabaseForm.tsx
+++ b/redisinsight/ui/src/pages/home/components/form/DatabaseForm.tsx
@@ -201,6 +201,7 @@ const DatabaseForm = (props: Props) => {
               }}
               autoComplete="new-password"
               disabled={isFieldDisabled('password')}
+              showExposureToggle="never"
             />
           </FormField>
         </FlexItem>


### PR DESCRIPTION
Due to security reasons, we do not want to have a functionality where password can be seen. Instead, when user clicks on the not empty password field, the field gets cleared and user can enter a new one without seeing the old. 
These changes just remove the hide / unhide button: 

| Before | After | 
| ---- | ---- |
| <img width="497" height="112" alt="image" src="https://github.com/user-attachments/assets/a5e6b2bf-0f93-4c3c-a202-9da34ed4a9a1" /> | <img width="497" height="112" alt="image" src="https://github.com/user-attachments/assets/1f40a5c0-6d62-4a18-977a-4a1aa88b63c5" /> |
| <img width="497" height="112" alt="image" src="https://github.com/user-attachments/assets/f5361e4c-b7b5-468b-b09c-2431d255bd4a" /> | <img width="497" height="112" alt="image" src="https://github.com/user-attachments/assets/13425881-b196-41e8-9e53-b9610458e059" />|