### PR TITLE
RI-7461: Unable to edit string key in JSON formatter

### DIFF
--- a/redisinsight/ui/src/components/base/utils/OutsideClickDetector.tsx
+++ b/redisinsight/ui/src/components/base/utils/OutsideClickDetector.tsx
@@ -33,7 +33,7 @@ export interface OutsideClickDetectorProps {
 // A click event's target can be imprecise, as the value will be
 // the closest common ancestor of the press (mousedown, touchstart)
 // and release (mouseup, touchend) events (often <body />) if
-// the the target of each event differs.
+// the target of each event differs.
 // We need the actual event targets to make the correct decisions
 // about user intention. So, consider the down/start and up/end
 // items below as the deconstruction of a click event.

--- a/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
+++ b/redisinsight/ui/src/components/inline-item-editor/InlineItemEditor.tsx
@@ -21,7 +21,6 @@ import {
   StyledTextInput,
 } from './InlineItemEditor.styles'
 
-
 import styles from './styles.module.scss'
 
 type Positions = 'top' | 'bottom' | 'left' | 'right' | 'inside'
@@ -216,7 +215,10 @@ const InlineItemEditor = (props: Props) => {
       {viewChildrenMode ? (
         children
       ) : (
-        <OutsideClickDetector onOutsideClick={handleClickOutside}>
+        <OutsideClickDetector
+          onOutsideClick={handleClickOutside}
+          isDisabled={isShowApprovePopover}
+        >
           <IIEContainer ref={containerEl}>
             <WindowEvent event="keydown" handler={handleOnEsc} />
             <FocusTrap disabled={disableFocusTrap}>


### PR DESCRIPTION
Disable outside click detector when ConfirmationPopover is shown.

Since ConfirmationPopover is "outside" the click detector "jurisdiction", 
clicking anywhere on it unmounts the editor and therefore, \form submission does not happen