### PR TITLE
RI-7517 Hide custom indexes from "Saved Queries" list

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
@@ -7,6 +7,7 @@ import { render, screen, fireEvent } from 'uiSrc/utils/test-utils'
 import { SavedQueriesScreen } from './SavedQueriesScreen'
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { useRedisearchListData } from '../useRedisearchListData'
+import { PresetDataType } from '../create-index/types'
 
 // Mock the telemetry sender once for this spec file
 jest.mock('uiSrc/telemetry', () => ({
@@ -39,7 +40,7 @@ describe('SavedQueriesScreen', () => {
     ;(useRedisearchListData as jest.Mock).mockReturnValue({
       loading: false,
       data: [],
-      stringData: ['idx:bikes_vss', 'idx:movies_vss'],
+      stringData: [PresetDataType.BIKES, PresetDataType.MOVIES],
     })
   })
 
@@ -71,15 +72,15 @@ describe('SavedQueriesScreen', () => {
 
   it('should select the first index by default', () => {
     renderComponent()
-    expect(screen.queryByText('idx:bikes_vss')).toBeInTheDocument()
+    expect(screen.queryByText(PresetDataType.BIKES)).toBeInTheDocument()
   })
 
   it('should select the default index if provided', () => {
-    renderComponent('idx:movies_vss')
+    renderComponent(PresetDataType.MOVIES)
 
     // The Select component isn't a native <select>, so assert by displayed text
-    expect(screen.queryByText('idx:bikes_vss')).not.toBeInTheDocument()
-    expect(screen.queryByText('idx:movies_vss')).toBeInTheDocument()
+    expect(screen.queryByText(PresetDataType.BIKES)).not.toBeInTheDocument()
+    expect(screen.queryByText(PresetDataType.MOVIES)).toBeInTheDocument()
   })
 
   it('should not render queries if the there is no index with preset data', () => {
@@ -92,22 +93,22 @@ describe('SavedQueriesScreen', () => {
     renderComponent()
 
     expect(screen.queryByText('idx:unknown_index')).not.toBeInTheDocument()
-    expect(screen.queryByText('idx:bikes_vss')).not.toBeInTheDocument()
-    expect(screen.queryByText('idx:movies_vss')).not.toBeInTheDocument()
+    expect(screen.queryByText(PresetDataType.BIKES)).not.toBeInTheDocument()
+    expect(screen.queryByText(PresetDataType.MOVIES)).not.toBeInTheDocument()
   })
 
   it('should render only saved queries related to preset data', () => {
     ;(useRedisearchListData as jest.Mock).mockReturnValue({
       loading: false,
       data: [],
-      stringData: ['idx:unknown_index', 'idx:bikes_vss'],
+      stringData: ['idx:unknown_index', PresetDataType.BIKES],
     })
 
     renderComponent()
 
     expect(screen.queryByText('idx:unknown_index')).not.toBeInTheDocument()
-    expect(screen.queryByText('idx:movies_vss')).not.toBeInTheDocument()
-    expect(screen.queryByText('idx:bikes_vss')).toBeInTheDocument()
+    expect(screen.queryByText(PresetDataType.MOVIES)).not.toBeInTheDocument()
+    expect(screen.queryByText(PresetDataType.BIKES)).toBeInTheDocument()
   })
 
   it('should call onClose when close button is clicked', () => {

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
@@ -39,7 +39,7 @@ describe('SavedQueriesScreen', () => {
     ;(useRedisearchListData as jest.Mock).mockReturnValue({
       loading: false,
       data: [],
-      stringData: ['idx:bikes_vss', 'idx:restaurants_vss'],
+      stringData: ['idx:bikes_vss', 'idx:movies_vss'],
     })
   })
 
@@ -75,10 +75,39 @@ describe('SavedQueriesScreen', () => {
   })
 
   it('should select the default index if provided', () => {
-    renderComponent('idx:restaurants_vss')
+    renderComponent('idx:movies_vss')
+
     // The Select component isn't a native <select>, so assert by displayed text
     expect(screen.queryByText('idx:bikes_vss')).not.toBeInTheDocument()
-    expect(screen.queryByText('idx:restaurants_vss')).toBeInTheDocument()
+    expect(screen.queryByText('idx:movies_vss')).toBeInTheDocument()
+  })
+
+  it('should not render queries if the there is no index with preset data', () => {
+    ;(useRedisearchListData as jest.Mock).mockReturnValue({
+      loading: false,
+      data: [],
+      stringData: ['idx:unknown_index'],
+    })
+
+    renderComponent()
+
+    expect(screen.queryByText('idx:unknown_index')).not.toBeInTheDocument()
+    expect(screen.queryByText('idx:bikes_vss')).not.toBeInTheDocument()
+    expect(screen.queryByText('idx:movies_vss')).not.toBeInTheDocument()
+  })
+
+  it('should render only saved queries related to preset data', () => {
+    ;(useRedisearchListData as jest.Mock).mockReturnValue({
+      loading: false,
+      data: [],
+      stringData: ['idx:unknown_index', 'idx:bikes_vss'],
+    })
+
+    renderComponent()
+
+    expect(screen.queryByText('idx:unknown_index')).not.toBeInTheDocument()
+    expect(screen.queryByText('idx:movies_vss')).not.toBeInTheDocument()
+    expect(screen.queryByText('idx:bikes_vss')).toBeInTheDocument()
   })
 
   it('should call onClose when close button is clicked', () => {

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
@@ -107,16 +107,18 @@ export const SavedQueriesScreen = ({
   const { stringData, loading } = useRedisearchListData()
   const savedIndexes = useMemo(
     () =>
-      stringData.map(
-        (index) =>
-          ({
-            value: index,
-            // Hardcoded values for the preset index, else empty arrays:
-            tags: mockSavedIndexes.find((i) => i.value === index)?.tags || [],
-            queries:
-              mockSavedIndexes.find((i) => i.value === index)?.queries || [],
-          }) as SavedIndex,
-      ),
+      stringData
+        .filter((index) => mockSavedIndexes.some((i) => i.value === index))
+        .map(
+          (index) =>
+            ({
+              value: index,
+              // Hardcoded values for the preset index, else empty arrays:
+              tags: mockSavedIndexes.find((i) => i.value === index)?.tags || [],
+              queries:
+                mockSavedIndexes.find((i) => i.value === index)?.queries || [],
+            }) as SavedIndex,
+        ),
     [stringData],
   )
   const selectedIndexItem = savedIndexes.find(


### PR DESCRIPTION
# Description

Stop showing custom indexes in the list with the "**Saved Queries**" on the new **Search** page. Only preset sample data indexes come with such queries, so we should show only them in the list.

_Note: Previously, we were showing the index, but with a blank space, leaving the users without any control over it._

<img width="1007" height="765" alt="image" src="https://github.com/user-attachments/assets/87b37f50-b109-4bce-8bcc-e5dfe909d72f" />

# How it was tested

## When only custom indexes are available

1. Open the **Databases** page and connect to an existing database (or establish a connection with a new instance)
2. Go to the **Browser** page and import sample data

_Note: If the database is not empty, you can run `flushdb` in the CLI, to make sure you can import sample data_

3. Go to the **Search** tab from the main navbar
4. Open the **Saved Queries** panel from the top right corner

You shouldn't see any indexes in the list, although you have such in the **Manage Indexes** panel. They're not related to preset sample data for the Vector Search onboarding feature, so they don't have any saved queries.

<img width="2292" height="1766" alt="image" src="https://github.com/user-attachments/assets/9b285d66-79a7-483a-8b26-c4289a16efb1" />

## When sample preset indexes with saved queries are available

5. Make sure to create a new index via the preset sample datasets, following the Vector Search onboarding wizard.

Now, you should be able to see only these indexes in the **Saved Queries** panel.

<img width="2282" height="1144" alt="image" src="https://github.com/user-attachments/assets/d8adf478-6e1f-4b8c-922f-1198de1afd84" />
