### PR TITLE
RI-7537: Update dark theme table hover color

### DIFF
--- a/redisinsight/ui/src/styles/themes/dark_theme/_theme_color.scss
+++ b/redisinsight/ui/src/styles/themes/dark_theme/_theme_color.scss
@@ -83,7 +83,7 @@ $tableDarkestBorderColor: #2c2c2c;
 
 $browserTableRowEven: #171717;
 $browserViewTypePassive: #171717;
-$browserComponentActive: #292f47;
+$browserComponentActive: #002f47;
 $browserTreeNodeOpen: #2b2f40;
 
 $inputTextColor: #dfe5ef;


### PR DESCRIPTION
# Preview

https://github.com/user-attachments/assets/ea46d4df-1fd2-436e-8631-cb30868b7b9e

| Before                                                                                                                                                          | After                                                                                                                                                           |
| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="1466" height="323" alt="Screenshot 2025-10-02 at 13 28 38" src="https://github.com/user-attachments/assets/1f6ce0f4-2a75-44f7-ab67-7e3a1b0359ba" /> | <img width="1469" height="299" alt="Screenshot 2025-10-02 at 13 28 55" src="https://github.com/user-attachments/assets/6f42401f-5bb0-4e5a-ae20-ed4e03ae0f7b" /> |

# Other affected areas

- Key details if there's a table

<img width="475" height="437" alt="Screenshot 2025-10-02 at 13 18 46" src="https://github.com/user-attachments/assets/f3f35514-721a-4ca5-a382-10912e6f7a60" />

- Analysis Log

<img width="252" height="307" alt="Screenshot 2025-10-02 at 13 20 05" src="https://github.com/user-attachments/assets/8e3d720a-aacd-47da-96c9-b2664df83d4a" />

