### PR TITLE
RI-7364 Connection to server lost

### DIFF
--- a/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
+++ b/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
@@ -34,7 +34,7 @@ export interface Props {
   testid?: string
   containerClassName?: string
   turnOffAutoRefresh?: boolean
-  onRefresh: (enableAutoRefresh: boolean) => void
+  onRefresh: (forceRefresh?: boolean) => void
   onRefreshClicked?: () => void
   onEnableAutoRefresh?: (
     enableAutoRefresh: boolean,
@@ -184,12 +184,12 @@ const AutoRefresh = ({
     setEditingRate(false)
   }
 
-  const handleRefresh = () => {
-    onRefresh(enableAutoRefresh)
+  const handleRefresh = (forceRefresh = false) => {
+    onRefresh(forceRefresh)
   }
 
   const handleRefreshClick = () => {
-    handleRefresh()
+    handleRefresh(true)
     onRefreshClicked?.()
   }
 

--- a/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.ts
+++ b/redisinsight/ui/src/components/database-overview/hooks/useDatabaseOverview.ts
@@ -48,8 +48,8 @@ export const useDatabaseOverview = () => {
     } = {},
   } = overview
 
-  const loadData = () => {
-    if (connectedInstanceId && !connectivityError) {
+  const loadData = (forceDataReload = false) => {
+    if (connectedInstanceId && (!connectivityError || forceDataReload)) {
       dispatch(getDatabaseConfigInfoAction(connectedInstanceId))
       setLastRefreshTime(Date.now())
     }
@@ -75,8 +75,8 @@ export const useDatabaseOverview = () => {
       },
     })
 
-  const handleRefresh = () => {
-    loadData()
+  const handleRefresh = (forceRefresh?: boolean) => {
+    loadData(forceRefresh)
   }
   const handleRefreshClick = () => {
     // clear error, if connectivity is broken, the interceptor will set it again

--- a/redisinsight/ui/src/pages/instance/instanceConnectionLost.spec.tsx
+++ b/redisinsight/ui/src/pages/instance/instanceConnectionLost.spec.tsx
@@ -14,15 +14,32 @@ import { ApiEndpoints } from 'uiSrc/constants'
 import { INSTANCES_MOCK } from 'uiSrc/mocks/handlers/instances/instancesHandlers'
 import { store } from 'uiSrc/slices/store'
 
-const initialState = set(cloneDeep(initialStateDefault), 'app.connectivity', {
-  loading: false,
-  error: 'Test error',
-})
-const mockedStore = mockStore(initialState)
+let mockedStore: ReturnType<typeof mockStore>
 
 beforeEach(() => {
   jest.resetAllMocks()
-  mockedStore.clearActions()
+
+  // Create fresh state for each test, inheriting all defaults
+  const initialState: typeof initialStateDefault = {
+    ...cloneDeep(initialStateDefault),
+    app: {
+      ...initialStateDefault.app,
+      connectivity: {
+        ...initialStateDefault.app.connectivity,
+        loading: false,
+        error: 'Test error',
+      },
+    },
+    connections: {
+      ...initialStateDefault.connections,
+      instances: {
+        ...initialStateDefault.connections.instances,
+        connectedInstance: INSTANCES_MOCK[0],
+      },
+    },
+  }
+
+  mockedStore = mockStore(initialState)
 })
 
 describe('instanceConnectionLost', () => {

--- a/redisinsight/ui/src/services/tests/apiService.spec.ts
+++ b/redisinsight/ui/src/services/tests/apiService.spec.ts
@@ -175,6 +175,39 @@ describe('connectivityErrorsInterceptor', () => {
       ])
     }
   })
+
+  it('should not dispatch connectivity error when instance ID does not match', async () => {
+    // Set up connected instance with different ID than the response URL
+    mockedTestStore.getState().connections.instances.connectedInstance = {
+      ...INSTANCES_MOCK[0],
+      id: 'different-instance-id',
+    }
+
+    jest
+      .spyOn(store, 'dispatch')
+      .mockImplementation(mockedTestStore.dispatch as any)
+    jest.spyOn(store, 'getState').mockImplementation(mockedTestStore.getState)
+
+    const response: any = {
+      response: {
+        status: 424,
+        data: {
+          error: 'RedisConnectionFailedException',
+        },
+        request: {
+          responseURL:
+            'http://localhost:5001/databases/test-instance-id/overview', // Different ID
+        },
+      },
+    }
+
+    try {
+      await connectivityErrorsInterceptor(response)
+    } catch {
+      // Should not dispatch any connectivity error actions
+      expect(mockedTestStore.getActions()).toEqual([])
+    }
+  })
 })
 
 describe('cloudAuthInterceptor', () => {

--- a/redisinsight/ui/src/services/tests/apiService.spec.ts
+++ b/redisinsight/ui/src/services/tests/apiService.spec.ts
@@ -13,6 +13,7 @@ import { store } from 'uiSrc/slices/store'
 import { setSSOFlow } from 'uiSrc/slices/instances/cloud'
 import { setConnectivityError } from 'uiSrc/slices/app/connectivity'
 import ApiErrors from 'uiSrc/constants/apiErrors'
+import { INSTANCES_MOCK } from 'uiSrc/mocks/handlers/instances/instancesHandlers'
 
 describe('requestInterceptor', () => {
   it('should properly set db-index to headers', () => {
@@ -71,6 +72,12 @@ describe('connectivityErrorsInterceptor', () => {
   })
 
   it('should properly handle 424 error and store default error message', async () => {
+    // Set up connected instance for interceptor to work
+    mockedTestStore.getState().connections.instances.connectedInstance = {
+      ...INSTANCES_MOCK[0],
+      id: 'test-instance-id',
+    }
+
     jest
       .spyOn(store, 'dispatch')
       .mockImplementation(mockedTestStore.dispatch as any)
@@ -82,17 +89,29 @@ describe('connectivityErrorsInterceptor', () => {
         data: {
           error: 'RedisConnectionFailedException',
         },
+        request: {
+          responseURL:
+            'http://localhost:5001/databases/test-instance-id/overview',
+        },
       },
     }
 
     try {
       await connectivityErrorsInterceptor(response)
     } catch {
-      expect(mockedTestStore.getActions()).toEqual([setConnectivityError(ApiErrors.ConnectionLost)])
+      expect(mockedTestStore.getActions()).toEqual([
+        setConnectivityError(ApiErrors.ConnectionLost),
+      ])
     }
   })
 
   it('should properly handle specific 424 error and store custom error message', async () => {
+    // Set up connected instance for interceptor to work
+    mockedTestStore.getState().connections.instances.connectedInstance = {
+      ...INSTANCES_MOCK[0],
+      id: 'test-instance-id',
+    }
+
     jest
       .spyOn(store, 'dispatch')
       .mockImplementation(mockedTestStore.dispatch as any)
@@ -106,17 +125,29 @@ describe('connectivityErrorsInterceptor', () => {
           error: 'RedisConnectionFailedException',
           errorCode: CustomErrorCodes.RedisConnectionDefaultUserDisabled,
         },
+        request: {
+          responseURL:
+            'http://localhost:5001/databases/test-instance-id/overview',
+        },
       },
     }
 
     try {
       await connectivityErrorsInterceptor(response)
     } catch {
-      expect(mockedTestStore.getActions()).toEqual([setConnectivityError('custom message')])
+      expect(mockedTestStore.getActions()).toEqual([
+        setConnectivityError('custom message'),
+      ])
     }
   })
 
   it('should properly handle specific 424 error and store default error message when no message available', async () => {
+    // Set up connected instance for interceptor to work
+    mockedTestStore.getState().connections.instances.connectedInstance = {
+      ...INSTANCES_MOCK[0],
+      id: 'test-instance-id',
+    }
+
     jest
       .spyOn(store, 'dispatch')
       .mockImplementation(mockedTestStore.dispatch as any)
@@ -129,13 +160,19 @@ describe('connectivityErrorsInterceptor', () => {
           error: 'RedisConnectionFailedException',
           errorCode: CustomErrorCodes.RedisConnectionDefaultUserDisabled,
         },
+        request: {
+          responseURL:
+            'http://localhost:5001/databases/test-instance-id/overview',
+        },
       },
     }
 
     try {
       await connectivityErrorsInterceptor(response)
     } catch {
-      expect(mockedTestStore.getActions()).toEqual([setConnectivityError(ApiErrors.ConnectionLost)])
+      expect(mockedTestStore.getActions()).toEqual([
+        setConnectivityError(ApiErrors.ConnectionLost),
+      ])
     }
   })
 })
@@ -186,7 +223,7 @@ describe('cloudAuthInterceptor', () => {
 })
 
 describe('isConnectivityError', () => {
-  it.each<{apiResponse: any, result: boolean}>([
+  it.each<{ apiResponse: any; result: boolean }>([
     {
       apiResponse: undefined,
       result: false,
@@ -244,8 +281,10 @@ describe('isConnectivityError', () => {
         },
       },
       result: false,
-    }
+    },
   ])('test %j', ({ apiResponse, result }) => {
-    expect(isConnectivityError(apiResponse?.status, apiResponse?.data)).toEqual(result)
+    expect(isConnectivityError(apiResponse?.status, apiResponse?.data)).toEqual(
+      result,
+    )
   })
 })

--- a/redisinsight/ui/src/slices/tests/app/connectivity.spec.ts
+++ b/redisinsight/ui/src/slices/tests/app/connectivity.spec.ts
@@ -23,6 +23,7 @@ import {
   getDatabaseConfigInfoFailure,
   getDatabaseConfigInfoSuccess,
 } from 'uiSrc/slices/instances/instances'
+import { INSTANCES_MOCK } from 'uiSrc/mocks/handlers/instances/instancesHandlers'
 
 let testStore: typeof mockedStore
 const onSuccessAction = jest.fn()
@@ -81,6 +82,12 @@ describe('app connectivity slice', () => {
 
   describe('retryConnection', () => {
     it('should handle success path', async () => {
+      // Set connected instance for interceptor to work
+      testStore.getState().connections.instances.connectedInstance = {
+        ...INSTANCES_MOCK[0],
+        id: '123', // Match the test database ID
+      }
+
       const getDbOverviewMock = jest.fn((_req, res, ctx) => res(ctx.json({})))
       mswServer.use(
         rest.get(
@@ -104,7 +111,7 @@ describe('app connectivity slice', () => {
           setConnectivityLoading(false),
         ]
 
-        expect(mockedStore.getActions()).toEqual(expectedActions)
+        expect(testStore.getActions()).toEqual(expectedActions)
       })
 
       expect(onSuccessAction).toHaveBeenCalledTimes(1)
@@ -112,8 +119,14 @@ describe('app connectivity slice', () => {
     })
 
     it('should handle failure path', async () => {
+      // Set connected instance for interceptor to work
+      testStore.getState().connections.instances.connectedInstance = {
+        ...INSTANCES_MOCK[0],
+        id: '123', // Match the test database ID
+      }
+
       jest.spyOn(store, 'dispatch').mockImplementation((action: any) => {
-        mockedStore.dispatch(action)
+        testStore.dispatch(action)
       })
       const getDbOverviewMock = jest.fn((_req, res, ctx) =>
         res(
@@ -143,7 +156,7 @@ describe('app connectivity slice', () => {
           setConnectivityLoading(false),
         ]
 
-        expect(mockedStore.getActions()).toEqual(expectedActions)
+        expect(testStore.getActions()).toEqual(expectedActions)
       })
 
       expect(onSuccessAction).not.toHaveBeenCalled()


### PR DESCRIPTION
# Description

Fix the "Connection Status" indicator in the Database Overview section to not alert that the connection is lost when it actually is active. It was happening when you try to establish a connection with another (not-running) database, wrongly affecting the status indicator for the current database connection.

_PS: Additionally, I found a weird behavior that the manual Refresh of the connection status was not working consistently. You can learn more about that in the comments below._ 

<img width="2202" height="1100" alt="image" src="https://github.com/user-attachments/assets/e229cd64-d268-4a2b-9b25-025bd8ffb7e8" />

# How it was tested

1. Open Redis Insight and connect to a (_running_) database instance, you should be able to do so
2. Try to switch the database connection to another **not-running** database instance, a toast notification will inform you, and the status icon in the top navbar shouldn't turn red
3. If you turn off the Redis instance of the active connection, a toast notification will inform you about the lost connection, and the status icon in the top navbar will turn red

## Before 

As you can see, when we're connected to a database instance and try to establish a connection with other (not-running) database, it also affects the status indicator of the current database.

https://github.com/user-attachments/assets/7b8b031c-eb97-403f-b86a-6d8d374f25fb

## After

Now, we no longer update the status indicator when we receive a "connection lost" error if it's not related to the active connection.

https://github.com/user-attachments/assets/f63e934b-7257-485a-9f0e-aa13a00f36ea

Of course, if we receive a "connection lost" error related to the active connection, we do update the status indicator, as expected.

https://github.com/user-attachments/assets/12caef3b-8001-463d-8d9a-98839ee1d79f


