### PR TITLE
RI-7410: Exclude backend dependencies from frontend optimisation

### DIFF
--- a/redisinsight/ui/vite.config.mjs
+++ b/redisinsight/ui/vite.config.mjs
@@ -101,6 +101,18 @@ export default defineConfig({
       '@antv/x6',
       '@antv/x6-react-shape',
       '@antv/hierarchy',
+      'class-transformer',
+      'keytar',
+      '@nestjs/common',
+      '@nestjs/core',
+      '@nestjs/event-emitter',
+      '@nestjs/platform-express',
+      '@nestjs/platform-socket.io',
+      '@nestjs/serve-static',
+      '@nestjs/swagger',
+      '@nestjs/typeorm',
+      '@nestjs/websockets',
+      'nestjs-form-data',
     ],
     esbuildOptions: {
       // fix for https://github.com/bvaughn/react-virtualized/issues/1722


### PR DESCRIPTION
When you install the dependencies root level, usually something like this happens:

<img width="667" height="545" alt="Screenshot 2025-09-02 at 16 05 54" src="https://github.com/user-attachments/assets/1cbdf573-f84f-4cdf-b871-5cd8a0f8ed29" />

which is caused by Vite, which is trying to optimise dependencies. The problem is that some of these dependencies are Node.js ones, not meant to run on the browser => we're getting errors.

There are probably more dependencies that can be included:
```
'class-validator',
'ioredis',
'redis',
'typeorm',
'sqlite3',
'express',
'socket.io',
'socket.io-client',
'fs-extra',
'jsonwebtoken',
'winston',
'adm-zip',
'busboy',
'tunnel-ssh',
'@segment/analytics-node',
```

but my driver for opening this PR was the ugly error, so if we find it useful to add more of that list, we can do it in a separate PR.
