### PR TITLE
[RI-7552] pressing ESC on a keyboard should close popups and unfocus from active input

### DIFF
--- a/redisinsight/ui/src/components/base/popover/RiPopover.tsx
+++ b/redisinsight/ui/src/components/base/popover/RiPopover.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Popover } from '@redis-ui/components'
 
+import * as keys from 'uiSrc/constants/keys'
 import { RiPopoverProps } from './types'
 import { anchorPositionMap, panelPaddingSizeMap } from './config'
 
@@ -21,6 +22,12 @@ export const RiPopover = ({
     {...props}
     open={isOpen}
     onClickOutside={closePopover}
+    onKeyDown={(event) => {
+      // Close on escape press
+      if (event.key === keys.ESCAPE) {
+        closePopover?.(event as any)
+      }
+    }}
     content={children}
     // Props passed to the children wrapper:
     className={panelClassName}

--- a/redisinsight/ui/src/components/table-column-search-trigger/TableColumnSearchTrigger.spec.tsx
+++ b/redisinsight/ui/src/components/table-column-search-trigger/TableColumnSearchTrigger.spec.tsx
@@ -64,4 +64,22 @@ describe('TableColumnSearchTrigger', () => {
     fireEvent.blur(searchInput)
     expect(handleOpenState).not.toHaveBeenCalled()
   })
+
+  it('should call "handleOpenState" with false when ESCAPE key is pressed', () => {
+    const handleOpenState = jest.fn()
+
+    render(
+      <TableColumnSearchTrigger
+        {...instance(mockedProps)}
+        isOpen
+        handleOpenState={handleOpenState}
+      />,
+    )
+
+    const searchInput = screen.getByTestId('search')
+    expect(searchInput).toBeInTheDocument()
+
+    fireEvent.keyDown(searchInput, { key: 'Escape' })
+    expect(handleOpenState).toHaveBeenCalledWith(false)
+  })
 })

--- a/redisinsight/ui/src/components/table-column-search-trigger/TableColumnSearchTrigger.tsx
+++ b/redisinsight/ui/src/components/table-column-search-trigger/TableColumnSearchTrigger.tsx
@@ -55,6 +55,8 @@ const TableColumnSearchTrigger = (props: Props) => {
   const onKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === keys.ENTER) {
       handleApply(value)
+    } else if (event.key === keys.ESCAPE) {
+      handleOpenState(false)
     }
   }
 


### PR DESCRIPTION
## Description

### adds close on ESCAPE press handler for RiPopover

https://github.com/user-attachments/assets/efbc9902-7669-4e61-b653-be0870a37373

### adds unfocus input on ESCAPE press for search inputs in virtual table (e.g. key details column search)

https://github.com/user-attachments/assets/aaa74adf-d587-4306-8dca-f244a3dbe06b


