### PR TITLE
Trigger the tests in the CI via a label

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ on:
       - 'feature/**'
       - 'bugfix/**'
       - 'ric/**'
+  pull_request:
+    types: [labeled]
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
# Description

Add a way to trigger the tests in the CI via a label, so we can run them for the open source contributions when they don't follow the branch naming strategy (_that runs them automatically_).
- `run-all-tests`
- `run-frontend-tests`
- `run-backend-tests`
- `run-integration-tests`