### PR TITLE
RI-7599 Fix styles of empty database guidelines

### DIFF
--- a/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
+++ b/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
@@ -58,12 +58,10 @@ const ExploreGuides = () => {
               inverted
               tabIndex={0}
               onClick={() => handleLinkClick(tutorialId)}
-              className={styles.btn}
               data-testid={`guide-button-${tutorialId}`}
             >
               {icon in GUIDE_ICONS && (
                 <RiIcon
-                  className={styles.icon}
                   type={GUIDE_ICONS[icon]}
                   data-testid={`guide-icon-${icon}`}
                   color="inherit"

--- a/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
+++ b/redisinsight/ui/src/components/explore-guides/ExploreGuides.tsx
@@ -66,6 +66,7 @@ const ExploreGuides = () => {
                   className={styles.icon}
                   type={GUIDE_ICONS[icon]}
                   data-testid={`guide-icon-${icon}`}
+                  color="inherit"
                 />
               )}
               {title}


### PR DESCRIPTION
# Description

Update the styles of the guidelines button visible when you have a blank database, so that the icons and the text use the same color.

_Note: Redis UI colors do not match what we have in Figma. Still, we rely on the default behavior, so we can inherit any updates in the future (potential color fixes)._

| Before | After |
| - | - |
<img width="674" height="280" alt="Screenshot 2025-10-06 at 10 54 15" src="https://github.com/user-attachments/assets/7690e339-30d3-460d-b1c7-2200722528e3" />|<img width="674" height="280" alt="Screenshot 2025-10-06 at 10 53 32" src="https://github.com/user-attachments/assets/a3199fbe-b286-4155-8e2f-b51f75dc51f2" />
<img width="653" height="300" alt="2025-10-06_10-54" src="https://github.com/user-attachments/assets/661d421f-f9bb-4659-8f57-7e25e449810d" />|<img width="674" height="280" alt="Screenshot 2025-10-06 at 10 53 39" src="https://github.com/user-attachments/assets/9853b896-ee7d-47e5-bd60-3850364e00ab" />

# How it was tested

1. Open the **Databases** page and connect to an existing database (or establish a connection with a new instance)
2. Open the **Browser** tab from the top navigation

_Note: Make sure that you have a clean database. If not, you can run `flushdb` in the CLI._
