### PR TITLE
RI-7529: Fix Time Series screen text for redirecting to Workbench

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/text-details-wrapper/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/text-details-wrapper/styles.module.scss
@@ -4,7 +4,6 @@
   padding: 16px 40px 30px;
 
   text-align: center;
-  color: #FFFFFFAD;
 
   h4 {
     font-size: 18px;


### PR DESCRIPTION
### Fix Time Series screen text for redirecting to Workbench
When there is Time Series key, the details are not displayed on the right like for most of the other key types, but there is a redirecting screen to workbench. The text in that screen has broken styles.
| Before | After |
| --- | --- |
| <img width="1214" height="688" alt="image" src="https://github.com/user-attachments/assets/0d52663e-dc7a-4ec9-951c-06059c5db1dd" /> | <img width="1214" height="688" alt="image" src="https://github.com/user-attachments/assets/36d48c48-d193-4b1d-8adf-dc4f137fdd94" /> | 
| <img width="1214" height="688" alt="image" src="https://github.com/user-attachments/assets/9b18a9d5-da8f-4818-99d0-a102f2cbc343" /> | <img width="1214" height="688" alt="image" src="https://github.com/user-attachments/assets/2208a5bd-8957-4338-8306-1cbaa03c5b88" /> |