### PR TITLE
RI-7259: Fix Toast message display by highlighting the title

### DIFF
--- a/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
+++ b/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
@@ -34,7 +34,7 @@ export const riToast = (
     }
     toastContent.message = (
       <ColorText color={color}>
-        <Title size="M">{message}</Title>
+        <Title size="XS">{message}</Title>
         <Spacer size="m" />
       </ColorText>
     )

--- a/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
+++ b/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
@@ -35,7 +35,7 @@ export const riToast = (
     toastContent.message = (
       <ColorText color={color}>
         <Title size="XS">{message}</Title>
-        <Spacer size="m" />
+        <Spacer size="s" />
       </ColorText>
     )
   } else {

--- a/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
+++ b/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
@@ -8,7 +8,7 @@ import {
 
 import { CommonProps } from 'uiSrc/components/base/theme/types'
 import { CancelIcon } from 'uiSrc/components/base/icons'
-import { ColorText, Title } from 'uiSrc/components/base/text'
+import { ColorText, Text } from 'uiSrc/components/base/text'
 import { Spacer } from '../../layout'
 
 type RiToastProps = React.ComponentProps<typeof Toast>
@@ -34,7 +34,9 @@ export const riToast = (
     }
     toastContent.message = (
       <ColorText color={color}>
-        <Title size="XS">{message}</Title>
+        <Text size="M" variant="semiBold">
+          {message}
+        </Text>
         <Spacer size="s" />
       </ColorText>
     )

--- a/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
+++ b/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
@@ -5,17 +5,14 @@ import {
   ToastContentParams,
   ToastOptions,
 } from '@redis-ui/components'
-import styled from 'styled-components'
-import { CommonProps, Theme } from 'uiSrc/components/base/theme/types'
+
+import { CommonProps } from 'uiSrc/components/base/theme/types'
 import { CancelIcon } from 'uiSrc/components/base/icons'
-import { ColorText } from 'uiSrc/components/base/text'
+import { ColorText, Title } from 'uiSrc/components/base/text'
+import { Spacer } from '../../layout'
 
 type RiToastProps = React.ComponentProps<typeof Toast>
 export const RiToast = (props: RiToastProps) => <Toast {...props} />
-
-const StyledMessage = styled.div<{ theme: Theme }>`
-  margin-bottom: ${({ theme }) => theme.core.space.space100};
-`
 
 type RiToastType = ToastContentParams &
   CommonProps & {
@@ -37,7 +34,8 @@ export const riToast = (
     }
     toastContent.message = (
       <ColorText color={color}>
-        <StyledMessage>{message}</StyledMessage>
+        <Title size="M">{message}</Title>
+        <Spacer size="m" />
       </ColorText>
     )
   } else {

--- a/redisinsight/ui/src/components/notifications/Notifications.tsx
+++ b/redisinsight/ui/src/components/notifications/Notifications.tsx
@@ -16,7 +16,6 @@ import { showOAuthProgress } from 'uiSrc/slices/oauth/cloud'
 import { CustomErrorCodes } from 'uiSrc/constants'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { ColorText } from 'uiSrc/components/base/text'
-import { InfoIcon } from 'uiSrc/components/base/icons'
 import { riToast, RiToaster } from 'uiSrc/components/base/display/toast'
 
 import errorMessages from './error-messages'
@@ -69,7 +68,6 @@ const Notifications = () => {
           className,
           message: title,
           description: getSuccessText(message),
-          customIcon: InfoIcon,
           actions: {
             primary: {
               closes: true,

--- a/redisinsight/ui/src/components/notifications/Notifications.tsx
+++ b/redisinsight/ui/src/components/notifications/Notifications.tsx
@@ -71,7 +71,7 @@ const Notifications = () => {
           actions: {
             primary: {
               closes: true,
-              label: 'Ok',
+              label: 'OK',
               onClick: handleClose,
             },
           },

--- a/redisinsight/ui/src/components/notifications/success-messages.tsx
+++ b/redisinsight/ui/src/components/notifications/success-messages.tsx
@@ -21,35 +21,45 @@ export default {
   ADDED_NEW_INSTANCE: (instanceName: string) => ({
     title: 'Database has been added',
     message: (
-      <>
-        <b>{formatNameShort(instanceName)}</b> has been added to Redis Insight.
-      </>
+      <Text component="span">
+        <Text variant="semiBold" component="span">
+          {formatNameShort(instanceName)}
+        </Text>{' '}
+        has been added to Redis Insight.
+      </Text>
     ),
   }),
   ADDED_NEW_RDI_INSTANCE: (instanceName: string) => ({
     title: 'Instance has been added',
     message: (
-      <>
-        <b>{formatNameShort(instanceName)}</b> has been added to RedisInsight.
-      </>
+      <Text component="span">
+        <Text variant="semiBold" component="span">
+          {formatNameShort(instanceName)}
+        </Text>{' '}
+        has been added to RedisInsight.
+      </Text>
     ),
   }),
   DELETE_INSTANCE: (instanceName: string) => ({
     title: 'Database has been deleted',
     message: (
-      <>
-        <b>{formatNameShort(instanceName)}</b> has been deleted from Redis
-        Insight.
-      </>
+      <Text component="span">
+        <Text variant="semiBold" component="span">
+          {formatNameShort(instanceName)}
+        </Text>{' '}
+        has been deleted from Redis Insight.
+      </Text>
     ),
   }),
   DELETE_RDI_INSTANCE: (instanceName: string) => ({
     title: 'Instance has been deleted',
     message: (
-      <>
-        <b>{formatNameShort(instanceName)}</b> has been deleted from
-        RedisInsight.
-      </>
+      <Text component="span">
+        <Text variant="semiBold" component="span">
+          {formatNameShort(instanceName)}
+        </Text>{' '}
+        has been deleted from RedisInsight.
+      </Text>
     ),
   }),
   DELETE_INSTANCES: (instanceNames: Maybe<string>[]) => {
@@ -58,10 +68,12 @@ export default {
       title: 'Databases have been deleted',
       message: (
         <>
-          <span>
-            <b>{instanceNames.length}</b> databases have been deleted from Redis
-            Insight:
-          </span>
+          <Text component="span">
+            <Text variant="semiBold" component="span">
+              {instanceNames.length}
+            </Text>{' '}
+            databases have been deleted from Redis Insight:
+          </Text>
           <ul style={{ marginBottom: 0 }}>
             {instanceNames.slice(0, limitShowRemovedInstances).map((el, i) => (
               // eslint-disable-next-line react/no-array-index-key
@@ -81,10 +93,12 @@ export default {
       title: 'Instances have been deleted',
       message: (
         <>
-          <span>
-            <b>{instanceNames.length}</b> instances have been deleted from
-            RedisInsight:
-          </span>
+          <Text component="span">
+            <Text variant="semiBold" component="span">
+              {instanceNames.length}
+            </Text>{' '}
+            instances have been deleted from RedisInsight:
+          </Text>
           <ul style={{ marginBottom: 0 }}>
             {instanceNames.slice(0, limitShowRemovedInstances).map((el, i) => (
               // eslint-disable-next-line react/no-array-index-key
@@ -101,17 +115,23 @@ export default {
   ADDED_NEW_KEY: (keyName: RedisResponseBuffer) => ({
     title: 'Key has been added',
     message: (
-      <>
-        <b>{formatNameShort(bufferToString(keyName))}</b> has been added.
-      </>
+      <Text component="span">
+        <Text variant="semiBold" component="span">
+          {formatNameShort(bufferToString(keyName))}
+        </Text>{' '}
+        has been added.
+      </Text>
     ),
   }),
   DELETED_KEY: (keyName: RedisResponseBuffer) => ({
     title: 'Key has been deleted',
     message: (
-      <>
-        <b>{formatNameShort(bufferToString(keyName))}</b> has been deleted.
-      </>
+      <Text component="span">
+        <Text variant="semiBold" component="span">
+          {formatNameShort(bufferToString(keyName))}
+        </Text>{' '}
+        has been deleted.
+      </Text>
     ),
   }),
   REMOVED_KEY_VALUE: (
@@ -126,9 +146,13 @@ export default {
     ),
     message: (
       <>
-        <b>{formatNameShort(bufferToString(keyValue))}</b> has been removed from
-        &nbsp;
-        <b>{formatNameShort(bufferToString(keyName))}</b>
+        <Text variant="semiBold" component="span">
+          {formatNameShort(bufferToString(keyValue))}
+        </Text>{' '}
+        has been removed from &nbsp;
+        <Text variant="semiBold" component="span">
+          {formatNameShort(bufferToString(keyName))}
+        </Text>
       </>
     ),
   }),
@@ -183,9 +207,12 @@ export default {
   MESSAGE_ACTION: (message: string, actionName: string) => ({
     title: <>Message has been {actionName}</>,
     message: (
-      <>
-        <b>{message}</b> has been successfully {actionName}.
-      </>
+      <Text component="span">
+        <Text variant="semiBold" component="span">
+          {message}
+        </Text>{' '}
+        has been successfully {actionName}.
+      </Text>
     ),
   }),
   NO_CLAIMED_MESSAGES: () => ({
@@ -199,9 +226,12 @@ export default {
   DELETE_INDEX: (indexName: string) => ({
     title: 'Index has been deleted',
     message: (
-      <>
-        <b>{formatNameShort(indexName)}</b> has been deleted.
-      </>
+      <Text component="span">
+        <Text variant="semiBold" component="span">
+          {formatNameShort(indexName)}
+        </Text>{' '}
+        has been deleted.
+      </Text>
     ),
   }),
   TEST_CONNECTION: () => ({
@@ -264,17 +294,23 @@ export default {
   DELETE_LIBRARY: (libraryName: string) => ({
     title: 'Library has been deleted',
     message: (
-      <>
-        <b>{formatNameShort(libraryName)}</b> has been deleted.
-      </>
+      <Text component="span">
+        <Text variant="semiBold" component="span">
+          {formatNameShort(libraryName)}
+        </Text>{' '}
+        has been deleted.
+      </Text>
     ),
   }),
   ADD_LIBRARY: (libraryName: string) => ({
     title: 'Library has been added',
     message: (
-      <>
-        <b>{formatNameShort(libraryName)}</b> has been added.
-      </>
+      <Text component="span">
+        <Text variant="semiBold" component="span">
+          {formatNameShort(libraryName)}
+        </Text>{' '}
+        has been added.
+      </Text>
     ),
   }),
   REMOVED_ALL_CAPI_KEYS: () => ({


### PR DESCRIPTION
#### Add styling to redis ui toast messages
- Make the title same size as the text, but bold
- Make the added / deleted or whatever contents needs to be highlighted - to be bold
- Change Ok to OK for success messages to match error messages 

| Before | After |
| ---- | ---- |
| <img width="439" height="124" alt="Screenshot 2025-07-25 at 15 32 05" src="https://github.com/user-attachments/assets/2c2d2667-108a-4fc6-920f-9d7d877f0885" /> | <img width="458" height="119" alt="image" src="https://github.com/user-attachments/assets/455fcf3c-fbab-44c9-8391-7da63b3f877a" /> <img width="458" height="93" alt="image" src="https://github.com/user-attachments/assets/fea03d8e-47f7-426a-814e-3c8e8d805c14" /> |


