### PR TITLE
RI-7431: rework autorefresh popover layout

### DIFF
--- a/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
+++ b/redisinsight/ui/src/components/auto-refresh/AutoRefresh.tsx
@@ -296,11 +296,10 @@ const AutoRefresh = ({
           <FlexItem>
             <RiPopover
               ownFocus={false}
-              anchorPosition="downRight"
+              anchorPosition="downCenter"
               isOpen={isPopoverOpen}
               anchorClassName={styles.anchorWrapper}
               panelClassName={cx(
-                'popover-without-top-tail',
                 styles.popoverWrapper,
                 {
                   [styles.popoverWrapperEditing]: editingRate,

--- a/redisinsight/ui/src/components/auto-refresh/styles.module.scss
+++ b/redisinsight/ui/src/components/auto-refresh/styles.module.scss
@@ -17,7 +17,6 @@
   width: 240px;
   height: 114px;
   padding: 28px 18px !important;
-  background-color: var(--euiColorLightestShade) !important;
 
   .input {
     display: inline-block;
@@ -26,7 +25,6 @@
     input {
       height: 30px !important;
       border-radius: 0 !important;
-      background-color: var(--euiColorLightestShade) !important;
     }
   }
 }
@@ -54,7 +52,6 @@
   display: none;
   right: 61px;
   margin-bottom: 3px;
-  background-color: var(--browserTableRowEven);
   width: 26px !important;
   height: 28px !important;
   padding: 5px;
@@ -69,11 +66,10 @@
   display: inline-block;
   width: 80px;
   height: 30px;
-  border: 1px solid transparent;
   cursor: pointer;
+  padding-left: 5px;
 
   &:hover {
-    padding-left: 5px;
     border-color: var(--controlsBorderColor);
 
     .refreshRatePencil {

--- a/redisinsight/ui/src/components/inline-item-editor/styles.module.scss
+++ b/redisinsight/ui/src/components/inline-item-editor/styles.module.scss
@@ -6,14 +6,6 @@
   }
 }
 
-.field {
-  min-width: 72px;
-  max-width: 100% !important;
-  box-shadow: 0 3px 3px var(--controlsBoxShadowColor) !important;
-  height: 33px !important;
-  border: 1px solid var(--controlsBoxShadowColor) !important;
-}
-
 .controls {
   .tooltip,
   .popoverWrapper {


### PR DESCRIPTION
Rework AutoRefresh popover to align to the rest design

|Before|After|
|-|-|
<img width="460" height="172" alt="Screenshot 2025-09-18 at 09 08 27" src="https://github.com/user-attachments/assets/417e4beb-fd49-48e5-bf6b-f48f03e2d04a" />|<img width="382" height="194" alt="Screenshot 2025-09-18 at 09 07 53" src="https://github.com/user-attachments/assets/29c1d87b-f85e-429c-89cf-dbc6b964ee0d" />
<img width="459" height="209" alt="Screenshot 2025-09-18 at 09 08 32" src="https://github.com/user-attachments/assets/72e24b1e-0d36-41d3-88ce-0f743f324960" />|<img width="355" height="207" alt="Screenshot 2025-09-18 at 09 07 58" src="https://github.com/user-attachments/assets/73318a05-fff1-4323-8142-a6dc0d53166d" />

