### PR TITLE
RI-7520: fix icons spacing for multi search input

### DIFF
--- a/redisinsight/ui/src/components/multi-search/MultiSearch.tsx
+++ b/redisinsight/ui/src/components/multi-search/MultiSearch.tsx
@@ -191,8 +191,7 @@ const MultiSearch = (props: Props) => {
             placeholder={placeholder}
             value={value}
             onKeyDown={handleKeyDown}
-            onChange={onChange
-            }
+            onChange={onChange}
             onFocus={() => setIsInputFocus(true)}
             onBlur={() => setIsInputFocus(false)}
             ref={inputRef}
@@ -292,7 +291,6 @@ const MultiSearch = (props: Props) => {
                   setShowAutoSuggestions((v) => !v)
                   inputRef.current?.focus()
                 }}
-                className={styles.historyIcon}
                 data-testid="show-suggestions-btn"
               />
             </RiTooltip>

--- a/redisinsight/ui/src/components/multi-search/styles.module.scss
+++ b/redisinsight/ui/src/components/multi-search/styles.module.scss
@@ -9,6 +9,7 @@
   .multiSearch {
     position: relative;
     flex: 1;
+    gap: 8px;
     height: 100%;
     display: flex;
     align-items: center;
@@ -103,10 +104,6 @@
       visibility: hidden;
       pointer-events: none;
     }
-  }
-
-  .historyIcon {
-    margin-inline: 8px;
   }
 
   .clearHistory {


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="93" height="71" alt="Screenshot 2025-10-01 at 10 43 48" src="https://github.com/user-attachments/assets/68b05d51-eb86-4c03-b11a-9a7398bac0f8" /> | <img width="102" height="69" alt="Screenshot 2025-10-01 at 10 41 46" src="https://github.com/user-attachments/assets/60fc7c0f-047a-4c7c-882f-a7b0681ca908" /> |
| <img width="87" height="58" alt="Screenshot 2025-10-01 at 10 43 56" src="https://github.com/user-attachments/assets/9bba9569-7752-47cc-87c9-99ebba653aa1" /> | <img width="93" height="56" alt="Screenshot 2025-10-01 at 10 41 32" src="https://github.com/user-attachments/assets/197ab232-1ec0-4153-b115-8d0b6c8d1484" /> |

