### PR TITLE
RI-7560: fix bottom group panel movement when expand / collapse

### DIFF
--- a/redisinsight/ui/src/pages/browser/BrowserPage.tsx
+++ b/redisinsight/ui/src/pages/browser/BrowserPage.tsx
@@ -5,6 +5,8 @@ import cx from 'classnames'
 
 import { isNumber } from 'lodash'
 import { useTheme } from '@redis-ui/styles'
+import styled from 'styled-components'
+
 import {
   formatLongName,
   getDbIndex,
@@ -65,6 +67,11 @@ const widthExplorePanel = 460
 
 export const firstPanelId = 'keys'
 export const secondPanelId = 'keyDetails'
+
+const BorderedResizablePanel = styled(ResizablePanel)`
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral500};
+`
 
 const isOneSideMode = (isInsightsOpen: boolean) =>
   globalThis.innerWidth <
@@ -324,7 +331,7 @@ const BrowserPage = () => {
           direction="horizontal"
           onLayout={onPanelWidthChange}
         >
-          <ResizablePanel
+          <BorderedResizablePanel
             defaultSize={sizes && sizes[0] ? sizes[0] : 50}
             minSize={45}
             id={firstPanelId}
@@ -333,10 +340,6 @@ const BrowserPage = () => {
                 arePanelsCollapsed ||
                 (isBrowserFullScreen && !isRightPanelOpen),
             })}
-            style={{
-              border: `1px solid ${theme.semantic.color.border.neutral500}`,
-              borderRadius: `8px`,
-            }}
           >
             <BrowserLeftPanel
               selectedKey={selectedKey}
@@ -344,11 +347,11 @@ const BrowserPage = () => {
               removeSelectedKey={handleRemoveSelectedKey}
               handleAddKeyPanel={handleAddKeyPanel}
             />
-          </ResizablePanel>
+          </BorderedResizablePanel>
           {!arePanelsCollapsed && !isBrowserFullScreen && (
             <ResizablePanelHandle />
           )}
-          <ResizablePanel
+          <BorderedResizablePanel
             defaultSize={sizes && sizes[1] ? sizes[1] : 50}
             minSize={45}
             id={secondPanelId}
@@ -359,10 +362,6 @@ const BrowserPage = () => {
               [styles.keyDetails]:
                 arePanelsCollapsed || (isRightPanelOpen && isBrowserFullScreen),
             })}
-            style={{
-              border: `1px solid ${theme.semantic.color.border.neutral500}`,
-              borderRadius: `8px`,
-            }}
           >
             <BrowserRightPanel
               arePanelsCollapsed={arePanelsCollapsed}
@@ -375,7 +374,7 @@ const BrowserPage = () => {
               handleBulkActionsPanel={handleBulkActionsPanel}
               closeRightPanels={closeRightPanels}
             />
-          </ResizablePanel>
+          </BorderedResizablePanel>
         </ResizableContainer>
       </div>
       <OnboardingStartPopover />

--- a/redisinsight/ui/src/pages/browser/BrowserPage.tsx
+++ b/redisinsight/ui/src/pages/browser/BrowserPage.tsx
@@ -361,7 +361,7 @@ const BrowserPage = () => {
             })}
             style={{
               border: `1px solid ${theme.semantic.color.border.neutral500}`,
-              borderRadius: `5px`,
+              borderRadius: `8px`,
             }}
           >
             <BrowserRightPanel

--- a/redisinsight/ui/src/templates/instance-page-template/InstancePageTemplate.tsx
+++ b/redisinsight/ui/src/templates/instance-page-template/InstancePageTemplate.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
+import styled from 'styled-components'
 
 import InstanceHeader from 'uiSrc/components/instance-header'
 import { ExplorePanelTemplate } from 'uiSrc/templates'
@@ -27,23 +28,16 @@ export interface Props {
   children: React.ReactNode
 }
 
+const ButtonGroupResizablePanel = styled(ResizablePanel)`
+  flex-basis: 27px !important;
+`
+
 export const getDefaultSizes = () => {
   const storedSizes = localStorageService.get(
     BrowserStorageItem.cliResizableContainer,
   )
 
   return storedSizes && Array.isArray(storedSizes) ? storedSizes : [60, 40]
-}
-
-export const calculateMainPanelInitialSize = () => {
-  const total = window.innerHeight
-  const remaining = total - 26
-  return Math.floor((remaining / total) * 100)
-}
-
-export const calculateBottomGroupPanelInitialSize = () => {
-  const total = window.innerHeight
-  return Math.ceil((26 / total) * 100)
 }
 
 const roundUpSizes = (sizes: number[]) => [
@@ -57,9 +51,6 @@ const InstancePageTemplate = (props: Props) => {
 
   const { isShowCli, isShowHelper } = useSelector(cliSettingsSelector)
   const { isShowMonitor } = useSelector(monitorSelector)
-
-  const sizeMain: number = calculateMainPanelInitialSize()
-  const sizeBottomCollapsed: number = calculateBottomGroupPanelInitialSize()
 
   const ref = useRef<ImperativePanelGroupHandle>(null)
 
@@ -92,7 +83,7 @@ const InstancePageTemplate = (props: Props) => {
     if (isShowBottomGroup) {
       ref.current?.setLayout(roundUpSizes(sizes))
     } else {
-      ref.current?.setLayout([sizeMain, sizeBottomCollapsed])
+      ref.current?.setLayout([100, 0])
     }
   }, [isShowBottomGroup])
 
@@ -111,7 +102,7 @@ const InstancePageTemplate = (props: Props) => {
         <ResizablePanel
           id={firstPanelId}
           minSize={7}
-          defaultSize={isShowBottomGroup ? sizes[0] : sizeMain}
+          defaultSize={isShowBottomGroup ? sizes[0] : 100}
           data-testid={firstPanelId}
         >
           <AppNavigationActionsProvider
@@ -129,15 +120,15 @@ const InstancePageTemplate = (props: Props) => {
           data-testid="resize-btn-browser-cli"
           style={{ display: isShowBottomGroup ? 'inherit' : 'none' }}
         />
-        <Spacer size="m" />
-        <ResizablePanel
+        {!isShowBottomGroup && <Spacer size="l" />}
+        <ButtonGroupResizablePanel
           id={secondPanelId}
-          defaultSize={isShowBottomGroup ? sizes[1] : sizeBottomCollapsed}
+          defaultSize={isShowBottomGroup ? sizes[1] : 0}
           minSize={isShowBottomGroup ? 20 : 0}
           data-testid={secondPanelId}
         >
           <BottomGroupComponents />
-        </ResizablePanel>
+        </ButtonGroupResizablePanel>
       </ResizableContainer>
     </>
   )


### PR DESCRIPTION
### Apply changes to the panels on the Browser Page to avoid not user friendly behavior:
1. Fix the moving on the bottom group component (containing the CLI / Command Helper / Profiler badges)

**Before:**

https://github.com/user-attachments/assets/acd3838b-973e-4091-9912-86daa1da80d3

**After:**

https://github.com/user-attachments/assets/4933f9a0-204b-4d51-932a-33c8ae4eb452

2. Change the border radius of the key details panel to match the border radius on the key list panel

| Before | After |
| --- | --- |
| <img width="526" height="342" alt="image" src="https://github.com/user-attachments/assets/92cce7b9-ee10-45da-8be1-1814f9de8bd2" /> | <img width="610" height="494" alt="image" src="https://github.com/user-attachments/assets/52332791-89a8-4bb1-86e3-77e2684cda9d" /> |