### PR TITLE
DEV: Remove unsupported devEngines field 

### DIFF
--- a/package.json
+++ b/package.json
@@ -317,11 +317,6 @@
     "npm": ">=6.x",
     "yarn": ">=1.21.3"
   },
-  "devEngines": {
-    "node": ">=22.x",
-    "npm": ">=6.x",
-    "yarn": ">=1.21.3"
-  },
   "browser": {
     "uuid": "./node_modules/uuid/dist/esm-browser/index.js"
   }


### PR DESCRIPTION
The `devEngines` field has changed in newer versions of npm and is now causing issues. For example, running `npx npkill` fails with:

```
npm error Invalid property "node"
```

This happens because npm expects a different format ([docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines)).

Additional context can be found [in this StackOverflow thread](https://stackoverflow.com/questions/79204945/why-does-npm-keep-giving-out-invalid-property-node).

TL;DR: The engines field already covers the original intent of devEngines. If we need runtime-specific configs in the future, we should add them via the officially supported configuration options.