### PR TITLE
RI-7474 Fix Insights panel visuals

### DIFF
--- a/redisinsight/ui/src/components/messages/database-not-opened/DatabaseNotOpened.tsx
+++ b/redisinsight/ui/src/components/messages/database-not-opened/DatabaseNotOpened.tsx
@@ -5,6 +5,7 @@ import { getUtmExternalLink } from 'uiSrc/utils/links'
 import { EXTERNAL_LINKS, UTM_CAMPAINGS } from 'uiSrc/constants/links'
 import TelescopeImg from 'uiSrc/assets/img/telescope-dark.svg'
 import { OAuthSocialAction, OAuthSocialSource } from 'uiSrc/slices/interfaces'
+import { Col } from 'uiSrc/components/base/layout/flex'
 
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import { Title } from 'uiSrc/components/base/text/Title'
@@ -26,14 +27,15 @@ const DatabaseNotOpened = (props: Props) => {
           Open a database
         </Title>
         <Spacer size="s" />
-        <>
+        <Col>
           <Text color="subdued" size="s">
             Open your Redis database, or create a new database to get started.
           </Text>
-          <Spacer size="s" />
+          <Spacer size="m" />
           <OAuthSsoHandlerDialog>
             {(ssoCloudHandlerClick) => (
               <ExternalLink
+                variant="small-inline"
                 iconSize="S"
                 href={getUtmExternalLink(EXTERNAL_LINKS.tryFree, {
                   campaign: UTM_CAMPAINGS[source] ?? source,
@@ -53,6 +55,7 @@ const DatabaseNotOpened = (props: Props) => {
           </OAuthSsoHandlerDialog>
           <Spacer size="xs" />
           <ExternalLink
+            variant="small-inline"
             iconSize="S"
             href={getUtmExternalLink(EXTERNAL_LINKS.docker, {
               campaign: UTM_CAMPAINGS[source] ?? source,
@@ -61,7 +64,7 @@ const DatabaseNotOpened = (props: Props) => {
           >
             Install using Docker
           </ExternalLink>
-        </>
+        </Col>
       </div>
       <img
         src={TelescopeImg}

--- a/redisinsight/ui/src/components/side-panels/components/header/styles.module.scss
+++ b/redisinsight/ui/src/components/side-panels/components/header/styles.module.scss
@@ -1,9 +1,7 @@
-
 .header {
   position: relative;
 
-  padding: 15px;
-  padding-bottom: 0;
+  padding: 12px;
 
   display: flex;
   align-items: center;

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Group/Group.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Group/Group.tsx
@@ -13,7 +13,7 @@ import { EAItemActions } from 'uiSrc/constants'
 import { ONBOARDING_FEATURES } from 'uiSrc/components/onboarding-features'
 
 import { RiAccordion } from 'uiSrc/components/base/display/accordion/RiAccordion'
-import { Col } from 'uiSrc/components/base/layout/flex'
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
 import { RiTooltip, OnboardingTour } from 'uiSrc/components'
 import { Text } from 'uiSrc/components/base/text'
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
@@ -125,15 +125,15 @@ const Group = (props: Props) => {
       defaultOpen={initialIsOpen}
       open={forceState === 'open' || isGroupOpen}
       label={
-        <Text className="group-header" size="m">
+        <Row align="end" justify="start" gap="s">
           {isShowFolder && (
-            <RiIcon
-              type={isGroupOpen ? 'KnowledgeBaseIcon' : 'FolderIcon'}
-              style={{ marginRight: '10px' }}
-            />
+            <RiIcon type={isGroupOpen ? 'KnowledgeBaseIcon' : 'FolderIcon'} />
           )}
-          {label}
-        </Text>
+
+          <Text className="group-header" size="m">
+            {label}
+          </Text>
+        </Row>
       }
       onOpenChange={handleOpen}
       style={{

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Navigation/Navigation.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Navigation/Navigation.tsx
@@ -32,6 +32,7 @@ import {
   appFeatureOnboardingSelector,
 } from 'uiSrc/slices/app/features'
 import { OnboardingSteps } from 'uiSrc/constants/onboarding'
+import { Spacer } from 'uiSrc/components/base/layout'
 import { FormValues } from '../UploadTutorialForm/UploadTutorialForm'
 
 import Group from '../Group'
@@ -148,7 +149,7 @@ const Navigation = (props: Props) => {
     } = item
 
     const paddingsStyle = {
-      paddingLeft: `${padding + level * 14}px`,
+      paddingLeft: `${padding + level * 0}px`, // Note: Using the accordion component, we don't need to manually increase padding for nested items anymore
       paddingRight: `${padding}px`,
     }
     const currentSourcePath =
@@ -185,6 +186,7 @@ const Navigation = (props: Props) => {
                     <WelcomeMyTutorials
                       handleOpenUpload={() => setIsCreateOpen(true)}
                     />
+                    <Spacer />
                     <div className={styles.uploadWarningContainer}>
                       <UploadWarning />
                     </div>

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Pagination/Pagination.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Pagination/Pagination.tsx
@@ -60,6 +60,14 @@ const Pagination = ({
         path: sourcePath + path,
         manifestPath: !isNil(key) ? `${groupPath}/${key}` : '',
       })
+
+      // Scroll the context panel to top
+      const panel = document.querySelector(
+        '[data-testid="enablement-area__page"]',
+      )
+      if (panel) {
+        panel.scrollTop = 0
+      }
     }
   }
 

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Pagination/styles.module.scss
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/components/Pagination/styles.module.scss
@@ -5,14 +5,16 @@
   justify-content: space-between;
   align-items: center;
   border-top: 1px solid var(--separatorColor);
-  & > div:first-of-type,& > div:last-of-type  {
+  & > div:first-of-type,
+  & > div:last-of-type {
     min-width: 94px;
   }
 }
 
 .paginationCompressed {
   padding: 8px 16px;
-  & > div:first-of-type, & > div:last-of-type {
+  & > div:first-of-type,
+  & > div:last-of-type {
     min-width: 70px;
   }
 
@@ -22,20 +24,10 @@
   }
 }
 
-.prevPage, .nextPage {
+.prevPage,
+.nextPage {
   & > span {
     justify-content: flex-start;
-  }
-}
-
-.prevPageCompressed {
-  & > span {
-    padding: 0 12px 0 4px !important;
-  }
-}
-.nextPageCompressed {
-  & > span {
-    padding: 0 4px 0 12px !important;
   }
 }
 

--- a/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/styles.module.scss
+++ b/redisinsight/ui/src/components/side-panels/panels/enablement-area/EnablementArea/styles.module.scss
@@ -2,6 +2,7 @@
   overflow: hidden;
   height: 100%;
   flex-grow: 1;
+  margin-top: 8px;
 }
 
 .innerContainerLoader {
@@ -24,5 +25,3 @@
 .internalPageVisible {
   transform: translateX(0);
 }
-
-

--- a/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/components/recommendation/Recommendation.tsx
+++ b/redisinsight/ui/src/components/side-panels/panels/live-time-recommendations/components/recommendation/Recommendation.tsx
@@ -43,8 +43,11 @@ import {
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { RiAccordion } from 'uiSrc/components/base/display/accordion/RiAccordion'
 import { Link } from 'uiSrc/components/base/link/Link'
+import { Title } from 'uiSrc/pages/vector-search/manage-indexes/styles'
 
 import styles from './styles.module.scss'
+
+const TITLE_TRUNCATE_LENGTH = 30 // Note: Temporary dirty fix for RI-7474, before the full redesign of this component
 
 export interface IProps {
   id: string
@@ -59,7 +62,9 @@ export interface IProps {
 }
 
 const RecommendationContent = styled(Card)`
-  padding: var(--size-m);
+  padding: 0;
+  border: none;
+  box-shadow: none;
 `
 
 const RecommendationTitle = ({
@@ -311,12 +316,16 @@ const Recommendation = ({
         data-testid={`${name}-accordion`}
         aria-label={`${name}-accordion`}
       >
-        <RecommendationContent
-          className={styles.accordionContent}
-          color="subdued"
-        >
-          {recommendationContent()}
-        </RecommendationContent>
+        <Col>
+          {/* Note: Temporary dirty fix for RI-7474, before the full redesign of this component */}
+          {title?.length > TITLE_TRUNCATE_LENGTH && <Title>{title}</Title>}
+          <RecommendationContent
+            className={styles.accordionContent}
+            color="subdued"
+          >
+            {recommendationContent()}
+          </RecommendationContent>
+        </Col>
       </RiAccordion>
     </div>
   )

--- a/redisinsight/ui/src/components/side-panels/styles.module.scss
+++ b/redisinsight/ui/src/components/side-panels/styles.module.scss
@@ -34,7 +34,6 @@ $animation-duration: 300ms;
   font-size: 16px;
 }
 
-
 .body {
   height: calc(100% - 60px);
   display: flex;
@@ -101,7 +100,9 @@ $animation-duration: 300ms;
   }
 
   .triggerText {
-    font: normal normal 400 12px/14px Graphik, sans-serif !important;
+    font:
+      normal normal 400 12px/14px Graphik,
+      sans-serif !important;
     color: var(--htmlColor) !important;
   }
 
@@ -114,11 +115,12 @@ $animation-duration: 300ms;
   display: flex;
   flex-shrink: 0 !important;
   overflow: initial !important;
-  margin-right: 12px;
-  border-bottom: 1px solid var(--separatorColor);
   align-items: center;
-  padding: 0 12px;
   flex-grow: 0;
+
+  & > div {
+    padding: 0 12px;
+  }
 }
 
 .assistantHeader {

--- a/redisinsight/ui/src/styles/themes/light_theme/_theme_color.scss
+++ b/redisinsight/ui/src/styles/themes/light_theme/_theme_color.scss
@@ -156,7 +156,7 @@ $recommendationBorderColor: #3953c3;
 
 
 // Recommendations
-$recommendationsBgColor: #FFFFFF;
+$recommendationsBgColor: #F6F7F9;
 $recommendationBgColor: #F6F7F9;
 $recommendationLiveBorderColor: #B37A1E;
 $recommendationColor: #415681;


### PR DESCRIPTION
# Description

Update the visuals of the Insights panel to make it look "not broken", after the EUI replacement.

## Rework the spacings for the tabs of the insights panel
    
- added spacing between the "Insights" title and the tabs
- added spacing between the tabs and the tutorial's content
- match the width of the tips subheader, with the tabs panel above it
- update visuals of the pagination buttons in the tutorials

| Before | After |
| - | - |
<img  alt="image" src="https://github.com/user-attachments/assets/dfe50ff5-1b43-42b5-8da4-83a24cbbc399" />|<img  alt="image" src="https://github.com/user-attachments/assets/6a0116df-62b2-49c7-b2f5-a79884db7778" />
<img alt="Screenshot 2025-09-23 at 13 39 04" src="https://github.com/user-attachments/assets/389eb882-c2ed-463e-8076-6869ecb6b0a8" />|<img alt="Screenshot 2025-09-23 at 13 36 46" src="https://github.com/user-attachments/assets/9f7d81c7-fd0f-4ed2-b25d-e73edb85eded" />

## Rework the "tutorials" visuals in the insights panel
    
- align the icons and the titles in the tutorials sections
- added a spacer between the action button and the warning banner in "my tutorials"
- fix the inline padding in the nested sections
- scroll the tutorial to the top when changing pages
- update popover styles

| Before | After |
| - | - |
<img alt="image" src="https://github.com/user-attachments/assets/6091e8d4-c6a8-483d-a091-7cf48e8f6dc6" />|<img  alt="image" src="https://github.com/user-attachments/assets/e1c20e96-8a01-46df-97e2-dac88269f4aa" />
<img  alt="Screenshot 2025-09-23 at 13 29 10" src="https://github.com/user-attachments/assets/88a3058b-dc0a-4919-82f5-d3d197ee4f08" />|<img  alt="Screenshot 2025-09-23 at 11 31 39" src="https://github.com/user-attachments/assets/4987f6eb-49c1-4638-a0d8-da86a373b89c" />
<img alt="Screenshot 2025-09-23 at 13 29 20" src="https://github.com/user-attachments/assets/58a8756e-8765-431c-ac01-7dc32715f15d" />|<img alt="Screenshot 2025-09-23 at 11 31 49" src="https://github.com/user-attachments/assets/cae9028d-ffce-462e-baad-86d1a84ab6dd" />

## Rework the visuals of the "tips" section in the "insights" panel
    
- removed borders and paddings for the content of the tips
- added full title above the content of the tip, if it's longer and truncated in the accordion
- update background color for the voting container on light theme

| Before | After |
| - | - |
<img width="756" height="1672" alt="image" src="https://github.com/user-attachments/assets/35b3e900-4dc8-4d12-b208-a6e70adb1f18" />|<img width="770" height="1672" alt="image" src="https://github.com/user-attachments/assets/71226671-cca2-4047-b882-aabe40d1c287" />
