### PR TITLE
RI-7547 Stop showing tooltip suggestions in the editor when inserting saved queries

### DIFF
--- a/redisinsight/ui/src/pages/workbench/components/query/Query/Query.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/query/Query/Query.tsx
@@ -493,6 +493,12 @@ const Query = (props: Props) => {
     const { data, forceHide, forceShow } = getSuggestions(editor, command)
     suggestionsRef.current = data
 
+    // Prevent suggestions if editor is not focused or cursor is not set
+    if (!editor.hasTextFocus() || !editor.getPosition()) {
+      editor.trigger('', 'hideSuggestWidget', null)
+      return
+    }
+
     if (!forceShow) {
       editor.trigger('', 'editor.action.triggerParameterHints', '')
       return

--- a/tests/playwright/pageObjects/pages/vector-search/vector-search-page.ts
+++ b/tests/playwright/pageObjects/pages/vector-search/vector-search-page.ts
@@ -36,6 +36,7 @@ export class VectorSearchPage extends BasePage {
     public readonly editorContainer: Locator
     public readonly editorViewLine: Locator
     public readonly editorTextBox: Locator
+    public readonly editorSuggesstionPopup: Locator
     public readonly editorSubmitButton: Locator
     public readonly editorClearButton: Locator
 
@@ -127,6 +128,9 @@ export class VectorSearchPage extends BasePage {
         this.editorTextBox = this.editorContainer.getByRole('textbox', {
             name: 'Editor content;Press Alt+F1',
         })
+        this.editorSuggesstionPopup = page.locator(
+            '.monaco-editor .suggest-widget.visible',
+        )
         this.editorSubmitButton = page.getByTestId('btn-submit')
         this.editorClearButton = page.getByTestId('btn-clear')
 

--- a/tests/playwright/tests/vector-search/query.spec.ts
+++ b/tests/playwright/tests/vector-search/query.spec.ts
@@ -46,7 +46,13 @@ test.describe('Vector Search - Query', () => {
         // Click on editor, fill in a query and submit it
         await searchPage.editorViewLine.click()
         await searchPage.editorTextBox.fill('FT._LIST')
+        await searchPage.waitForLocatorVisible(
+            searchPage.editorSuggesstionPopup,
+        )
         await searchPage.editorSubmitButton.click()
+        await searchPage.waitForLocatorNotVisible(
+            searchPage.editorSuggesstionPopup,
+        )
 
         // Verify the query results
         await searchPage.waitForLocatorVisible(searchPage.commandsResults)

--- a/tests/playwright/tests/vector-search/saved-queries.spec.ts
+++ b/tests/playwright/tests/vector-search/saved-queries.spec.ts
@@ -121,5 +121,10 @@ test.describe('Vector Search - Saved Queries', () => {
         await expect(searchPage.editorTextBox).toHaveValue(
             'FT.SEARCH idx:bikes_vss "@brand:Nord" SORTBY price ASC', // TODO: Replace this with actual query, once we reimplement them soon
         )
+
+        // Verify that the suggestion popup is not visible
+        await searchPage.waitForLocatorNotVisible(
+            searchPage.editorSuggesstionPopup,
+        )
     })
 })


### PR DESCRIPTION
# Description

Disable the "suggestions tooltip" in the code editor on the **Vector Search** page when inserting a saved query, because it was hiding the **Run** button (_on a specific screen size_).

| Before | After |
| - | - |
<img width="1449" height="797" alt="image" src="https://github.com/user-attachments/assets/c67f0047-40d6-49ee-8bf9-9da22b64b6ab" />|<img width="1446" height="799" alt="image" src="https://github.com/user-attachments/assets/fb542466-6cd3-49a3-a95e-c422981d7e7f" />

# How it was tested

1. Open the **Databases** page and connect to an existing database (or establish a connection with a new instance)
2. Go to the **Search** tab from the main navbar

_Note: Make sure to create a new index via the preset sample datasets, following the Vector Search onboarding wizard._

3. Open the **Saved Queries** panel from the top right corner
4. Click on the "**Insert**" button of any of the provided queries

At this point, the query should be added automatically to the code editor, but the "Run" button should remain visible.

https://github.com/user-attachments/assets/ee63c13e-7078-4f32-b518-0940d6ecf3e4

