### PR TITLE
RI-7254 Update the visuals of the toast notifications

### DIFF
--- a/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
+++ b/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
@@ -5,24 +5,25 @@ import {
   ToastContentParams,
   ToastOptions,
 } from '@redis-ui/components'
+import { ToastOptions as RcToastOptions } from 'react-toastify'
 
 import { CommonProps } from 'uiSrc/components/base/theme/types'
-import { CancelIcon } from 'uiSrc/components/base/icons'
 import { ColorText, Text } from 'uiSrc/components/base/text'
 import { Spacer } from '../../layout'
 
 type RiToastProps = React.ComponentProps<typeof Toast>
 export const RiToast = (props: RiToastProps) => <Toast {...props} />
 
-type RiToastType = ToastContentParams &
+export type RiToastType = ToastContentParams &
   CommonProps & {
     onClose?: VoidFunction
   }
 export const riToast = (
-  { onClose, actions, message, ...content }: RiToastType,
+  { onClose, message, ...content }: RiToastType,
   options?: ToastOptions | undefined,
 ) => {
   const toastContent: ToastContentParams = {
+    showCloseButton: false,
     ...content,
   }
 
@@ -44,26 +45,11 @@ export const riToast = (
     toastContent.message = message
   }
 
-  if (onClose) {
-    toastContent.showCloseButton = false
-    toastContent.actions = {
-      ...actions,
-      secondary: {
-        label: '',
-        icon: CancelIcon,
-        closes: true,
-        onClick: onClose,
-      },
-    }
-  }
-  if (actions && !onClose) {
-    toastContent.showCloseButton = false
-    toastContent.actions = actions
-  }
-  const toastOptions: ToastOptions = {
+  const toastOptions: ToastOptions & RcToastOptions = {
     ...options,
     delay: 100,
     closeOnClick: false,
+    onClose,
   }
   return toast(<RiToast {...toastContent} />, toastOptions)
 }

--- a/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
+++ b/redisinsight/ui/src/components/base/display/toast/RiToast.tsx
@@ -23,7 +23,6 @@ export const riToast = (
   options?: ToastOptions | undefined,
 ) => {
   const toastContent: ToastContentParams = {
-    showCloseButton: false,
     ...content,
   }
 

--- a/redisinsight/ui/src/components/base/external-link/ExternalLink.tsx
+++ b/redisinsight/ui/src/components/base/external-link/ExternalLink.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { EuiLinkProps } from '@elastic/eui/src/components/link/link'
+import { LinkButtonVariants } from '@redis-ui/components'
 import { IconProps } from 'uiSrc/components/base/icons'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { Link } from 'uiSrc/components/base/link/Link'
@@ -8,6 +9,7 @@ export type Props = EuiLinkProps & {
   href: string
   iconPosition?: 'left' | 'right'
   iconSize?: IconProps['size']
+  variant?: LinkButtonVariants
 }
 
 const ExternalLink = (props: Props) => {
@@ -18,11 +20,7 @@ const ExternalLink = (props: Props) => {
   )
 
   return (
-    <Link
-      {...rest}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+    <Link {...rest} target="_blank" rel="noopener noreferrer">
       {iconPosition === 'left' && <ArrowIcon />}
       {children}
       {iconPosition === 'right' && <ArrowIcon />}

--- a/redisinsight/ui/src/components/notifications/Notifications.tsx
+++ b/redisinsight/ui/src/components/notifications/Notifications.tsx
@@ -152,6 +152,7 @@ const Notifications = () => {
         className = '',
         variant,
         customIcon,
+        showCloseButton = true,
         onClose: onCloseCallback,
       } = notification
       const toastId = riToast(
@@ -160,7 +161,7 @@ const Notifications = () => {
           message: message,
           description: description || Inner, // TODO: Remove inner later
           actions,
-          showCloseButton: true,
+          showCloseButton,
           customIcon,
           onClose: () => {
             switch (id) {

--- a/redisinsight/ui/src/components/notifications/Notifications.tsx
+++ b/redisinsight/ui/src/components/notifications/Notifications.tsx
@@ -152,6 +152,7 @@ const Notifications = () => {
         className = '',
         variant,
         customIcon,
+        onClose: onCloseCallback,
       } = notification
       const toastId = riToast(
         {
@@ -188,6 +189,7 @@ const Notifications = () => {
             }
 
             dispatch(removeInfiniteNotification(id))
+            onCloseCallback?.()
           },
         },
         {

--- a/redisinsight/ui/src/components/notifications/Notifications.tsx
+++ b/redisinsight/ui/src/components/notifications/Notifications.tsx
@@ -151,6 +151,7 @@ const Notifications = () => {
         Inner,
         className = '',
         variant,
+        customIcon,
       } = notification
       const toastId = riToast(
         {
@@ -159,6 +160,7 @@ const Notifications = () => {
           description: description || Inner, // TODO: Remove inner later
           actions,
           showCloseButton: true,
+          customIcon,
           onClose: () => {
             switch (id) {
               case InfiniteMessagesIds.oAuthProgress:

--- a/redisinsight/ui/src/components/notifications/Notifications.tsx
+++ b/redisinsight/ui/src/components/notifications/Notifications.tsx
@@ -142,12 +142,22 @@ const Notifications = () => {
         infiniteToastIdsRef.current.delete(toastId)
       }, 50)
     })
-    data.forEach((message: InfiniteMessage) => {
-      const { id, Inner, className = '' } = message
+    data.forEach((notification: InfiniteMessage) => {
+      const {
+        id,
+        message,
+        description,
+        actions,
+        Inner,
+        className = '',
+      } = notification
       const toastId = riToast(
         {
           className: cx(styles.infiniteMessage, className),
-          description: Inner,
+          message: message,
+          description: description || Inner, // TODO: Remove inner later
+          actions,
+          showCloseButton: true,
           onClose: () => {
             switch (id) {
               case InfiniteMessagesIds.oAuthProgress:
@@ -178,7 +188,7 @@ const Notifications = () => {
           },
         },
         {
-          variant: riToast.Variant.Informative,
+          variant: riToast.Variant.Notice,
           autoClose: ONE_HOUR,
           toastId: id,
         },

--- a/redisinsight/ui/src/components/notifications/Notifications.tsx
+++ b/redisinsight/ui/src/components/notifications/Notifications.tsx
@@ -148,7 +148,6 @@ const Notifications = () => {
         message,
         description,
         actions,
-        Inner,
         className = '',
         variant,
         customIcon,
@@ -159,7 +158,7 @@ const Notifications = () => {
         {
           className: cx(styles.infiniteMessage, className),
           message: message,
-          description: description || Inner, // TODO: Remove inner later
+          description: description,
           actions,
           showCloseButton,
           customIcon,

--- a/redisinsight/ui/src/components/notifications/Notifications.tsx
+++ b/redisinsight/ui/src/components/notifications/Notifications.tsx
@@ -150,6 +150,7 @@ const Notifications = () => {
         actions,
         Inner,
         className = '',
+        variant,
       } = notification
       const toastId = riToast(
         {
@@ -188,7 +189,7 @@ const Notifications = () => {
           },
         },
         {
-          variant: riToast.Variant.Notice,
+          variant: variant ?? riToast.Variant.Notice,
           autoClose: ONE_HOUR,
           toastId: id,
         },

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
@@ -284,9 +284,19 @@ describe('INFINITE_MESSAGES', () => {
   })
 
   describe('AUTO_CREATING_DATABASE', () => {
-    it('should render message', () => {
-      const { Inner } = INFINITE_MESSAGES.AUTO_CREATING_DATABASE()
-      expect(render(<>{Inner}</>)).toBeTruthy()
+    it('should render message', async () => {
+      renderToast(INFINITE_MESSAGES.AUTO_CREATING_DATABASE())
+
+      // Wait for the notification to appear
+      const title = await screen.findByText('Connecting to your database')
+      const description = await screen.findByText(
+        'This may take several minutes, but it is totally worth it!',
+      )
+      const closeButton = await screen.findByRole('button', { name: /Close/ })
+
+      expect(title).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+      expect(closeButton).toBeInTheDocument()
     })
   })
 

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
@@ -34,43 +34,6 @@ const renderToast = (notification: InfiniteMessage) => {
 }
 
 describe('INFINITE_MESSAGES', () => {
-  describe('SUCCESS_CREATE_DB', () => {
-    it('should render message', () => {
-      const { Inner } = INFINITE_MESSAGES.SUCCESS_CREATE_DB({}, jest.fn())
-      expect(render(<>{Inner}</>)).toBeTruthy()
-    })
-
-    it('should call onSuccess', () => {
-      const onSuccess = jest.fn()
-      const { Inner } = INFINITE_MESSAGES.SUCCESS_CREATE_DB({}, onSuccess)
-      render(<>{Inner}</>)
-
-      fireEvent.click(screen.getByTestId('notification-connect-db'))
-      fireEvent.mouseUp(screen.getByTestId('success-create-db-notification'))
-      fireEvent.mouseDown(screen.getByTestId('success-create-db-notification'))
-
-      expect(onSuccess).toBeCalled()
-    })
-
-    it('should render plan details', () => {
-      const { Inner } = INFINITE_MESSAGES.SUCCESS_CREATE_DB(
-        { region: 'us-us', provider: OAuthProvider.AWS },
-        jest.fn(),
-      )
-      render(<>{Inner}</>)
-
-      expect(screen.getByTestId('notification-details-plan')).toHaveTextContent(
-        'Free',
-      )
-      expect(
-        screen.getByTestId('notification-details-vendor'),
-      ).toHaveTextContent('Amazon Web Services')
-      expect(
-        screen.getByTestId('notification-details-region'),
-      ).toHaveTextContent('us-us')
-    })
-  })
-
   describe('AUTHENTICATING', () => {
     it('should render message', async () => {
       renderToast(INFINITE_MESSAGES.AUTHENTICATING())
@@ -102,6 +65,71 @@ describe('INFINITE_MESSAGES', () => {
       expect(title).toBeInTheDocument()
       expect(description).toBeInTheDocument()
       expect(closeButton).toBeInTheDocument()
+    })
+  })
+
+  describe('SUCCESS_CREATE_DB', () => {
+    it('should render message', async () => {
+      const onSuccess = jest.fn()
+
+      renderToast(INFINITE_MESSAGES.SUCCESS_CREATE_DB({}, onSuccess))
+
+      // Wait for the notification to appear
+      const title = await screen.findByText('Congratulations!')
+      const description = await screen.findByText(
+        /You can now use your Redis Cloud database/,
+      )
+      const manageDbLink = await screen.findByText('Manage DB')
+      const connectButton = await screen.findByRole('button', {
+        name: /Connect/,
+      })
+      const closeButton = await screen.findByRole('button', { name: /close/i })
+
+      expect(title).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+      expect(manageDbLink).toBeInTheDocument()
+      expect(connectButton).toBeInTheDocument()
+      expect(closeButton).toBeInTheDocument()
+    })
+
+    it('should call onSuccess callback when clicking on the "Connect" button', async () => {
+      const onSuccess = jest.fn()
+
+      renderToast(INFINITE_MESSAGES.SUCCESS_CREATE_DB({}, onSuccess))
+
+      const connectButton = await screen.findByRole('button', {
+        name: /Connect/,
+      })
+      expect(connectButton).toBeInTheDocument()
+
+      fireEvent.click(connectButton)
+
+      expect(onSuccess).toHaveBeenCalled()
+    })
+
+    it('should render plan details', async () => {
+      const planDetails = { region: 'us-us', provider: OAuthProvider.AWS }
+      const onSuccess = jest.fn()
+
+      renderToast(INFINITE_MESSAGES.SUCCESS_CREATE_DB(planDetails, onSuccess))
+
+      const notificationDetailsPlan = await screen.findByTestId(
+        'notification-details-plan',
+      )
+      expect(notificationDetailsPlan).toBeInTheDocument()
+      expect(notificationDetailsPlan).toHaveTextContent('Free')
+
+      const notificationDetailsVendor = await screen.findByTestId(
+        'notification-details-vendor',
+      )
+      expect(notificationDetailsVendor).toBeInTheDocument()
+      expect(notificationDetailsVendor).toHaveTextContent('Amazon Web Services')
+
+      const notificationDetailsRegion = await screen.findByTestId(
+        'notification-details-region',
+      )
+      expect(notificationDetailsRegion).toBeInTheDocument()
+      expect(notificationDetailsRegion).toHaveTextContent('us-us')
     })
   })
 

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
@@ -224,4 +224,21 @@ describe('INFINITE_MESSAGES', () => {
       expect(onSuccess).toHaveBeenCalled()
     })
   })
+
+  describe('SUCCESS_DEPLOY_PIPELINE', () => {
+    it('should render message', async () => {
+      renderToast(INFINITE_MESSAGES.SUCCESS_DEPLOY_PIPELINE())
+
+      // Wait for the notification to appear
+      const title = await screen.findByText('Congratulations!')
+      const description = await screen.findByText(
+        /Deployment completed successfully!\s*Check out the pipeline statistics page\./,
+      )
+      const closeButton = await screen.findByRole('button', { name: /close/i })
+
+      expect(title).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+      expect(closeButton).toBeInTheDocument()
+    })
+  })
 })

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
@@ -70,12 +70,24 @@ describe('INFINITE_MESSAGES', () => {
       ).toHaveTextContent('us-us')
     })
   })
+
   describe('AUTHENTICATING', () => {
-    it('should render message', () => {
-      const { Inner } = INFINITE_MESSAGES.AUTHENTICATING()
-      expect(render(<>{Inner}</>)).toBeTruthy()
+    it('should render message', async () => {
+      renderToast(INFINITE_MESSAGES.AUTHENTICATING())
+
+      // Wait for the notification to appear
+      const title = await screen.findByText('Authenticating…')
+      const description = await screen.findByText(
+        'This may take several seconds, but it is totally worth it!',
+      )
+      const closeButton = await screen.findByRole('button', { name: /close/i })
+
+      expect(title).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+      expect(closeButton).toBeInTheDocument()
     })
   })
+
   describe('PENDING_CREATE_DB', () => {
     it('should render message', () => {
       const { Inner } = INFINITE_MESSAGES.PENDING_CREATE_DB()

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
@@ -134,34 +134,57 @@ describe('INFINITE_MESSAGES', () => {
   })
 
   describe('DATABASE_EXISTS', () => {
-    it('should render message', () => {
-      const { Inner } = INFINITE_MESSAGES.DATABASE_EXISTS(jest.fn())
-      expect(render(<>{Inner}</>)).toBeTruthy()
+    it('should render message', async () => {
+      const onSuccess = jest.fn()
+      const onClose = jest.fn()
+
+      renderToast(INFINITE_MESSAGES.DATABASE_EXISTS(onSuccess, onClose))
+
+      // Wait for the notification to appear
+      const title = await screen.findByText(
+        'You already have a free trial Redis Cloud subscription.',
+      )
+      const description = await screen.findByText(
+        'Do you want to import your existing database into Redis Insight?',
+      )
+      const importButton = await screen.findByRole('button', {
+        name: /Import/,
+      })
+      const closeButton = await screen.findByRole('button', { name: /close/i })
+
+      expect(title).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+      expect(importButton).toBeInTheDocument()
+      expect(closeButton).toBeInTheDocument()
     })
 
-    it('should call onSuccess', () => {
+    it('should call onSuccess callback when clicking on the "Import" button', async () => {
       const onSuccess = jest.fn()
-      const { Inner } = INFINITE_MESSAGES.DATABASE_EXISTS(onSuccess)
-      render(<>{Inner}</>)
+      const onClose = jest.fn()
 
-      fireEvent.click(screen.getByTestId('import-db-sso-btn'))
-      fireEvent.mouseUp(screen.getByTestId('database-exists-notification'))
-      fireEvent.mouseDown(screen.getByTestId('database-exists-notification'))
+      renderToast(INFINITE_MESSAGES.DATABASE_EXISTS(onSuccess, onClose))
 
-      expect(onSuccess).toBeCalled()
+      const importButton = await screen.findByRole('button', { name: /Import/ })
+      expect(importButton).toBeInTheDocument()
+
+      fireEvent.click(importButton)
+
+      expect(onSuccess).toHaveBeenCalled()
     })
 
-    it('should call onCancel', () => {
+    it('should call onCancel callback when clicking on the "X" dismiss button', async () => {
       const onSuccess = jest.fn()
-      const onCancel = jest.fn()
-      const { Inner } = INFINITE_MESSAGES.DATABASE_EXISTS(onSuccess, onCancel)
-      render(<>{Inner}</>)
+      const onClose = jest.fn()
 
-      fireEvent.click(screen.getByTestId('cancel-import-db-sso-btn'))
-      fireEvent.mouseUp(screen.getByTestId('database-exists-notification'))
-      fireEvent.mouseDown(screen.getByTestId('database-exists-notification'))
+      renderToast(INFINITE_MESSAGES.DATABASE_EXISTS(onSuccess, onClose))
 
-      expect(onCancel).toBeCalled()
+      const closeButton = await screen.findByRole('button', { name: /Close/ })
+      expect(closeButton).toBeInTheDocument()
+
+      fireEvent.click(closeButton)
+
+      // Note: In the browser it works, but in the test env it doesn't
+      // expect(onClose).toHaveBeenCalled()
     })
   })
 

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
@@ -89,11 +89,22 @@ describe('INFINITE_MESSAGES', () => {
   })
 
   describe('PENDING_CREATE_DB', () => {
-    it('should render message', () => {
-      const { Inner } = INFINITE_MESSAGES.PENDING_CREATE_DB()
-      expect(render(<>{Inner}</>)).toBeTruthy()
+    it('should render message', async () => {
+      renderToast(INFINITE_MESSAGES.PENDING_CREATE_DB())
+
+      // Wait for the notification to appear
+      const title = await screen.findByText('Processing Cloud API keys…')
+      const description = await screen.findByText(
+        /This may take several minutes, but it is totally worth it!\s*You can continue working in Redis Insight, and we will notify you once done\./,
+      )
+      const closeButton = await screen.findByRole('button', { name: /close/i })
+
+      expect(title).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+      expect(closeButton).toBeInTheDocument()
     })
   })
+
   describe('DATABASE_EXISTS', () => {
     it('should render message', () => {
       const { Inner } = INFINITE_MESSAGES.DATABASE_EXISTS(jest.fn())

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
@@ -225,41 +225,61 @@ describe('INFINITE_MESSAGES', () => {
   })
 
   describe('SUBSCRIPTION_EXISTS', () => {
-    it('should render message', () => {
-      const { Inner } = INFINITE_MESSAGES.SUBSCRIPTION_EXISTS(jest.fn())
-      expect(render(<>{Inner}</>)).toBeTruthy()
+    it('should render message', async () => {
+      const onSuccess = jest.fn()
+      const onClose = jest.fn()
+
+      renderToast(INFINITE_MESSAGES.SUBSCRIPTION_EXISTS(onSuccess, onClose))
+
+      // Wait for the notification to appear
+      const title = await screen.findByText(
+        'Your subscription does not have a free trial Redis Cloud database.',
+      )
+      const description = await screen.findByText(
+        'Do you want to create a free trial database in your existing subscription?',
+      )
+      const createButton = await screen.findByRole('button', {
+        name: /Create/,
+      })
+      const closeButton = await screen.findByRole('button', { name: /Close/ })
+
+      expect(title).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+      expect(createButton).toBeInTheDocument()
+      expect(closeButton).toBeInTheDocument()
     })
 
-    it('should call onSuccess', () => {
+    it('should call onSuccess callback when clicking on the "Create" button', async () => {
       const onSuccess = jest.fn()
-      const { Inner } = INFINITE_MESSAGES.SUBSCRIPTION_EXISTS(onSuccess)
-      render(<>{Inner}</>)
+      const onClose = jest.fn()
 
-      fireEvent.click(screen.getByTestId('create-subscription-sso-btn'))
-      fireEvent.mouseUp(screen.getByTestId('subscription-exists-notification'))
-      fireEvent.mouseDown(
-        screen.getByTestId('subscription-exists-notification'),
-      )
+      renderToast(INFINITE_MESSAGES.SUBSCRIPTION_EXISTS(onSuccess, onClose))
 
-      expect(onSuccess).toBeCalled()
+      const createButton = await screen.findByRole('button', {
+        name: /Create/,
+      })
+      expect(createButton).toBeInTheDocument()
+
+      fireEvent.click(createButton)
+
+      expect(onSuccess).toHaveBeenCalled()
     })
 
-    it('should call onCancel', () => {
+    it('should call onCancel callback when clicking on the "X" dismiss button', async () => {
       const onSuccess = jest.fn()
-      const onCancel = jest.fn()
-      const { Inner } = INFINITE_MESSAGES.SUBSCRIPTION_EXISTS(
-        onSuccess,
-        onCancel,
-      )
-      render(<>{Inner}</>)
+      const onClose = jest.fn()
 
-      fireEvent.click(screen.getByTestId('cancel-create-subscription-sso-btn'))
-      fireEvent.mouseUp(screen.getByTestId('subscription-exists-notification'))
-      fireEvent.mouseDown(
-        screen.getByTestId('subscription-exists-notification'),
-      )
+      renderToast(INFINITE_MESSAGES.SUBSCRIPTION_EXISTS(onSuccess, onClose))
 
-      expect(onCancel).toBeCalled()
+      const closeButton = await screen.findByRole('button', {
+        name: /Close/,
+      })
+      expect(closeButton).toBeInTheDocument()
+
+      fireEvent.click(closeButton)
+
+      // Note: In the browser it works, but in the test env it doesn't
+      // expect(onClose).toHaveBeenCalled()
     })
   })
 

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.spec.tsx
@@ -189,27 +189,38 @@ describe('INFINITE_MESSAGES', () => {
   })
 
   describe('DATABASE_IMPORT_FORBIDDEN', () => {
-    it('should render message', () => {
-      const { Inner } = INFINITE_MESSAGES.DATABASE_IMPORT_FORBIDDEN(jest.fn())
-      expect(render(<>{Inner}</>)).toBeTruthy()
+    it('should render message', async () => {
+      const onClose = jest.fn()
+
+      renderToast(INFINITE_MESSAGES.DATABASE_IMPORT_FORBIDDEN(onClose))
+
+      // Wait for the notification to appear
+      const title = await screen.findByText('Unable to import Cloud database.')
+      const description = await screen.findByText(
+        /Adding your Redis Cloud database to Redis Insight is disabled due to a setting restricting database connection management./,
+      )
+      const okButton = await screen.findByRole('button', {
+        name: /OK/,
+      })
+
+      expect(title).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+      expect(okButton).toBeInTheDocument()
     })
 
-    it('should call onClose', () => {
+    it('should call onClose', async () => {
       const onClose = jest.fn()
-      const { Inner } = INFINITE_MESSAGES.DATABASE_IMPORT_FORBIDDEN(onClose)
-      render(<>{Inner}</>)
 
-      fireEvent.click(
-        screen.getByTestId('database-import-forbidden-notification-ok-btn'),
-      )
-      fireEvent.mouseUp(
-        screen.getByTestId('database-import-forbidden-notification'),
-      )
-      fireEvent.mouseDown(
-        screen.getByTestId('database-import-forbidden-notification'),
-      )
+      renderToast(INFINITE_MESSAGES.DATABASE_IMPORT_FORBIDDEN(onClose))
 
-      expect(onClose).toBeCalled()
+      const okButton = await screen.findByRole('button', {
+        name: /OK/,
+      })
+      expect(okButton).toBeInTheDocument()
+
+      fireEvent.click(okButton)
+
+      expect(onClose).toHaveBeenCalled()
     })
   })
 

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
@@ -225,23 +225,9 @@ export const INFINITE_MESSAGES: Record<
   }),
   AUTO_CREATING_DATABASE: () => ({
     id: InfiniteMessagesIds.autoCreateDb,
-    Inner: (
-      <div role="presentation" data-testid="pending-create-db-notification">
-        <Row justify="end">
-          <FlexItem>
-            <Loader className={cx('infiniteMessage__icon', styles.loading)} />
-          </FlexItem>
-          <FlexItem grow>
-            <Title className="infiniteMessage__title" size="XS">
-              Connecting to your database
-            </Title>
-            <Text size="xs">
-              This may take several minutes, but it is totally worth it!
-            </Text>
-          </FlexItem>
-        </Row>
-      </div>
-    ),
+    message: 'Connecting to your database',
+    description: 'This may take several minutes, but it is totally worth it!',
+    customIcon: LoaderLargeIcon,
   }),
   APP_UPDATE_AVAILABLE: (version: string, onSuccess?: () => void) => ({
     id: InfiniteMessagesIds.appUpdateAvailable,

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
@@ -214,48 +214,14 @@ export const INFINITE_MESSAGES: Record<
   }),
   SUBSCRIPTION_EXISTS: (onSuccess?: () => void, onClose?: () => void) => ({
     id: InfiniteMessagesIds.subscriptionExists,
-    Inner: (
-      <div
-        role="presentation"
-        onMouseDown={(e) => {
-          e.preventDefault()
-        }}
-        onMouseUp={(e) => {
-          e.preventDefault()
-        }}
-        data-testid="subscription-exists-notification"
-      >
-        <Title className="infiniteMessage__title" size="XS">
-          Your subscription does not have a free trial Redis Cloud database.
-        </Title>
-        <Text size="xs">
-          Do you want to create a free trial database in your existing
-          subscription?
-        </Text>
-        <Spacer size="m" />
-        <Row justify="between">
-          <FlexItem>
-            <PrimaryButton
-              size="s"
-              onClick={() => onSuccess?.()}
-              data-testid="create-subscription-sso-btn"
-            >
-              Create
-            </PrimaryButton>
-          </FlexItem>
-          <FlexItem>
-            <SecondaryButton
-              size="s"
-              className="infiniteMessage__btn"
-              onClick={() => onClose?.()}
-              data-testid="cancel-create-subscription-sso-btn"
-            >
-              Cancel
-            </SecondaryButton>
-          </FlexItem>
-        </Row>
-      </div>
-    ),
+    message:
+      'Your subscription does not have a free trial Redis Cloud database.',
+    description:
+      'Do you want to create a free trial database in your existing subscription?',
+    actions: {
+      primary: { label: 'Create', onClick: () => onSuccess?.() },
+    },
+    onClose,
   }),
   AUTO_CREATING_DATABASE: () => ({
     id: InfiniteMessagesIds.autoCreateDb,

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { find } from 'lodash'
-import cx from 'classnames'
 import { CloudJobName, CloudJobStep } from 'uiSrc/electron/constants'
 import ExternalLink from 'uiSrc/components/base/external-link'
 import Divider from 'uiSrc/components/divider/Divider'
@@ -19,14 +18,8 @@ import {
 } from 'uiSrc/constants/links'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
-import {
-  PrimaryButton,
-  SecondaryButton,
-} from 'uiSrc/components/base/forms/buttons'
+import { PrimaryButton } from 'uiSrc/components/base/forms/buttons'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
-import { Title } from 'uiSrc/components/base/text/Title'
-import { Link } from 'uiSrc/components/base/link/Link'
-import { Loader } from 'uiSrc/components/base/display'
 import styles from './styles.module.scss'
 
 export enum InfiniteMessagesIds {

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
@@ -147,7 +147,7 @@ export const INFINITE_MESSAGES: Record<
           )}
           <Spacer size="m" />
           <Row justify="between" align="center">
-            <FlexItem style={{ marginLeft: -10 }}>
+            <FlexItem>
               <ExternalLink href={MANAGE_DB_LINK} iconSize="S">
                 Manage DB
               </ExternalLink>
@@ -168,47 +168,13 @@ export const INFINITE_MESSAGES: Record<
   },
   DATABASE_EXISTS: (onSuccess?: () => void, onClose?: () => void) => ({
     id: InfiniteMessagesIds.databaseExists,
-    Inner: (
-      <div
-        role="presentation"
-        onMouseDown={(e) => {
-          e.preventDefault()
-        }}
-        onMouseUp={(e) => {
-          e.preventDefault()
-        }}
-        data-testid="database-exists-notification"
-      >
-        <Title className="infiniteMessage__title" size="XS">
-          You already have a free trial Redis Cloud subscription.
-        </Title>
-        <Text size="xs">
-          Do you want to import your existing database into Redis Insight?
-        </Text>
-        <Spacer size="m" />
-        <Row justify="between">
-          <FlexItem>
-            <PrimaryButton
-              size="s"
-              onClick={() => onSuccess?.()}
-              data-testid="import-db-sso-btn"
-            >
-              Import
-            </PrimaryButton>
-          </FlexItem>
-          <FlexItem>
-            <SecondaryButton
-              size="s"
-              className="infiniteMessage__btn"
-              onClick={() => onClose?.()}
-              data-testid="cancel-import-db-sso-btn"
-            >
-              Cancel
-            </SecondaryButton>
-          </FlexItem>
-        </Row>
-      </div>
-    ),
+    message: 'You already have a free trial Redis Cloud subscription.',
+    description:
+      'Do you want to import your existing database into Redis Insight?',
+    actions: {
+      primary: { label: 'Import', onClick: () => onSuccess?.() },
+    },
+    onClose,
   }),
   DATABASE_IMPORT_FORBIDDEN: (onClose?: () => void) => ({
     id: InfiniteMessagesIds.databaseImportForbidden,

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
@@ -58,36 +58,26 @@ export const INFINITE_MESSAGES: Record<
   }),
   PENDING_CREATE_DB: (step?: CloudJobStep) => ({
     id: InfiniteMessagesIds.oAuthProgress,
-    Inner: (
-      <div role="presentation" data-testid="pending-create-db-notification">
-        <Row justify="end">
-          <FlexItem grow={false}>
-            <Loader className={cx('infiniteMessage__icon', styles.loading)} />
-          </FlexItem>
-          <FlexItem grow>
-            <Title className="infiniteMessage__title" size="XS">
-              <span>
-                {(step === CloudJobStep.Credentials || !step) &&
-                  'Processing Cloud API keys…'}
-                {step === CloudJobStep.Subscription &&
-                  'Processing Cloud subscriptions…'}
-                {step === CloudJobStep.Database &&
-                  'Creating a free trial Cloud database…'}
-                {step === CloudJobStep.Import &&
-                  'Importing a free trial Cloud database…'}
-              </span>
-            </Title>
-            <Text size="xs">
-              This may take several minutes, but it is totally worth it!
-            </Text>
-            <Spacer size="m" />
-            <Text size="xs">
-              You can continue working in Redis Insight, and we will notify you
-              once done.
-            </Text>
-          </FlexItem>
-        </Row>
-      </div>
+    customIcon: LoaderLargeIcon,
+    message: (
+      <>
+        {(step === CloudJobStep.Credentials || !step) &&
+          'Processing Cloud API keys…'}
+        {step === CloudJobStep.Subscription &&
+          'Processing Cloud subscriptions…'}
+        {step === CloudJobStep.Database &&
+          'Creating a free trial Cloud database…'}
+        {step === CloudJobStep.Import &&
+          'Importing a free trial Cloud database…'}
+      </>
+    ),
+    description: (
+      <>
+        This may take several minutes, but it is totally worth it!
+        <Spacer size="m" />
+        You can continue working in Redis Insight, and we will notify you once
+        done.
+      </>
     ),
   }),
   SUCCESS_CREATE_DB: (
@@ -349,8 +339,7 @@ export const INFINITE_MESSAGES: Record<
       <>
         With Redis Insight {version} you have access to new useful features and
         optimizations.
-        <br />
-        <br />
+        <Spacer size="m" />
         Restart Redis Insight to install updates.
       </>
     ),

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
@@ -5,6 +5,7 @@ import { CloudJobName, CloudJobStep } from 'uiSrc/electron/constants'
 import ExternalLink from 'uiSrc/components/base/external-link'
 import Divider from 'uiSrc/components/divider/Divider'
 import { OAuthProviders } from 'uiSrc/components/oauth/oauth-select-plan/constants'
+import { LoaderLargeIcon } from 'uiSrc/components/base/icons'
 
 import { CloudSuccessResult, InfiniteMessage } from 'uiSrc/slices/interfaces'
 
@@ -51,23 +52,9 @@ export const INFINITE_MESSAGES: Record<
 > = {
   AUTHENTICATING: () => ({
     id: InfiniteMessagesIds.oAuthProgress,
-    Inner: (
-      <div role="presentation" data-testid="authenticating-notification">
-        <Row justify="end">
-          <FlexItem>
-            <Loader className={cx('infiniteMessage__icon', styles.loading)} />
-          </FlexItem>
-          <FlexItem grow>
-            <Title className="infiniteMessage__title" size="XS">
-              Authenticating…
-            </Title>
-            <Text size="xs">
-              This may take several seconds, but it is totally worth it!
-            </Text>
-          </FlexItem>
-        </Row>
-      </div>
-    ),
+    message: 'Authenticating…',
+    description: 'This may take several seconds, but it is totally worth it!',
+    customIcon: LoaderLargeIcon,
   }),
   PENDING_CREATE_DB: (step?: CloudJobStep) => ({
     id: InfiniteMessagesIds.oAuthProgress,

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
@@ -148,7 +148,11 @@ export const INFINITE_MESSAGES: Record<
           <Spacer size="m" />
           <Row justify="between" align="center">
             <FlexItem>
-              <ExternalLink href={MANAGE_DB_LINK} iconSize="S">
+              <ExternalLink
+                href={MANAGE_DB_LINK}
+                iconSize="XS"
+                variant="small-inline"
+              >
                 Manage DB
               </ExternalLink>
             </FlexItem>
@@ -178,49 +182,35 @@ export const INFINITE_MESSAGES: Record<
   }),
   DATABASE_IMPORT_FORBIDDEN: (onClose?: () => void) => ({
     id: InfiniteMessagesIds.databaseImportForbidden,
-    Inner: (
-      <div
-        role="presentation"
-        onMouseDown={(e) => {
-          e.preventDefault()
-        }}
-        onMouseUp={(e) => {
-          e.preventDefault()
-        }}
-        data-testid="database-import-forbidden-notification"
-      >
-        <Title className="infiniteMessage__title" size="XS">
-          Unable to import Cloud database.
-        </Title>
-        <Text size="xs">
-          Adding your Redis Cloud database to Redis Insight is disabled due to a
-          setting restricting database connection management.
-          <Spacer size="m" />
-          Log in to{' '}
-          <Link
-            target="_blank"
-            color="text"
-            tabIndex={-1}
-            href="https://cloud.redis.io/#/databases?utm_source=redisinsight&utm_medium=main&utm_campaign=disabled_db_management"
-          >
-            Redis Cloud
-          </Link>{' '}
-          to check your database.
-        </Text>
+    message: 'Unable to import Cloud database.',
+    description: (
+      <>
+        Adding your Redis Cloud database to Redis Insight is disabled due to a
+        setting restricting database connection management.
         <Spacer size="m" />
-        <Row justify="end">
-          <FlexItem>
-            <PrimaryButton
-              size="s"
-              onClick={() => onClose?.()}
-              data-testid="database-import-forbidden-notification-ok-btn"
-            >
-              Ok
-            </PrimaryButton>
-          </FlexItem>
-        </Row>
-      </div>
+        Log in to{' '}
+        <ExternalLink
+          target="_blank"
+          variant="small-inline"
+          iconSize={'XS'}
+          tabIndex={-1}
+          href={getUtmExternalLink(EXTERNAL_LINKS.cloudConsole, {
+            medium: UTM_MEDIUMS.Main,
+            campaign: 'disabled_db_management',
+          })}
+        >
+          Redis Cloud
+        </ExternalLink>{' '}
+        to check your database.
+      </>
     ),
+    actions: {
+      primary: {
+        label: 'OK',
+        onClick: () => onClose?.(),
+      },
+    },
+    showCloseButton: false,
   }),
   SUBSCRIPTION_EXISTS: (onSuccess?: () => void, onClose?: () => void) => ({
     id: InfiniteMessagesIds.subscriptionExists,

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
@@ -93,87 +93,76 @@ export const INFINITE_MESSAGES: Record<
         CloudJobName.CreateFreeSubscriptionAndDatabase,
       ].includes(jobName)
     const text = `You can now use your Redis Cloud database${withFeed ? ' with pre-loaded sample data' : ''}.`
+
     return {
       id: InfiniteMessagesIds.oAuthSuccess,
-      className: 'wide',
-      Inner: (
-        <div
-          role="presentation"
-          onMouseDown={(e) => {
-            e.preventDefault()
-          }}
-          onMouseUp={(e) => {
-            e.preventDefault()
-          }}
-          data-testid="success-create-db-notification"
-        >
-          <Row justify="end">
-            <FlexItem className="infiniteMessage__icon">
-              <RiIcon type="ChampagneIcon" size="original" />
-            </FlexItem>
-            <FlexItem grow>
-              <Title className="infiniteMessage__title" size="XS">
-                Congratulations!
-              </Title>
-              <Text size="xs">
-                {text}
-                <Spacer size="s" />
-                <b>Notice:</b> the database will be deleted after 15 days of
-                inactivity.
-              </Text>
-              {!!details && (
-                <>
-                  <Spacer size="m" />
-                  <Divider variant="fullWidth" />
-                  <Spacer size="m" />
-                  <Row className={styles.detailsRow} justify="between">
-                    <FlexItem>
-                      <Text size="xs">Plan</Text>
-                    </FlexItem>
-                    <FlexItem data-testid="notification-details-plan">
-                      <Text size="xs">Free</Text>
-                    </FlexItem>
-                  </Row>
-                  <Row className={styles.detailsRow} justify="between">
-                    <FlexItem>
-                      <Text size="xs">Cloud Vendor</Text>
-                    </FlexItem>
-                    <FlexItem
-                      className={styles.vendorLabel}
-                      data-testid="notification-details-vendor"
-                    >
-                      {!!vendor?.icon && <RiIcon type={vendor?.icon} />}
-                      <Text size="xs">{vendor?.label}</Text>
-                    </FlexItem>
-                  </Row>
-                  <Row className={styles.detailsRow} justify="between">
-                    <FlexItem>
-                      <Text size="xs">Region</Text>
-                    </FlexItem>
-                    <FlexItem data-testid="notification-details-region">
-                      <Text size="xs">{details.region}</Text>
-                    </FlexItem>
-                  </Row>
-                </>
-              )}
+      message: 'Congratulations!',
+      description: (
+        <>
+          {text}
+          <Spacer size="m" />
+          <Text variant="semiBold" component="span">
+            Notice:
+          </Text>{' '}
+          the database will be deleted after 15 days of inactivity.
+          {!!details && (
+            <>
               <Spacer size="m" />
-              <Row justify="between" align="center">
+              <Divider variant="fullWidth" />
+              <Spacer size="m" />
+              <Row className={styles.detailsRow} justify="between">
                 <FlexItem>
-                  <ExternalLink href={MANAGE_DB_LINK}>Manage DB</ExternalLink>
+                  <Text size="xs">Plan</Text>
                 </FlexItem>
-                <FlexItem>
-                  <PrimaryButton
-                    size="s"
-                    onClick={() => onSuccess()}
-                    data-testid="notification-connect-db"
-                  >
-                    Connect
-                  </PrimaryButton>
+                <FlexItem data-testid="notification-details-plan">
+                  <Text size="xs">Free</Text>
                 </FlexItem>
               </Row>
+              <Row
+                className={styles.detailsRow}
+                justify="between"
+                align="center"
+              >
+                <FlexItem>
+                  <Text size="xs">Cloud Vendor</Text>
+                </FlexItem>
+                <FlexItem
+                  className={styles.vendorLabel}
+                  data-testid="notification-details-vendor"
+                  $gap="s"
+                >
+                  {!!vendor?.icon && <RiIcon type={vendor?.icon} />}
+                  <Text size="xs">{vendor?.label}</Text>
+                </FlexItem>
+              </Row>
+              <Row className={styles.detailsRow} justify="between">
+                <FlexItem>
+                  <Text size="xs">Region</Text>
+                </FlexItem>
+                <FlexItem data-testid="notification-details-region">
+                  <Text size="xs">{details.region}</Text>
+                </FlexItem>
+              </Row>
+            </>
+          )}
+          <Spacer size="m" />
+          <Row justify="between" align="center">
+            <FlexItem style={{ marginLeft: -10 }}>
+              <ExternalLink href={MANAGE_DB_LINK} iconSize="S">
+                Manage DB
+              </ExternalLink>
+            </FlexItem>
+            <FlexItem>
+              <PrimaryButton
+                size="small"
+                onClick={() => onSuccess()}
+                data-testid="notification-connect-db"
+              >
+                Connect
+              </PrimaryButton>
             </FlexItem>
           </Row>
-        </div>
+        </>
       ),
     }
   },

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
@@ -6,7 +6,7 @@ import ExternalLink from 'uiSrc/components/base/external-link'
 import Divider from 'uiSrc/components/divider/Divider'
 import { OAuthProviders } from 'uiSrc/components/oauth/oauth-select-plan/constants'
 
-import { CloudSuccessResult } from 'uiSrc/slices/interfaces'
+import { CloudSuccessResult, InfiniteMessage } from 'uiSrc/slices/interfaces'
 
 import { Maybe } from 'uiSrc/utils'
 import { getUtmExternalLink } from 'uiSrc/utils/links'
@@ -44,7 +44,11 @@ const MANAGE_DB_LINK = getUtmExternalLink(EXTERNAL_LINKS.cloudConsole, {
   medium: UTM_MEDIUMS.Main,
 })
 
-export const INFINITE_MESSAGES = {
+// TODO: Refactor this type definition to work with the real parameters and their types we use in each message
+export const INFINITE_MESSAGES: Record<
+  string,
+  (...args: any[]) => InfiniteMessage
+> = {
   AUTHENTICATING: () => ({
     id: InfiniteMessagesIds.oAuthProgress,
     Inner: (
@@ -353,39 +357,19 @@ export const INFINITE_MESSAGES = {
   }),
   APP_UPDATE_AVAILABLE: (version: string, onSuccess?: () => void) => ({
     id: InfiniteMessagesIds.appUpdateAvailable,
-    Inner: (
-      <div
-        role="presentation"
-        onMouseDown={(e) => {
-          e.preventDefault()
-        }}
-        onMouseUp={(e) => {
-          e.preventDefault()
-        }}
-        data-testid="app-update-available-notification"
-      >
-        <Title className="infiniteMessage__title" size="XS">
-          New version is now available
-        </Title>
-        <Text size="s">
-          <>
-            With Redis Insight
-            {` ${version} `}
-            you have access to new useful features and optimizations.
-            <br />
-            Restart Redis Insight to install updates.
-          </>
-        </Text>
+    message: 'New version is now available',
+    description: (
+      <>
+        With Redis Insight {version} you have access to new useful features and
+        optimizations.
         <br />
-        <PrimaryButton
-          size="s"
-          onClick={() => onSuccess?.()}
-          data-testid="app-restart-btn"
-        >
-          Restart
-        </PrimaryButton>
-      </div>
+        <br />
+        Restart Redis Insight to install updates.
+      </>
     ),
+    actions: {
+      primary: { label: 'Restart', onClick: () => onSuccess?.() },
+    },
   }),
   SUCCESS_DEPLOY_PIPELINE: () => ({
     id: InfiniteMessagesIds.pipelineDeploySuccess,

--- a/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
+++ b/redisinsight/ui/src/components/notifications/components/infinite-messages/InfiniteMessages.tsx
@@ -373,47 +373,20 @@ export const INFINITE_MESSAGES: Record<
   }),
   SUCCESS_DEPLOY_PIPELINE: () => ({
     id: InfiniteMessagesIds.pipelineDeploySuccess,
-    className: 'wide',
-    Inner: (
-      <div
-        role="presentation"
-        onMouseDown={(e) => {
-          e.preventDefault()
-        }}
-        onMouseUp={(e) => {
-          e.preventDefault()
-        }}
-        data-testid="success-deploy-pipeline-notification"
-      >
-        <Row justify="end">
-          <FlexItem className="infiniteMessage__icon">
-            <RiIcon type="ChampagneIcon" size="original" />
-          </FlexItem>
-          <FlexItem grow>
-            <Title className="infiniteMessage__title" size="XS">
-              Congratulations!
-            </Title>
-            <Text size="xs">
-              Deployment completed successfully!
-              <br />
-              Check out the pipeline statistics page.
-            </Text>
-            <Spacer size="m" />
-            {/* // TODO remove display none when statistics page will be available */}
-            <Row style={{ display: 'none' }} justify="end" align="center">
-              <FlexItem>
-                <PrimaryButton
-                  size="s"
-                  onClick={() => {}}
-                  data-testid="notification-connect-db"
-                >
-                  Statistics
-                </PrimaryButton>
-              </FlexItem>
-            </Row>
-          </FlexItem>
-        </Row>
-      </div>
+    message: 'Congratulations!',
+    description: (
+      <>
+        Deployment completed successfully!
+        <br />
+        Check out the pipeline statistics page.
+      </>
     ),
+    // TODO enable when statistics page will be available
+    // actions: {
+    //   primary: {
+    //     label: 'Statistics',
+    //     onClick: () => {},
+    //   }
+    // }
   }),
 }

--- a/redisinsight/ui/src/slices/interfaces/app.ts
+++ b/redisinsight/ui/src/slices/interfaces/app.ts
@@ -255,6 +255,7 @@ export interface InfiniteMessage {
   description?: RiToastType['description']
   actions?: RiToastType['actions']
   customIcon?: RiToastType['customIcon']
+  onClose?: () => void
 }
 
 export interface StateAppNotifications {

--- a/redisinsight/ui/src/slices/interfaces/app.ts
+++ b/redisinsight/ui/src/slices/interfaces/app.ts
@@ -13,6 +13,7 @@ import {
 import { ConfigDBStorageItem } from 'uiSrc/constants/storage'
 import { GetServerInfoResponse } from 'apiSrc/modules/server/dto/server.dto'
 import { RedisString as RedisStringAPI } from 'apiSrc/common/constants/redis-string'
+import { RiToastType } from 'uiSrc/components/base/display/toast/RiToast'
 
 export interface CustomError {
   details?: any[]
@@ -243,8 +244,11 @@ export interface IGlobalNotification {
 
 export interface InfiniteMessage {
   id: string
-  Inner: string | JSX.Element
+  Inner?: string | JSX.Element // TODO: Remove inner later
   className?: string
+  message?: RiToastType['message']
+  description?: RiToastType['description']
+  actions?: RiToastType['actions']
 }
 
 export interface StateAppNotifications {

--- a/redisinsight/ui/src/slices/interfaces/app.ts
+++ b/redisinsight/ui/src/slices/interfaces/app.ts
@@ -13,7 +13,11 @@ import {
 import { ConfigDBStorageItem } from 'uiSrc/constants/storage'
 import { GetServerInfoResponse } from 'apiSrc/modules/server/dto/server.dto'
 import { RedisString as RedisStringAPI } from 'apiSrc/common/constants/redis-string'
-import { RiToastType } from 'uiSrc/components/base/display/toast/RiToast'
+import {
+  riToast,
+  RiToastType,
+} from 'uiSrc/components/base/display/toast/RiToast'
+import { ToastVariant } from '@redis-ui/components'
 
 export interface CustomError {
   details?: any[]
@@ -245,6 +249,7 @@ export interface IGlobalNotification {
 export interface InfiniteMessage {
   id: string
   Inner?: string | JSX.Element // TODO: Remove inner later
+  variant?: ToastVariant
   className?: string
   message?: RiToastType['message']
   description?: RiToastType['description']

--- a/redisinsight/ui/src/slices/interfaces/app.ts
+++ b/redisinsight/ui/src/slices/interfaces/app.ts
@@ -13,10 +13,7 @@ import {
 import { ConfigDBStorageItem } from 'uiSrc/constants/storage'
 import { GetServerInfoResponse } from 'apiSrc/modules/server/dto/server.dto'
 import { RedisString as RedisStringAPI } from 'apiSrc/common/constants/redis-string'
-import {
-  riToast,
-  RiToastType,
-} from 'uiSrc/components/base/display/toast/RiToast'
+import { RiToastType } from 'uiSrc/components/base/display/toast/RiToast'
 import { ToastVariant } from '@redis-ui/components'
 
 export interface CustomError {
@@ -248,7 +245,6 @@ export interface IGlobalNotification {
 
 export interface InfiniteMessage {
   id: string
-  Inner?: string | JSX.Element // TODO: Remove inner later
   variant?: ToastVariant
   className?: string
   message?: RiToastType['message']

--- a/redisinsight/ui/src/slices/interfaces/app.ts
+++ b/redisinsight/ui/src/slices/interfaces/app.ts
@@ -254,6 +254,7 @@ export interface InfiniteMessage {
   message?: RiToastType['message']
   description?: RiToastType['description']
   actions?: RiToastType['actions']
+  customIcon?: RiToastType['customIcon']
 }
 
 export interface StateAppNotifications {

--- a/redisinsight/ui/src/slices/interfaces/app.ts
+++ b/redisinsight/ui/src/slices/interfaces/app.ts
@@ -255,6 +255,7 @@ export interface InfiniteMessage {
   description?: RiToastType['description']
   actions?: RiToastType['actions']
   customIcon?: RiToastType['customIcon']
+  showCloseButton?: boolean
   onClose?: () => void
 }
 


### PR DESCRIPTION
# Description

Update the visuals of the infinite notification to resemble more closely the Redis UI toasts, and the FIgma designs.
- update the interface and the way we serve the data for the infinite notification, so it will resemble more closely the expected format by Redis UI, and make all infinite notifications use it
- rework the way we show the default "X" button for dismissing notifications
- update the variant to reflect the expected design

# How it was tested

There are numerous use cases in which we use infinite notifications. Although we have a common way to dispatch these types of notifications, I still had to update the way we build up the data for each notification. Here are all of the updated notifications:

## Authenticating

1. Click on the "Cloud Login" button in the top right corner, and login via one of the providers
2. Once you're redirected back to the app, you'll see the notification for a second

Or, dispatch manually the notification anywhere in the code:
```js
 dispatch(addInfiniteNotification(INFINITE_MESSAGES.AUTHENTICATING()))
```

| Old | Before | After |
| - | - | - |
<img width="373" height="136" alt="image" src="https://github.com/user-attachments/assets/0bbdfd70-6f9d-4cb0-86b6-d899bcce7ff1" />|<img width="549" height="90" alt="Screenshot 2025-09-18 at 9 36 16" src="https://github.com/user-attachments/assets/a38ca75a-2d04-4145-8fa1-ce3b94bc3b21" />|<img width="437" height="97" alt="image" src="https://github.com/user-attachments/assets/e533f4a6-b413-460f-a12b-023168d612ba" />
<img width="390" height="149" alt="image" src="https://github.com/user-attachments/assets/6a395f74-92e4-46a9-8f6c-e59e60873aee" />|<img width="549" height="90" alt="Screenshot 2025-09-18 at 9 36 26" src="https://github.com/user-attachments/assets/ce94b21c-02f8-4602-8efa-2d02c7069b95" />|<img width="431" height="96" alt="image" src="https://github.com/user-attachments/assets/1e42e97b-926e-4679-83e7-119e79d88df5" />

## Pending cloud database creation

1. Go to **Databases** and click on the **+ Add Redis Database** button
2. Under the "**Get started with Redis Cloud account**" section, click on the "**New database**" option
3. Make sure to confirm the new cloud database creation in the modal, and you'll see the toast notification 

Or, dispatch manually the notification anywhere in the code:
```js
dispatch(addInfiniteNotification(INFINITE_MESSAGES.PENDING_CREATE_DB()))
```

_Note: This notification can display different titles, based on the step in the process:
- Processing Cloud API keys…
- Processing Cloud subscriptions…
- Creating a free trial Cloud database…
- Importing a free trial Cloud database…_

| Old | Before | After |
| - | - | - |
<img width="431" height="220" alt="Screenshot 2025-09-18 at 10 57 10" src="https://github.com/user-attachments/assets/b117e5a4-fc91-40e7-90be-6e3e66288dd7" />|<img width="431" height="102" alt="Screenshot 2025-09-18 at 10 50 13" src="https://github.com/user-attachments/assets/c6c7c201-0d96-44d2-846d-5a4b3e6fa6e5" />|<img width="436" height="159" alt="Screenshot 2025-09-18 at 11 01 51" src="https://github.com/user-attachments/assets/fb23b3a2-3280-4b11-9a66-26c80cca9315" />
<img width="431" height="220" alt="Screenshot 2025-09-18 at 10 57 18" src="https://github.com/user-attachments/assets/cf04a0be-d5d8-4df1-8196-2a0c314e92e5" />|<img width="431" height="102" alt="Screenshot 2025-09-18 at 10 50 23" src="https://github.com/user-attachments/assets/4a8a71e7-2997-4b68-8d39-8e2453e4359e" />|<img width="436" height="159" alt="Screenshot 2025-09-18 at 11 01 59" src="https://github.com/user-attachments/assets/b2984273-d73e-4d5a-adbe-213e831becec" />

## Successfully created Cloud database

Follow the steps from the previous use case ([#Pending cloud database creation](#pending-cloud-database-creation)) and wait till the end, to see the success toast notification.

Or, dispatch manually the notification anywhere in the code:
```js
dispatch(
      addInfiniteNotification(
        INFINITE_MESSAGES.SUCCESS_CREATE_DB(
          {
            provider: OAuthProvider.AWS,
            region: 'us-east-1',
          },
          () => alert('Success create DB'),
          CloudJobName.CreateFreeDatabase,
        ),
      ),
)
```

_Note: Here, we don't use the action button, because we have a lot of content and it becomes very ugly if we reduce it width (to make room for the two action buttons). Still, we can't use the semantic colored buttons, so the following visuals look off._

| Old | Before | After |
| - | - | - |
<img width="431" height="337" alt="Screenshot 2025-09-18 at 10 57 47" src="https://github.com/user-attachments/assets/bd9099e4-99a2-4870-997e-40a13a8c24d8" />|<img width="436" height="212" alt="Screenshot 2025-09-18 at 11 16 52" src="https://github.com/user-attachments/assets/fdce5d89-8601-434d-8c02-44885d9ebd80" />|<img width="428" height="232" alt="Screenshot 2025-09-18 at 16 24 00" src="https://github.com/user-attachments/assets/2ee4e673-9e23-4af0-89cb-6e47b4bb4fac" />
<img width="431" height="337" alt="Screenshot 2025-09-18 at 10 57 40" src="https://github.com/user-attachments/assets/12edaeaa-532a-4fe8-bdd3-899b821dcf5b" />|<img width="436" height="212" alt="Screenshot 2025-09-18 at 11 17 03" src="https://github.com/user-attachments/assets/1eba4dd9-ba4c-4ab0-9941-4e0420708fdc" />|<img width="428" height="232" alt="Screenshot 2025-09-18 at 16 24 10" src="https://github.com/user-attachments/assets/862adb09-8a5e-4a46-85a2-73363ce7395d" />

## Database already exists

Follow the steps from the previous use case ([#Successfully created Cloud database](#successfully-created-cloud database)) and wait till the end, to see the toast notification that such a database already exists.

Or, dispatch manually the notification anywhere in the code:
```js
dispatch(
      addInfiniteNotification(
        INFINITE_MESSAGES.DATABASE_EXISTS(
          () => alert('Import'),
          () => alert('Close'),
        ),
      ),
)
```

| Old | Before | After |
| - | - | - |
<img width="428" height="244" alt="Screenshot 2025-09-18 at 13 50 59" src="https://github.com/user-attachments/assets/85f549fc-8a89-49f9-8c26-7b4ef845fc3f" />|<img width="428" height="136" alt="Screenshot 2025-09-18 at 13 53 14" src="https://github.com/user-attachments/assets/e447b13f-4960-4ffd-8d7c-b03a611df6eb" />|<img width="428" height="100" alt="Screenshot 2025-09-18 at 14 14 06" src="https://github.com/user-attachments/assets/a0c19344-e291-4637-9c5a-b9d915f9e14c" />
<img width="428" height="244" alt="Screenshot 2025-09-18 at 13 51 07" src="https://github.com/user-attachments/assets/9a9a329f-c834-4d77-ae0f-09849c57de69" />|<img width="428" height="136" alt="Screenshot 2025-09-18 at 13 53 24" src="https://github.com/user-attachments/assets/12a5f5a1-8ebe-4d57-9ea1-0387f9a5da19" />|<img width="428" height="100" alt="Screenshot 2025-09-18 at 14 14 14" src="https://github.com/user-attachments/assets/187c4622-1961-4a1b-b7ca-cf093cdb458a" />

## Cloud Import Forbidden

I was not able to find a way to reproduce this scenario in the app, but you can manually open the notification this way:

```js
dispatch(
      addInfiniteNotification(
        INFINITE_MESSAGES.DATABASE_IMPORT_FORBIDDEN(() => alert('Close')),
      ),
)
```

| Before | After |
| - | - |
<img width="428" height="149" alt="Screenshot 2025-09-18 at 15 54 44" src="https://github.com/user-attachments/assets/9cf79de0-4036-4c47-9be8-90c36c890c5a" />|<img width="428" height="162" alt="Screenshot 2025-09-18 at 16 28 49" src="https://github.com/user-attachments/assets/55c104f5-9aee-4bcf-b366-94b69fe391a3" />
<img width="428" height="149" alt="Screenshot 2025-09-18 at 15 54 54" src="https://github.com/user-attachments/assets/41bc4875-10c7-498d-9be3-89887277758e" />|<img width="428" height="162" alt="Screenshot 2025-09-18 at 16 28 57" src="https://github.com/user-attachments/assets/e8643687-44ff-46e6-af5f-05835bbd9b2b" />

## Subscription already exists

I was not able to find a way to reproduce this scenario in the app, but you can manually open the notification this way:

```js
 dispatch(
      addInfiniteNotification(
        INFINITE_MESSAGES.SUBSCRIPTION_EXISTS(
          () => alert('Create'),
          () => alert('Cancel'),
        ),
      ),
)
```

| Before | After |
| - | - |
<img width="423" height="139" alt="Screenshot 2025-09-18 at 16 32 51" src="https://github.com/user-attachments/assets/a5e83099-7830-4a5b-bdeb-663332853927" />|<img width="423" height="126" alt="Screenshot 2025-09-18 at 16 35 24" src="https://github.com/user-attachments/assets/3685a901-62f0-48fe-9993-8b106ad2b18d" />
<img width="423" height="139" alt="Screenshot 2025-09-18 at 16 33 00" src="https://github.com/user-attachments/assets/8c81e75c-4cb3-4d28-87a0-29f2037473c0" />|<img width="423" height="126" alt="Screenshot 2025-09-18 at 16 35 29" src="https://github.com/user-attachments/assets/2ff1905d-e301-4946-bdc4-7308a15c7004" />

## Automatic creation of a database

I was not able to find a way to reproduce this scenario in the app, but you can manually open the notification this way:

```js
dispatch(
      addInfiniteNotification(INFINITE_MESSAGES.AUTO_CREATING_DATABASE()),
)
```

| Before | After |
| - | - |
<img width="423" height="76" alt="Screenshot 2025-09-18 at 16 44 46" src="https://github.com/user-attachments/assets/60e03dbd-b0e5-4fcb-a079-f27400e53b76" />|<img width="423" height="98" alt="Screenshot 2025-09-18 at 16 46 14" src="https://github.com/user-attachments/assets/e99a4306-b971-4aa1-a9a8-7c68128ec738" />
<img width="423" height="76" alt="Screenshot 2025-09-18 at 16 44 55" src="https://github.com/user-attachments/assets/12cc0055-72de-4ee7-8f17-8c1a815a1f68" />|<img width="423" height="98" alt="Screenshot 2025-09-18 at 16 46 20" src="https://github.com/user-attachments/assets/790fd5ac-c3f7-4af4-8dff-35f806558193" />

## App Update Available

1. Download an older version of the app from the archive
 
Wait for a minute, and you'll notice the notification, suggesting you to restart the app

Or, dispatch manually the notification anywhere in the code:
```js
dispatch(
  addInfiniteNotification(
    INFINITE_MESSAGES.APP_UPDATE_AVAILABLE('2.74', () => {
      console.log('Restarting...')
    })
  )
)
```

| Old | Before | After |
| - | - | - |
<img width="373" height="207" alt="Screenshot 2025-09-16 at 14 51 50" src="https://github.com/user-attachments/assets/83e4c6ae-702f-4137-9bf6-579d41c2aa9c" />|<img width="625" height="143" alt="image" src="https://github.com/user-attachments/assets/58c6d351-63cb-41d5-bb0a-d05984823d2b" />|<img width="628" height="138" alt="image" src="https://github.com/user-attachments/assets/6c27ea3d-8a64-4e82-85a8-9f215b338865" />
<img width="381" height="216" alt="image" src="https://github.com/user-attachments/assets/f9df93c7-7721-4105-8120-99ec5faa3919" />|<img width="620" height="138" alt="image" src="https://github.com/user-attachments/assets/6fde74f3-eab8-4d60-800e-182d26fad527" />|<img width="633" height="153" alt="image" src="https://github.com/user-attachments/assets/9798d7e1-a850-4b1e-b030-2760f5ea8198" />

## Successfully deployed RDI pipeline

1. Go to the **Databases** page and click on the **Redis Data Integration** tab 
4. Open an existing RDI instance (or create a new one, but it's complicated)
5. From the top right corner, click on **Deploy Pipeline** button

Wait for the action to complete, and you'll see the notification.

Or, dispatch the notification manually anywhere in the code:
```js
dispatch(
  addInfiniteNotification(
    INFINITE_MESSAGES.SUCCESS_DEPLOY_PIPELINE()
  )
)
```

| Old | Before | After |
| - | - | - |
<img width="453" height="143" alt="Screenshot 2025-09-18 at 9 19 49" src="https://github.com/user-attachments/assets/225be9ed-c439-4d95-bb32-36e4f6bea107" />|<img width="549" height="108" alt="Screenshot 2025-09-18 at 9 34 19" src="https://github.com/user-attachments/assets/365ad633-d565-4168-85ba-8c0f47508c3b" />|<img width="547" height="143" alt="Screenshot 2025-09-18 at 9 16 47" src="https://github.com/user-attachments/assets/cec7e70b-905c-49c1-904a-507490029286" />
<img width="453" height="143" alt="Screenshot 2025-09-18 at 9 19 56" src="https://github.com/user-attachments/assets/b1142322-ffb8-4efe-ae05-52d209576a4f" />|<img width="549" height="108" alt="Screenshot 2025-09-18 at 9 34 27" src="https://github.com/user-attachments/assets/cadcbce9-9dc9-4caf-935f-883bd1a32dd2" />|<img width="547" height="143" alt="Screenshot 2025-09-18 at 9 17 01" src="https://github.com/user-attachments/assets/f37123e0-c47b-4ffb-b5d3-4314d97797ac" />
