### PR TITLE
RI-7549 Fix the layout of the FT.INFO command output in the Workbench results

### DIFF
--- a/redisinsight/ui/src/packages/redisearch/src/components/TableInfoResult/TableInfoResult.tsx
+++ b/redisinsight/ui/src/packages/redisearch/src/components/TableInfoResult/TableInfoResult.tsx
@@ -6,9 +6,10 @@ import { Table, ColumnDefinition } from 'uiSrc/components/base/layout/table'
 
 import { RiIcon } from 'uiSrc/components/base/icons/RiIcon'
 import { ColorText, Text } from '../../../../../components/base/text'
-import { LoadingContent } from '../../../../../components/base/layout'
+import { LoadingContent, Spacer } from '../../../../../components/base/layout'
 import GroupBadge from '../GroupBadge'
 import { InfoAttributesBoolean } from '../../constants'
+import { FlexGroup } from 'uiSrc/components/base/layout/flex'
 
 export interface Props {
   query: string
@@ -68,7 +69,7 @@ const TableInfoResult = React.memo((props: Props) => {
     <div>
       {result ? (
         <>
-          <Text className="row" size="s" color="subdued">
+          <Text className="row" size="s">
             Indexing
             <GroupBadge
               type={result?.index_definition?.key_type?.toLowerCase()}
@@ -79,7 +80,7 @@ const TableInfoResult = React.memo((props: Props) => {
               ?.map((prefix: any) => `"${prefix}"`)
               .join(',')}
           </Text>
-          <Text className="row" size="s" color="subdued">
+          <Text className="row" size="s">
             Options:{' '}
             {result?.index_options?.length ? (
               <ColorText style={{ color: 'var(--euiColorFullShade)' }}>
@@ -98,7 +99,7 @@ const TableInfoResult = React.memo((props: Props) => {
   const Footer = () => (
     <div>
       {result ? (
-        <Text className="row" size="s" color="subdued">
+        <Text className="row" size="s">
           {`Number of docs: ${result?.num_docs || '0'} (max ${result?.max_doc_id || '0'}) | `}
           {`Number of records: ${result?.num_records || '0'} | `}
           {`Number of terms: ${result?.num_terms || '0'}`}
@@ -116,11 +117,16 @@ const TableInfoResult = React.memo((props: Props) => {
   return (
     <div className="container">
       {isDataArr && (
-        <div className="content" data-testid={`query-table-result-${query}`}>
+        <FlexGroup
+          direction="column"
+          gap="m"
+          className="content"
+          data-testid={`query-table-result-${query}`}
+        >
           {Header()}
           <Table columns={columns} data={items ?? []} />
           {Footer()}
-        </div>
+        </FlexGroup>
       )}
       {isDataEl && <div className={cx('resultEl')}>{result}</div>}
       {!isDataArr && !isDataEl && (

--- a/redisinsight/ui/src/packages/redisearch/src/styles/styles.scss
+++ b/redisinsight/ui/src/packages/redisearch/src/styles/styles.scss
@@ -106,6 +106,7 @@ html {
 }
 
 .badge {
+  display: inline-flex !important;
   position: relative;
   font: normal normal normal 12px/15px;
   margin: 0 5px;


### PR DESCRIPTION
# Description

Fix the layout of the `FT.INFO` command output in the results panel on the **Workbench** page
- update the layout to not break into multiple lines
- update the colors, give up on the blue color
- added more spacing between the elements

| Before | After |
| - | - |
<img alt="image" src="https://github.com/user-attachments/assets/779fb6fe-8732-4bdf-9ea4-f318dbcd7e40" />|<img alt="Screenshot 2025-09-25 at 9 37 03" src="https://github.com/user-attachments/assets/fe513a30-de98-44c2-b6ad-fd06003018c1" />

# How it was tested

1. Open the **Databases** page and connect to an existing database (or establish a connection with a new instance)
2. Go to the **Workbench** tab from the main navbar
3. Type in the `FT.INFO` command in the code editor and click on the "**Run**" button

Observe the result in the list below.

| Old | Before | After |
| - | - | - |
<img width="1079" height="441" alt="Screenshot 2025-09-25 at 11 27 42" src="https://github.com/user-attachments/assets/6ce7f026-3ed7-47c8-9b36-98a944763a4a" />|<img width="1106" height="485" alt="Screenshot 2025-09-25 at 11 27 00" src="https://github.com/user-attachments/assets/94f76a40-d2b6-45aa-a0a0-bf37bfb32cd6" />|<img width="1097" height="472" alt="Screenshot 2025-09-25 at 9 37 03" src="https://github.com/user-attachments/assets/2875b26b-4797-4b56-9de4-ed94f8a64129" />
<img width="1079" height="441" alt="Screenshot 2025-09-25 at 11 27 33" src="https://github.com/user-attachments/assets/e8c94b4f-ec4e-4806-bc73-c4d11aca007e" />|<img width="1106" height="485" alt="Screenshot 2025-09-25 at 11 27 17" src="https://github.com/user-attachments/assets/db96a2aa-7e86-4bd9-84a4-7b6a61420b73" />|<img width="1097" height="472" alt="Screenshot 2025-09-25 at 9 37 14" src="https://github.com/user-attachments/assets/51cb1ae2-0f71-40c9-baf3-a17894e00e27" />


