### PR TITLE
RI-7541: Use size m instead of hard coded width and height for the svg

### DIFF
--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.styles.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.styles.tsx
@@ -40,8 +40,6 @@ const ControlsIcon = styled(RiIcon)`
   position: relative;
   margin-left: 3px;
   margin-top: 2px;
-  width: 17px !important;
-  height: 17px !important;
 
   :global(.insightsOpen) {
     @media only screen and (max-width: 1440px) {

--- a/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details-header/components/key-details-header-formatter/KeyDetailsHeaderFormatter.tsx
@@ -75,6 +75,7 @@ const KeyDetailsHeaderFormatter = (props: Props) => {
                 <OptionText>{text}</OptionText>
               ) : (
                 <ControlsIcon
+                  size="m"
                   type="FormatterIcon"
                   data-testid={`key-value-formatter-option-selected-${value}`}
                 />


### PR DESCRIPTION
Since Redis UI Icon component has a size, the size should be used instead hard coded pixels for the icon svg, where possible. 

Almost no visible difference: 

| Before | After | 
| --- | --- | 
| <img width="290" height="267" alt="image" src="https://github.com/user-attachments/assets/a2e9c604-6a71-4a96-a27a-438e247e85a3" /> | <img width="290" height="267" alt="image" src="https://github.com/user-attachments/assets/567b497f-7933-4ddd-a540-8a565d158ed6" /> |