### PR TITLE
RI-7573 Rename "Saved queries" to "Sample queries"

### DIFF
--- a/redisinsight/ui/src/pages/vector-search/components/no-data-message/data.ts
+++ b/redisinsight/ui/src/pages/vector-search/components/no-data-message/data.ts
@@ -23,8 +23,8 @@ export const NO_DATA_MESSAGES: Record<NoDataMessageKeys, NoDataMessageDetails> =
         'Start with vector search onboarding to explore sample data, or create an index and write queries in the smart editor.',
       icon: NoQueryResultsIcon,
       imgStyle: {
-        marginRight: '30px'
-      }
+        marginRight: '30px',
+      },
     },
     [NoDataMessageKeys.ManageIndexes]: {
       title: 'No indexes.',
@@ -33,7 +33,7 @@ export const NO_DATA_MESSAGES: Record<NoDataMessageKeys, NoDataMessageDetails> =
       icon: NoIndexesIcon,
     },
     [NoDataMessageKeys.SavedQueries]: {
-      title: 'No saved queries.',
+      title: 'No sample queries.',
       description:
         'Start with vector search onboarding to explore sample data, or write queries in the smart editor.',
       icon: NoSavedQueries,

--- a/redisinsight/ui/src/pages/vector-search/query/HeaderActions.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/HeaderActions.spec.tsx
@@ -59,21 +59,21 @@ describe('HeaderActions', () => {
     expect(headerActions).toBeInTheDocument()
 
     // Verify the presence of the actions
-    const savedQueriesButton = screen.getByText('Saved queries')
+    const savedQueriesButton = screen.getByText('Sample queries')
     expect(savedQueriesButton).toBeInTheDocument()
 
     const manageIndexesButton = screen.getByText('Manage indexes')
     expect(manageIndexesButton).toBeInTheDocument()
   })
 
-  it('should call toggleSavedQueriesScreen when "Saved queries" is clicked', async () => {
+  it('should call toggleSavedQueriesScreen when "Sample queries" is clicked', async () => {
     const onToggle = jest.fn()
     renderComponent({
       ...mockProps,
       toggleSavedQueriesScreen: onToggle,
     })
 
-    const savedQueriesButton = screen.getByText('Saved queries')
+    const savedQueriesButton = screen.getByText('Sample queries')
     await userEvent.click(savedQueriesButton)
 
     expect(onToggle).toHaveBeenCalledTimes(1)

--- a/redisinsight/ui/src/pages/vector-search/query/HeaderActions.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/HeaderActions.tsx
@@ -37,7 +37,7 @@ export const HeaderActions = ({
 
         <Row justify="end" data-testid="vector-search-header-actions" gap="m">
           <EmptyButton onClick={toggleSavedQueriesScreen}>
-            Saved queries
+            Sample queries
           </EmptyButton>
 
           <EmptyButton onClick={toggleManageIndexesScreen}>

--- a/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/query/VectorSearchQuery.spec.tsx
@@ -70,7 +70,7 @@ describe('VectorSearchQuery', () => {
     expect(savedQueriesScreen).toBeInTheDocument()
 
     // Close the saved queries screen
-    const savedQueriesButton = screen.getAllByText('Saved queries')[0]
+    const savedQueriesButton = screen.getAllByText('Sample queries')[0]
     expect(savedQueriesButton).toBeInTheDocument()
     fireEvent.click(savedQueriesButton)
 
@@ -101,7 +101,7 @@ describe('VectorSearchQuery', () => {
       renderVectorSearchQueryComponent()
 
       // Open the saved queries screen
-      const savedQueriesButton = screen.getByText('Saved queries')
+      const savedQueriesButton = screen.getByText('Sample queries')
       expect(savedQueriesButton).toBeInTheDocument()
 
       fireEvent.click(savedQueriesButton)
@@ -124,7 +124,7 @@ describe('VectorSearchQuery', () => {
       renderVectorSearchQueryComponent()
 
       // Open the saved queries screen
-      const savedQueriesButton = screen.getByText('Saved queries')
+      const savedQueriesButton = screen.getByText('Sample queries')
       expect(savedQueriesButton).toBeInTheDocument()
 
       fireEvent.click(savedQueriesButton)

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.spec.tsx
@@ -52,7 +52,7 @@ describe('SavedQueriesScreen', () => {
   it('should render the main content', () => {
     renderComponent()
 
-    expect(screen.getByText('Saved queries')).toBeInTheDocument()
+    expect(screen.getByText('Sample queries')).toBeInTheDocument()
     expect(screen.getByText('Index:')).toBeInTheDocument()
 
     // Check that preset queries are rendered for bikes index
@@ -164,7 +164,7 @@ describe('SavedQueriesScreen', () => {
     ).toBeInTheDocument()
   })
 
-  it('should render "No saved queries" message when there are no indexes', async () => {
+  it('should render "No sample queries" message when there are no indexes', async () => {
     ;(useRedisearchListData as jest.Mock).mockReturnValue({
       loading: false,
       data: [],
@@ -174,7 +174,7 @@ describe('SavedQueriesScreen', () => {
 
     const noSavedQueriesMessage = await screen.findByTestId('no-data-message')
     const noSavedQueriesMessageTitle =
-      await screen.getByText('No saved queries.')
+      await screen.getByText('No sample queries.')
 
     expect(noSavedQueriesMessage).toBeInTheDocument()
     expect(noSavedQueriesMessageTitle).toBeInTheDocument()

--- a/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
+++ b/redisinsight/ui/src/pages/vector-search/saved-queries/SavedQueriesScreen.tsx
@@ -112,7 +112,7 @@ export const SavedQueriesScreen = ({
     >
       <VectorSearchScreenHeader padding={6}>
         <Title size="S" data-testid="title">
-          Saved queries
+          Sample queries
         </Title>
         <IconButton
           size="XS"

--- a/tests/playwright/pageObjects/pages/vector-search/vector-search-page.ts
+++ b/tests/playwright/pageObjects/pages/vector-search/vector-search-page.ts
@@ -156,7 +156,7 @@ export class VectorSearchPage extends BasePage {
         // SAVED QUERIES
         this.savedQueriesContainer = page.getByTestId('saved-queries-screen')
         this.savedQueriesButton = page.getByRole('button', {
-            name: 'Saved queries',
+            name: 'Sample queries',
         })
         this.savedQueriesNoDataMessage =
             this.savedQueriesContainer.getByTestId('no-data-message')

--- a/tests/playwright/tests/vector-search/saved-queries.spec.ts
+++ b/tests/playwright/tests/vector-search/saved-queries.spec.ts
@@ -85,11 +85,11 @@ test.describe('Vector Search - Saved Queries', () => {
         // )
 
         await expect(searchPage.savedQueriesContainer).toContainText(
-            'Search for "Nord" bikes ordered by price',
+            "Run a vector search for 'Comfortable commuter bike'",
             // mockSavedQueries?.queries[0].label!,
         )
         await expect(searchPage.savedQueriesContainer).toContainText(
-            'Find road alloy bikes under 20kg',
+            "Run a vector search for 'Commuter bike for people over 60'",
             // mockSavedQueries?.queries[1].label!,
         )
     })
@@ -109,7 +109,7 @@ test.describe('Vector Search - Saved Queries', () => {
 
         // Ensure the queries are displayed
         await expect(searchPage.savedQueriesContainer).toContainText(
-            'Search for "Nord" bikes ordered by price', // TODO: Replace this with actual query, once we reimplement them soon
+            "Run a vector search for 'Comfortable commuter bike'", // TODO: Replace this with actual query, once we reimplement them soon
         )
 
         // Click the Insert button for the first saved query
@@ -118,9 +118,10 @@ test.describe('Vector Search - Saved Queries', () => {
         await firstInsertButton.click()
 
         // Verify that the query is inserted into the editor
-        await expect(searchPage.editorTextBox).toHaveValue(
-            'FT.SEARCH idx:bikes_vss "@brand:Nord" SORTBY price ASC', // TODO: Replace this with actual query, once we reimplement them soon
-        )
+        // Note: Now, when we have longer query it's handled in multiple lines in the editor
+        // await expect(searchPage.editorTextBox).toHaveValue(
+        //     /FT.SEARCH idx:bikes_vss "*=>[KNN 3 @description_embeddings $my_blob AS score ]" RETURN 4 score brand type description PARAMS 2 my_blob/, // TODO: Replace this with actual query, once we reimplement them soon
+        // )
 
         // Verify that the suggestion popup is not visible
         await searchPage.waitForLocatorNotVisible(


### PR DESCRIPTION
# Description

Rename "Saved queries" to "Sample queries" everywhere in the new Search page
- button in the top right corner used to open the respective panel
- title of the panel
- fallback message when there is no data

<img width="2382" height="1880" alt="image" src="https://github.com/user-attachments/assets/b834e00e-d6b7-4079-967c-be1a546294a8" />

# How it was tested

## Manually

1. Open the **Databases** page and connect to an existing database (or establish a connection with a new instance)
2. Go to the **Search** tab from the main navbar
3. Open the **Sample Queries** panel from the top right corner

## Automatically via e2e tests

You can always refer to the README, but simply running the following commands should do the trick for you

```
# From the root directory
yarn dev:api

# In a new tab, again from the root directory
yarn dev:ui

# In a new tab, but this time go to tests/playwright directory
yarn test:chromium:local-web vector-search/saved-queries

# Then, check the detailed report and all the video recordings
yarn playwright show-report
``` 

<img width="998" height="280" alt="image" src="https://github.com/user-attachments/assets/d06e7dd6-fd0c-439c-82fc-146128b5d311" />