### PR TITLE
RI-7431: Layout fixed. Rework keys list/tree header

### DIFF
--- a/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
+++ b/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import cx from 'classnames'
+import styled from 'styled-components'
 import { ChevronDownIcon, ResetIcon } from 'uiSrc/components/base/icons'
 import {
   errorValidateRefreshRateNumber,
@@ -7,6 +8,8 @@ import {
   Nullable,
   validateRefreshRateNumber,
 } from 'uiSrc/utils'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
+import { Theme } from 'uiSrc/components/base/theme/types'
 import InlineItemEditor from 'uiSrc/components/inline-item-editor'
 import { localStorageService } from 'uiSrc/services'
 import { BrowserStorageItem } from 'uiSrc/constants'
@@ -199,119 +202,157 @@ const AutoRefresh = ({
     onEnableAutoRefresh?.(value, refreshRate)
   }
 
+  const AutoRefreshInterval = styled('span')`
+    color: ${({ theme }: { theme: Theme }) =>
+      !disabled && enableAutoRefresh
+        ? theme.semantic.color.text.primary400
+        : 'inherit'};
+    opacity: ${disabled ? '0.5' : 'inherit'};
+  `
+
+  const AutoRefreshButton = styled(IconButton)`
+    color: ${({ theme }: { theme: Theme }) =>
+      !disabled && enableAutoRefresh
+        ? theme.semantic.color.text.primary400
+        : 'inherit'};
+  `
+
+  const AutoRefreshConfigButton = styled(IconButton)`
+    svg {
+      width: 10px;
+      height: 10px;
+    }
+    background-color: ${({ theme }: { theme: Theme }) =>
+      isPopoverOpen ? theme.color.gray100 : 'transparent'};
+  }
+`
+
   return (
-    <div
-      className={cx(styles.container, containerClassName, {
+    <Row
+      align="center"
+      gap="m"
+      className={cx(containerClassName, {
         [styles.enable]: !disabled && enableAutoRefresh,
       })}
       data-testid={getDataTestid('auto-refresh-container')}
     >
-      <ColorText className={styles.summary}>
-        {displayText && (
-          <span data-testid={getDataTestid('refresh-message-label')}>
-            {enableAutoRefresh ? 'Auto refresh:' : 'Last refresh:'}
-          </span>
-        )}
-        {displayLastRefresh && (
-          <span
-            className={cx('refresh-message-time', styles.time, {
-              [styles.disabled]: disabled,
-            })}
-            data-testid={getDataTestid('refresh-message')}
-          >
-            {` ${enableAutoRefresh ? refreshRateMessage : refreshMessage}`}
-          </span>
-        )}
-      </ColorText>
-
-      <RiTooltip
-        title={!disabled && 'Last Refresh'}
-        className={styles.tooltip}
-        position="top"
-        content={disabled ? disabledRefreshButtonMessage : refreshMessage}
-        data-testid={getDataTestid('refresh-tooltip')}
-      >
-        <IconButton
-          size={iconSize}
-          icon={ResetIcon}
-          disabled={loading || disabled}
-          onClick={handleRefreshClick}
-          onMouseEnter={updateLastRefresh}
-          className={cx('auto-refresh-btn', styles.btn, {
-            [styles.rolling]: !disabled && enableAutoRefresh,
-          })}
-          aria-labelledby={getDataTestid('refresh-btn')?.replaceAll?.('-', ' ')}
-          data-testid={getDataTestid('refresh-btn')}
-        />
-      </RiTooltip>
-
-      <RiPopover
-        ownFocus={false}
-        anchorPosition="downRight"
-        isOpen={isPopoverOpen}
-        anchorClassName={styles.anchorWrapper}
-        panelClassName={cx('popover-without-top-tail', styles.popoverWrapper, {
-          [styles.popoverWrapperEditing]: editingRate,
-        })}
-        closePopover={closePopover}
-        button={
-          <IconButton
-            disabled={disabled}
-            size="S"
-            icon={ChevronDownIcon}
-            aria-label="Auto-refresh config popover"
-            className={cx(styles.anchorBtn, {
-              [styles.anchorBtnOpen]: isPopoverOpen,
-            })}
-            onClick={onButtonClick}
-            data-testid={getDataTestid('auto-refresh-config-btn')}
-          />
-        }
-      >
-        <SwitchInput
-          title="Auto Refresh"
-          checked={enableAutoRefresh}
-          onCheckedChange={onChangeEnableAutoRefresh}
-          className={styles.switchOption}
-          data-testid={getDataTestid('auto-refresh-switch')}
-        />
-        <div className={styles.inputContainer}>
-          <div className={styles.inputLabel}>Refresh rate:</div>
-          {!editingRate && (
-            <ColorText
-              className={styles.refreshRateText}
-              onClick={() => setEditingRate(true)}
-              data-testid={getDataTestid('refresh-rate')}
+      <FlexItem>
+        <ColorText size="s">
+          {displayText && (
+            <span data-testid={getDataTestid('refresh-message-label')}>
+              {enableAutoRefresh ? 'Auto refresh:' : 'Last refresh:'}
+            </span>
+          )}
+          {displayLastRefresh && (
+            <AutoRefreshInterval
+              className={cx('refresh-message-time')}
+              data-testid={getDataTestid('refresh-message')}
             >
-              {`${refreshRate} s`}
-              <div className={styles.refreshRatePencil}>
-                <RiIcon type="EditIcon" />
-              </div>
-            </ColorText>
+              {` ${enableAutoRefresh ? refreshRateMessage : refreshMessage}`}
+            </AutoRefreshInterval>
           )}
-          {editingRate && (
-            <>
-              <div
-                className={styles.input}
-                data-testid={getDataTestid('auto-refresh-rate-input')}
-              >
-                <InlineItemEditor
-                  initialValue={refreshRate}
-                  fieldName="refreshRate"
-                  placeholder={DEFAULT_REFRESH_RATE}
-                  isLoading={loading}
-                  validation={validateRefreshRateNumber}
-                  disableByValidation={errorValidateRefreshRateNumber}
-                  onDecline={() => handleDeclineAutoRefreshRate()}
-                  onApply={(value) => handleApplyAutoRefreshRate(value)}
+        </ColorText>
+      </FlexItem>
+      <FlexItem>
+        <Row align="center" gap="none">
+          <FlexItem>
+            <RiTooltip
+              title={!disabled && 'Last Refresh'}
+              className={styles.tooltip}
+              position="top"
+              content={disabled ? disabledRefreshButtonMessage : refreshMessage}
+              data-testid={getDataTestid('refresh-tooltip')}
+            >
+              <AutoRefreshButton
+                size={iconSize}
+                icon={ResetIcon}
+                disabled={loading || disabled}
+                onClick={handleRefreshClick}
+                onMouseEnter={updateLastRefresh}
+                className={cx('auto-refresh-btn')}
+                aria-labelledby={getDataTestid('refresh-btn')?.replaceAll?.(
+                  '-',
+                  ' ',
+                )}
+                data-testid={getDataTestid('refresh-btn')}
+              />
+            </RiTooltip>
+          </FlexItem>
+          <FlexItem>
+            <RiPopover
+              ownFocus={false}
+              anchorPosition="downRight"
+              isOpen={isPopoverOpen}
+              anchorClassName={styles.anchorWrapper}
+              panelClassName={cx(
+                'popover-without-top-tail',
+                styles.popoverWrapper,
+                {
+                  [styles.popoverWrapperEditing]: editingRate,
+                },
+              )}
+              closePopover={closePopover}
+              button={
+                <AutoRefreshConfigButton
+                  disabled={disabled}
+                  size="XS"
+                  icon={ChevronDownIcon}
+                  aria-label="Auto-refresh config popover"
+                  className={cx(styles.anchorBtn, {
+                    [styles.anchorBtnOpen]: isPopoverOpen,
+                  })}
+                  onClick={onButtonClick}
+                  data-testid={getDataTestid('auto-refresh-config-btn')}
                 />
+              }
+            >
+              <SwitchInput
+                title="Auto Refresh"
+                checked={enableAutoRefresh}
+                onCheckedChange={onChangeEnableAutoRefresh}
+                className={styles.switchOption}
+                data-testid={getDataTestid('auto-refresh-switch')}
+              />
+              <div className={styles.inputContainer}>
+                <div className={styles.inputLabel}>Refresh rate:</div>
+                {!editingRate && (
+                  <ColorText
+                    className={styles.refreshRateText}
+                    onClick={() => setEditingRate(true)}
+                    data-testid={getDataTestid('refresh-rate')}
+                  >
+                    {`${refreshRate} s`}
+                    <div className={styles.refreshRatePencil}>
+                      <RiIcon type="EditIcon" />
+                    </div>
+                  </ColorText>
+                )}
+                {editingRate && (
+                  <>
+                    <div
+                      className={styles.input}
+                      data-testid={getDataTestid('auto-refresh-rate-input')}
+                    >
+                      <InlineItemEditor
+                        initialValue={refreshRate}
+                        fieldName="refreshRate"
+                        placeholder={DEFAULT_REFRESH_RATE}
+                        isLoading={loading}
+                        validation={validateRefreshRateNumber}
+                        disableByValidation={errorValidateRefreshRateNumber}
+                        onDecline={() => handleDeclineAutoRefreshRate()}
+                        onApply={(value) => handleApplyAutoRefreshRate(value)}
+                      />
+                    </div>
+                    <ColorText>{' s'}</ColorText>
+                  </>
+                )}
               </div>
-              <ColorText>{' s'}</ColorText>
-            </>
-          )}
-        </div>
-      </RiPopover>
-    </div>
+            </RiPopover>
+          </FlexItem>
+        </Row>
+      </FlexItem>
+    </Row>
   )
 }
 

--- a/redisinsight/ui/src/components/auto-refresh/styles.module.scss
+++ b/redisinsight/ui/src/components/auto-refresh/styles.module.scss
@@ -1,39 +1,3 @@
-.container {
-  position: relative;
-  white-space: nowrap;
-}
-
-.btn {
-  display: inline-block;
-  margin-top: 1px;
-  transition: transform 0.3s ease;
-
-  &:global(.euiButtonIcon--xSmall) {
-    svg {
-      width: 16px;
-      height: 16px;
-    }
-  }
-
-  svg {
-    width: 18px;
-    height: 18px;
-  }
-
-  &.rolling svg {
-    color: var(--euiColorPrimary) !important;
-  }
-}
-
-.time {
-  padding-right: 6px;
-  color: var(--euiTextSubduedColor) !important;
-
-  &.disabled {
-    opacity: 0.5;
-  }
-}
-
 .summary {
   color: var(--euiColorMediumShade) !important;
   vertical-align: middle;
@@ -82,36 +46,8 @@
   color: var(--euiTextSubduedColor) !important;
 }
 
-.anchorBtn {
-  width: 18px !important;
-  height: 22px !important;
-  margin-top: 4px;
-
-  &Open {
-    background-color: var(--browserComponentActive) !important;
-    border-bottom: 2px solid var(--euiColorPrimary) !important;
-    border-radius: 4px 4px 0 0 !important;
-  }
-
-  svg {
-    width: 10px !important;
-    height: 10px !important;
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    pointer-events: none;
-  }
-}
-
 .switchOption {
   padding-bottom: 16px;
-}
-
-.enable {
-  .time {
-    color: var(--euiColorPrimary) !important;
-  }
 }
 
 .refreshRatePencil {

--- a/redisinsight/ui/src/components/keys-summary/KeysSummary.tsx
+++ b/redisinsight/ui/src/components/keys-summary/KeysSummary.tsx
@@ -12,6 +12,7 @@ import { KeyTreeSettings } from 'uiSrc/pages/browser/components/key-tree'
 
 import ScanMore from '../scan-more'
 import styles from './styles.module.scss'
+import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 
 export interface Props {
   loading: boolean
@@ -53,18 +54,18 @@ const KeysSummary = (props: Props) => {
   return (
     <>
       {(!!totalItemsCount || isNull(totalItemsCount)) && (
-        <div className={styles.content} data-testid="keys-summary">
-          <Text size="xs" component="div">
-            {!!scanned && (
-              <>
-                <ColorText variant="semiBold">
+        <Row align="center" gap="l" data-testid="keys-summary">
+          {!!scanned && (
+            <FlexItem>
+              <Row gap="s">
+                <ColorText size="s" variant="semiBold" component="span">
                   {'Results: '}
                   <span data-testid="keys-number-of-results">
                     {numberWithSpaces(resultsLength)}
                   </span>
                   {'. '}
                 </ColorText>
-                <ColorText color="secondary">
+                <ColorText size="s" color="secondary" component="span">
                   {'Scanned '}
                   <span data-testid="keys-number-of-scanned">
                     {notAccurateScanned}
@@ -81,37 +82,46 @@ const KeysSummary = (props: Props) => {
                     ])}
                   />
                 </ColorText>
-                {showScanMore && (
-                  <ScanMore
-                    withAlert
-                    fill={false}
-                    style={scanMoreStyle}
-                    scanned={scanned}
-                    totalItemsCount={totalItemsCount}
-                    loading={loading}
-                    loadMoreItems={loadMoreItems}
-                    nextCursor={nextCursor}
-                  />
-                )}
-              </>
-            )}
-
-            {!scanned && (
-              <Text size="s" variant="semiBold">
+              </Row>
+            </FlexItem>
+          )}
+          {!scanned && (
+            <FlexItem>
+              <Text size="s" variant="semiBold" component="span">
                 {'Total: '}
                 {nullableNumberWithSpaces(totalItemsCount)}
               </Text>
-            )}
-          </Text>
-          {viewType === KeyViewType.Tree && (
-            <KeyTreeSettings loading={loading} />
+            </FlexItem>
           )}
-        </div>
+          {showScanMore && (
+            <FlexItem>
+              <ScanMore
+                withAlert
+                fill={false}
+                style={scanMoreStyle}
+                scanned={scanned}
+                totalItemsCount={totalItemsCount}
+                loading={loading}
+                loadMoreItems={loadMoreItems}
+                nextCursor={nextCursor}
+              />
+            </FlexItem>
+          )}
+          {viewType === KeyViewType.Tree && (
+            <FlexItem>
+              <KeyTreeSettings loading={loading} />
+            </FlexItem>
+          )}
+        </Row>
       )}
       {loading && !totalItemsCount && !isNull(totalItemsCount) && (
-        <Text size="xs" data-testid="scanning-text">
-          Scanning...
-        </Text>
+        <Row align="center">
+          <FlexItem>
+            <Text size="s" data-testid="scanning-text">
+              Scanning...
+            </Text>
+          </FlexItem>
+        </Row>
       )}
     </>
   )

--- a/redisinsight/ui/src/components/keys-summary/styles.module.scss
+++ b/redisinsight/ui/src/components/keys-summary/styles.module.scss
@@ -1,8 +1,3 @@
-.content {
-  display: flex;
-  align-items: center;
-}
-
 .loading {
   opacity: 0;
 }

--- a/redisinsight/ui/src/components/scan-more/ScanMore.tsx
+++ b/redisinsight/ui/src/components/scan-more/ScanMore.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { isNull } from 'lodash'
+import styled from 'styled-components'
 
 import { SCAN_COUNT_DEFAULT } from 'uiSrc/constants/api'
 import { RiTooltip } from 'uiSrc/components'
-import { Button } from 'uiSrc/components/base/forms/buttons'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
+import { TextButton } from '@redis-ui/components'
+import { Text } from 'uiSrc/components/base/text'
+import { Theme } from 'uiSrc/components/base/theme/types'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -23,22 +26,22 @@ export interface Props {
 const WARNING_MESSAGE =
   'Scanning additional keys may decrease performance and memory available.'
 
+const ScanMoreButton = styled(TextButton)`
+  color: ${({ theme }: { theme: Theme }) => theme.semantic.color.text.primary400} !important;
+  line-height: inherit;
+`
+
 const ScanMore = ({
-  fill = true,
   withAlert = true,
   scanned = 0,
   totalItemsCount = 0,
   loading,
-  style,
   loadMoreItems,
   nextCursor,
 }: Props) => (
   <>
     {(scanned || isNull(totalItemsCount)) && nextCursor !== '0' && (
-      <Button
-        variant={fill ? 'primary' : 'secondary-ghost'}
-        size="s"
-        style={style ?? { marginLeft: 25, height: 26 }}
+      <ScanMoreButton
         disabled={loading}
         onClick={() =>
           loadMoreItems?.({
@@ -48,17 +51,17 @@ const ScanMore = ({
         }
         data-testid="scan-more"
       >
+        <Text size="s">Scan more</Text>
         {withAlert && (
           <RiTooltip
             content={WARNING_MESSAGE}
             position="top"
             anchorClassName={styles.anchor}
           >
-            <RiIcon type="InfoIcon" />
+            <RiIcon color="primary400" size="m" type="InfoIcon" />
           </RiTooltip>
         )}
-        Scan more
-      </Button>
+      </ScanMoreButton>
     )}
   </>
 )

--- a/redisinsight/ui/src/components/scan-more/styles.module.scss
+++ b/redisinsight/ui/src/components/scan-more/styles.module.scss
@@ -2,5 +2,4 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-right: var(--size-s);
 }

--- a/redisinsight/ui/src/pages/browser/components/key-tree/KeyTreeSettings/KeyTreeSettings.tsx
+++ b/redisinsight/ui/src/pages/browser/components/key-tree/KeyTreeSettings/KeyTreeSettings.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import { isEqual } from 'lodash'
+import styled from 'styled-components'
 
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import {
@@ -32,6 +33,7 @@ import {
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { RiSelect } from 'uiSrc/components/base/forms/select/RiSelect'
 import { RiPopover } from 'uiSrc/components/base'
+import { Theme } from 'uiSrc/components/base/theme/types'
 import styles from './styles.module.scss'
 
 export interface Props {
@@ -85,12 +87,16 @@ const KeyTreeSettings = ({ loading }: Props) => {
     setDelimiters(treeViewDelimiter)
   }, [treeViewSort, treeViewDelimiter])
 
+  const TreeViewSettingsButton = styled(IconButton)`
+    background-color: ${({ theme }: { theme: Theme }) =>
+      isPopoverOpen ? theme.color.gray100 : 'transparent'};
+  `
+
   const button = (
-    <IconButton
+    <TreeViewSettingsButton
       icon={SettingsIcon}
       onClick={onButtonClick}
       disabled={loading}
-      className={cx(styles.anchorBtn)}
       aria-label="open tree view settings"
       data-testid="tree-view-settings-btn"
     />
@@ -143,7 +149,7 @@ const KeyTreeSettings = ({ loading }: Props) => {
         anchorPosition="downLeft"
         isOpen={isPopoverOpen}
         anchorClassName={styles.anchorWrapper}
-        panelClassName={styles.popoverWrapper}
+        panelClassName={cx('popover-without-top-tail', styles.popoverWrapper)}
         closePopover={closePopover}
         button={button}
       >

--- a/redisinsight/ui/src/pages/browser/components/key-tree/KeyTreeSettings/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/components/key-tree/KeyTreeSettings/styles.module.scss
@@ -8,16 +8,6 @@
   }
 }
 
-.anchorBtn {
-  width: 24px;
-  height: 100% !important;
-
-  svg {
-    width: 18px !important;
-    height: 18px !important;
-  }
-}
-
 .popoverWrapper {
   width: 300px;
   padding: 14px 16px !important;

--- a/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/KeysHeader.tsx
@@ -52,13 +52,13 @@ import { BrowserColumns, KeyValueFormat } from 'uiSrc/constants'
 
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { setConnectivityError } from 'uiSrc/slices/app/connectivity'
-import {
-  IconButton,
-  SecondaryButton,
-} from 'uiSrc/components/base/forms/buttons'
 import { Checkbox } from 'uiSrc/components/base/forms/checkbox/Checkbox'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import styles from './styles.module.scss'
+import { ButtonGroup } from 'uiSrc/components/base/forms/button-group/ButtonGroup'
+import styled from 'styled-components'
+import {TextButton} from '@redis-ui/components'
+import {Text} from 'uiSrc/components/base/text'
 
 const HIDE_REFRESH_LABEL_WIDTH = 640
 
@@ -68,7 +68,6 @@ interface ISwitchType<T> {
   disabled?: boolean
   ariaLabel: string
   dataTestId: string
-  getClassName: () => string
   onClick: () => void
   isActiveView: () => boolean
   getIconType: () => IconType
@@ -119,9 +118,6 @@ const KeysHeader = (props: Props) => {
       isActiveView() {
         return viewType === this.type
       },
-      getClassName() {
-        return cx(styles.viewTypeBtn, { [styles.active]: this.isActiveView() })
-      },
       getIconType() {
         return EqualIcon
       },
@@ -139,9 +135,6 @@ const KeysHeader = (props: Props) => {
       disabled: isTreeViewDisabled,
       isActiveView() {
         return viewType === this.type
-      },
-      getClassName() {
-        return cx(styles.viewTypeBtn, { [styles.active]: this.isActiveView() })
       },
       getIconType() {
         return FoldersIcon
@@ -288,80 +281,85 @@ const KeysHeader = (props: Props) => {
     })
   }
 
+  const ViewSwitchButtonGroup = styled(ButtonGroup)`
+    button {
+      width: 24px !important;
+      min-width: 24px !important;
+    }
+  `
   const ViewSwitch = () => (
-    <div className={styles.viewTypeSwitch} data-testid="view-type-switcher">
-      <OnboardingTour options={ONBOARDING_FEATURES.BROWSER_TREE_VIEW}>
-        <>
-          {viewTypes.map((view) => (
-            <RiTooltip
-              content={view.tooltipText}
-              position="top"
-              key={view.tooltipText}
+    <OnboardingTour options={ONBOARDING_FEATURES.BROWSER_TREE_VIEW}>
+      <ViewSwitchButtonGroup data-testid="view-type-switcher">
+        {viewTypes.map((view) => (
+          <RiTooltip
+            content={view.tooltipText}
+            position="top"
+            key={view.tooltipText}
+          >
+            <ButtonGroup.Button
+              aria-label={view.ariaLabel}
+              onClick={() => view.onClick()}
+              isSelected={view.isActiveView()}
+              data-testid={view.dataTestId}
+              disabled={view.disabled || false}
             >
-              <IconButton
-                size="S"
-                className={view.getClassName()}
-                icon={view.getIconType()}
-                aria-label={view.ariaLabel}
-                onClick={() => view.onClick()}
-                data-testid={view.dataTestId}
-                disabled={view.disabled || false}
-              />
-            </RiTooltip>
-          ))}
-        </>
-      </OnboardingTour>
-    </div>
+              <ButtonGroup.Icon icon={view.getIconType()} />
+            </ButtonGroup.Button>
+          </RiTooltip>
+        ))}
+      </ViewSwitchButtonGroup>
+    </OnboardingTour>
   )
 
   return (
     <div className={styles.content} ref={rootDivRef}>
       <AutoSizer disableHeight>
         {({ width }) => (
-          <div style={{ width }}>
-            <div className={styles.bottom}>
-              <div className={styles.keysSummary}>
-                <KeysSummary
-                  items={keysState.keys}
-                  totalItemsCount={keysState.total}
-                  scanned={
-                    isSearched ||
-                    (isFiltered && searchMode === SearchMode.Pattern) ||
-                    viewType === KeyViewType.Tree
-                      ? keysState.scanned
-                      : 0
-                  }
-                  loading={loading}
-                  showScanMore={
-                    !(
-                      searchMode === SearchMode.Redisearch &&
-                      keysState.maxResults &&
-                      keysState.keys.length >= keysState.maxResults
-                    )
-                  }
-                  scanMoreStyle={scanMoreStyle}
-                  loadMoreItems={handleScanMore}
-                  nextCursor={nextCursor}
-                />
-              </div>
-              <div className={styles.keysControlsWrapper}>
-                <AutoRefresh
-                  disabled={
-                    searchMode === SearchMode.Redisearch && !selectedIndex
-                  }
-                  disabledRefreshButtonMessage="Select an index to refresh keys."
-                  iconSize="S"
-                  postfix="keys"
-                  loading={loading}
-                  lastRefreshTime={keysState.lastRefreshTime}
-                  displayText={(width || 0) > HIDE_REFRESH_LABEL_WIDTH}
-                  containerClassName={styles.refreshContainer}
-                  onRefresh={handleRefreshKeys}
-                  onEnableAutoRefresh={handleEnableAutoRefresh}
-                  onChangeAutoRefreshRate={handleChangeAutoRefreshRate}
-                  testid="keys"
-                />
-                <div className={styles.columnsButtonPopup}>
+          <Row justify="between" style={{ width }}>
+            <FlexItem>
+              <KeysSummary
+                items={keysState.keys}
+                totalItemsCount={keysState.total}
+                scanned={
+                  isSearched ||
+                  (isFiltered && searchMode === SearchMode.Pattern) ||
+                  viewType === KeyViewType.Tree
+                    ? keysState.scanned
+                    : 0
+                }
+                loading={loading}
+                showScanMore={
+                  !(
+                    searchMode === SearchMode.Redisearch &&
+                    keysState.maxResults &&
+                    keysState.keys.length >= keysState.maxResults
+                  )
+                }
+                scanMoreStyle={scanMoreStyle}
+                loadMoreItems={handleScanMore}
+                nextCursor={nextCursor}
+              />
+            </FlexItem>
+            <FlexItem>
+              <Row gap="l">
+                <FlexItem>
+                  <AutoRefresh
+                    disabled={
+                      searchMode === SearchMode.Redisearch && !selectedIndex
+                    }
+                    disabledRefreshButtonMessage="Select an index to refresh keys."
+                    iconSize="S"
+                    postfix="keys"
+                    loading={loading}
+                    lastRefreshTime={keysState.lastRefreshTime}
+                    displayText={(width || 0) > HIDE_REFRESH_LABEL_WIDTH}
+                    onRefresh={handleRefreshKeys}
+                    onEnableAutoRefresh={handleEnableAutoRefresh}
+                    onChangeAutoRefreshRate={handleChangeAutoRefreshRate}
+                    testid="keys"
+                  />
+                </FlexItem>
+                <FlexItem>
                   <RiPopover
                     ownFocus={false}
                     anchorPosition="downLeft"
@@ -370,18 +368,15 @@ const KeysHeader = (props: Props) => {
                     panelClassName={styles.popoverWrapper}
                     closePopover={() => setColumnsConfigShown(false)}
                     button={
-                      <SecondaryButton
-                        size="small"
-                        icon={ColumnsIcon}
+                      <TextButton
                         onClick={toggleColumnsConfigVisibility}
                         className={styles.columnsButton}
                         data-testid="btn-columns-actions"
                         aria-label="columns"
                       >
-                        <span className={styles.columnsButtonText}>
-                          Columns
-                        </span>
-                      </SecondaryButton>
+                        <RiIcon size="m" type="ColumnsIcon" />
+                        <Text size="s">Columns</Text>
+                      </TextButton>
                     }
                   >
                     <Row align="center" gap="m">
@@ -428,11 +423,13 @@ const KeysHeader = (props: Props) => {
                       data-testid="show-ttl"
                     />
                   </RiPopover>
-                </div>
-                {ViewSwitch()}
-              </div>
-            </div>
-          </div>
+                </FlexItem>
+                <FlexItem>
+                  {ViewSwitch()}
+                </FlexItem>
+              </Row>
+            </FlexItem>
+          </Row>
         )}
       </AutoSizer>
     </div>

--- a/redisinsight/ui/src/pages/browser/components/keys-header/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/components/keys-header/styles.module.scss
@@ -20,13 +20,6 @@
   flex-wrap: wrap;
 }
 
-.viewTypeSwitch {
-  margin-left: 8px;
-  flex-shrink: 0;
-  background-color: var(--browserViewTypePassive) !important;
-  border-radius: 4px;
-}
-
 .viewTypeBtn {
   width: 24px !important;
   height: 24px !important;
@@ -62,20 +55,10 @@
   margin: 4px 8px 4px 4px;
 }
 
-.keysControlsWrapper {
-  display: flex;
-  align-items: center;
-  margin: 4px 4px 4px auto;
-}
-
 .columnsButton {
   padding: 4px 6px 4px 4px;
   border-color: transparent !important;
   box-shadow: none !important;
-}
-
-.columnsButtonPopup {
-  margin-left: 20px;
 }
 
 .checkbox {

--- a/redisinsight/ui/src/styles/base/_helpers.scss
+++ b/redisinsight/ui/src/styles/base/_helpers.scss
@@ -89,7 +89,7 @@
 }
 
 .popover-without-top-tail {
-  margin-top: -6px;
+  margin-top: -8px;
 
   // removes top arrow (it is always first child)
   & > span:nth-child(1) * {


### PR DESCRIPTION
| Before | After |
| - | - |
<img width="935" height="66" alt="Screenshot 2025-09-16 at 10 31 11" src="https://github.com/user-attachments/assets/5f3dfbbb-b42f-4fe0-afde-b8f48d5ff850" /> | <img width="928" height="55" alt="Screenshot 2025-09-16 at 10 28 56" src="https://github.com/user-attachments/assets/9490705c-e759-4655-b6c3-4e8fce45b6bf" />
| - | - |
<img width="944" height="73" alt="Screenshot 2025-09-16 at 10 31 21" src="https://github.com/user-attachments/assets/e11ed701-19c0-4577-b496-41c663bacad6" /> | <img width="943" height="55" alt="Screenshot 2025-09-16 at 10 29 38" src="https://github.com/user-attachments/assets/f839c612-884e-49a4-99e4-e42471771707" />
| - | - |
<img width="931" height="62" alt="Screenshot 2025-09-16 at 10 31 34" src="https://github.com/user-attachments/assets/8dea174e-90ea-4854-8c37-8448fe1c5f93" /> | <img width="920" height="55" alt="Screenshot 2025-09-16 at 10 29 47" src="https://github.com/user-attachments/assets/d720b8c3-d26f-4165-8d43-eb285f96becb" />
