### PR TITLE
RI-7447: Prevent full page reload when "Claim" is clicked

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessageClaimPopover/MessageClaimPopover.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/stream-details/messages-view/MessageClaimPopover/MessageClaimPopover.tsx
@@ -342,7 +342,6 @@ const MessageClaimPopover = (props: Props) => {
             </SecondaryButton>
             <PrimaryButton
               className={styles.footerBtn}
-              type="submit"
               onClick={() => formik.handleSubmit()}
               data-testid="btn-submit"
             >


### PR DESCRIPTION
Well, the hard part here is to set up the scenario 😸 

# Preview

https://github.com/user-attachments/assets/e7181e85-3893-49e2-ae9e-545636456342

# Setup

1. Create a stream with some data
```
XADD mystream * sensor-id s-1 temp 21.4 status ok
XADD mystream * sensor-id s-2 temp 22.1 status ok
XADD mystream * sensor-id s-1 temp 23.0 status warn
XADD mystream * sensor-id s-3 temp 19.8 status ok
XADD mystream * sensor-id s-2 temp 25.5 status crit
```

2. Create a consumer group
```
XGROUP CREATE mystream cg1 $ MKSTREAM
```

3. Use **separate** terminals to simulate 2 consumers
```
terminal 1: XREADGROUP GROUP cg1 c1 COUNT 2 BLOCK 0 STREAMS mystream >
terminal 2: XREADGROUP GROUP cg1 c2 COUNT 2 BLOCK 0 STREAMS mystream >
```

4. Add more data
```
XADD mystream * sensor-id s-4 temp 20.2 status ok
XADD mystream * sensor-id s-1 temp 26.3 status crit
```

5. You should have a pending message 