### PR TITLE
RI-7598 Change visuals of the "Import sample data" popover

### DIFF
--- a/redisinsight/ui/src/components/markdown/CodeButtonBlock/components/RunConfirmationPopover.tsx
+++ b/redisinsight/ui/src/components/markdown/CodeButtonBlock/components/RunConfirmationPopover.tsx
@@ -7,6 +7,7 @@ import { setDBConfigStorageField } from 'uiSrc/services'
 import { ConfigDBStorageItem } from 'uiSrc/constants/storage'
 import { FeatureFlagComponent } from 'uiSrc/components'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
+import { Row } from 'uiSrc/components/base/layout/flex'
 import {
   PrimaryButton,
   SecondaryButton,
@@ -67,7 +68,7 @@ const RunConfirmationPopover = ({ onApply }: Props) => {
         aria-label="checkbox do not show agan"
       />
       <div className={styles.popoverFooter}>
-        <div>
+        <Row gap="m" justify="end">
           <FeatureFlagComponent name={FeatureFlags.envDependent}>
             <SecondaryButton
               size="s"
@@ -86,7 +87,7 @@ const RunConfirmationPopover = ({ onApply }: Props) => {
           >
             Run
           </PrimaryButton>
-        </div>
+        </Row>
       </div>
     </>
   )

--- a/redisinsight/ui/src/components/navigation-menu/components/notifications-center/Notification/Notification.tsx
+++ b/redisinsight/ui/src/components/navigation-menu/components/notifications-center/Notification/Notification.tsx
@@ -10,6 +10,7 @@ import { truncateText } from 'uiSrc/utils'
 import { FlexItem, Row } from 'uiSrc/components/base/layout/flex'
 import { TitleSize, Title } from 'uiSrc/components/base/text/Title'
 import { Text } from 'uiSrc/components/base/text'
+import { Spacer } from 'uiSrc/components/base/layout'
 import { RiBadge } from 'uiSrc/components/base/display/badge/RiBadge'
 
 import styles from '../styles.module.scss'
@@ -31,10 +32,9 @@ const Notification = (props: Props) => {
       >
         {notification.title}
       </Title>
-
+      <Spacer size="s" />
       <Text
         size="s"
-        color="subdued"
         className={cx('notificationHTMLBody', styles.notificationBody)}
         data-testid="notification-body"
       >
@@ -43,7 +43,7 @@ const Notification = (props: Props) => {
 
       <Row className={styles.notificationFooter} align="center" justify="start">
         <FlexItem>
-          <Text size="xs" color="subdued" data-testid="notification-date">
+          <Text size="xs" data-testid="notification-date">
             {format(notification.timestamp * 1000, NOTIFICATION_DATE_FORMAT)}
           </Text>
         </FlexItem>

--- a/redisinsight/ui/src/pages/browser/components/load-sample-data/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/components/load-sample-data/styles.module.scss
@@ -1,15 +1,3 @@
 .popover {
   min-width: 380px !important;
 }
-
-.buttonWrapper {
-  .loadDataBtn {
-    height: 36px !important;
-
-    :global(.euiButton__text) {
-      font-size: 14px !important;
-      font-weight: 400 !important;
-    }
-  }
-}
-

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/remove-list-elements/RemoveListElements.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/list-details/remove-list-elements/RemoveListElements.tsx
@@ -261,24 +261,30 @@ const RemoveListElements = (props: Props) => {
                 />
               </FormField>
             </FlexItem>
-            <FlexItem grow style={{ width: '100%' }}>
-              <FormField
-                additionalText={!canRemoveMultiple ? InfoBoxPopover() : <></>}
-              >
-                <TextInput
-                  name={config.count.name}
-                  id={config.count.name}
-                  maxLength={200}
-                  placeholder={config.count.placeholder}
-                  value={count}
-                  data-testid="count-input"
-                  autoComplete="off"
-                  onChange={handleCountChange}
-                  ref={countInput}
-                  disabled={!canRemoveMultiple}
-                />
-              </FormField>
-            </FlexItem>
+            <Row grow>
+              <FlexItem grow>
+                <FormField>
+                  <TextInput
+                    name={config.count.name}
+                    id={config.count.name}
+                    maxLength={200}
+                    placeholder={config.count.placeholder}
+                    value={count}
+                    data-testid="count-input"
+                    autoComplete="off"
+                    onChange={handleCountChange}
+                    ref={countInput}
+                    disabled={!canRemoveMultiple}
+                  />
+                </FormField>
+              </FlexItem>
+
+              {!canRemoveMultiple ? (
+                <FlexItem>{InfoBoxPopover()}</FlexItem>
+              ) : (
+                <></>
+              )}
+            </Row>
           </Row>
         </FlexItem>
       </EntryContent>

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/components/add-item/ConfirmOverwrite.tsx
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/components/add-item/ConfirmOverwrite.tsx
@@ -7,7 +7,8 @@ import {
 } from 'uiSrc/components/base/forms/buttons'
 import { Text } from 'uiSrc/components/base/text'
 import { RiPopover } from 'uiSrc/components/base'
-import styles from '../../styles.module.scss'
+import { Row } from 'uiSrc/components/base/layout/flex'
+import { Spacer } from 'uiSrc/components/base/layout'
 
 interface ConfirmOverwriteProps {
   isOpen: boolean
@@ -37,8 +38,8 @@ const ConfirmOverwrite = ({
       You already have the same JSON key. If you proceed, a value of the
       existing JSON key will be overwritten.
     </Text>
-
-    <div className={styles.confirmDialogActions}>
+    <Spacer size="l" />
+    <Row justify="end" gap="m">
       <SecondaryButton
         aria-label="Cancel"
         size="small"
@@ -56,7 +57,7 @@ const ConfirmOverwrite = ({
       >
         Overwrite
       </PrimaryButton>
-    </div>
+    </Row>
   </RiPopover>
 )
 

--- a/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/styles.module.scss
+++ b/redisinsight/ui/src/pages/browser/modules/key-details/components/rejson-details/styles.module.scss
@@ -269,20 +269,6 @@
   max-width: none;
 }
 
-.confirmDialogActions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 16px;
-
-  button {
-    margin-left: 8px;
-
-    &:first-of-type {
-      margin-left: 0;
-    }
-  }
-}
-
 .actions {
   margin-top: 1em;
   display: flex;

--- a/redisinsight/ui/src/styles/components/_popover.scss
+++ b/redisinsight/ui/src/styles/components/_popover.scss
@@ -35,22 +35,5 @@
 }
 
 .popoverLikeTooltip {
-  border: none;
   max-width: 267px !important;
-  background-color: var(--euiTooltipBackgroundColor) !important;
-  .euiPopover__panelArrow.euiPopover__panelArrow--bottom:after {
-    border-bottom-color: var(--euiTooltipBackgroundColor) !important;
-  }
-
-  .euiPopover__panelArrow.euiPopover__panelArrow--right:after {
-    border-right-color: var(--euiTooltipBackgroundColor) !important;
-  }
-
-  .euiPopover__panelArrow.euiPopover__panelArrow--left:after {
-    border-left-color: var(--euiTooltipBackgroundColor) !important;
-  }
-
-  .euiPopover__panelArrow.euiPopover__panelArrow--top:after {
-    border-top-color: var(--euiTooltipBackgroundColor) !important;
-  }
 }


### PR DESCRIPTION
# Description

Update the colors of the "**Import sample data**" popover to follow the color palette defined by Redis UI.
a.k.a remove a custom color override introduced for EUI 4 years ago.

| Before | After |
| - | - |
<img width="674" height="280" alt="Screenshot 2025-10-06 at 11 44 13" src="https://github.com/user-attachments/assets/ff2f4da0-c7f2-4dd7-af2a-ec9bb25d3b20" />|<img width="674" height="280" alt="Screenshot 2025-10-06 at 11 43 08" src="https://github.com/user-attachments/assets/854ce176-4aa6-4414-ac97-ed624f8f445d" />

# How it was tested

1. Open the **Databases** page and connect to an existing database (or establish a connection with a new instance)
2. Open the **Browser** tab from the top navigation

_Note: Make sure that you have a clean database. If not, you can run flushdb in the CLI._

| Before | After |
| - | - |
<img width="674" height="280" alt="Screenshot 2025-10-06 at 11 44 05" src="https://github.com/user-attachments/assets/4dd25868-ebd4-4803-8351-f6b0ba31e93d" />|<img width="674" height="280" alt="Screenshot 2025-10-06 at 11 42 59" src="https://github.com/user-attachments/assets/19492e1b-90af-498b-a600-bdba19e4fc4a" />
<img width="674" height="280" alt="Screenshot 2025-10-06 at 11 44 13" src="https://github.com/user-attachments/assets/ff2f4da0-c7f2-4dd7-af2a-ec9bb25d3b20" />|<img width="674" height="280" alt="Screenshot 2025-10-06 at 11 43 08" src="https://github.com/user-attachments/assets/854ce176-4aa6-4414-ac97-ed624f8f445d" />

## Note

Also, this is a global change, so it does affect all the popovers in the application that was using the blue color. Now, they all should follow the Redis UI color palette.

### Tutorials

1. Open the **Insights** panel from the top right corner
2. Open the **Tutorials** tab
3. Pick the "**How To Query Your Data**" tutorial

And you can run any of the code snippets under the "EXACT MATCH" section

| Before | After |
| - | - |
<img width="475" height="473" alt="Screenshot 2025-10-06 at 11 44 38" src="https://github.com/user-attachments/assets/2197c842-aa32-43a2-9b6d-34e9078695f2" />|<img width="475" height="473" alt="Screenshot 2025-10-06 at 11 47 04" src="https://github.com/user-attachments/assets/62161ed4-7c36-4df4-aa6a-fd7575968dee" />

### Tips

1. Open the **Insights** panel from the top right corner
2. Open the **Tips** tab
3. Open existing tip (if you don't have such, make sure to insert some data in the database, and maybe analyze it)
4. Scroll down to the bottom of the tip and click on the voting buttons (confirmation popover will apear)

| Before | After |
| - | - |
<img width="516" height="680" alt="image" src="https://github.com/user-attachments/assets/a1eefe56-eb84-4dfd-bf60-ceecdd08a54b" />|<img width="469" height="556" alt="image" src="https://github.com/user-attachments/assets/30ba780c-da8b-4953-92ea-3b5c4ce4ae2f" />

### RDI

1. Open the **Redis Data Integration** tab from the top navbar 
2. Open an existing RDI configuration, or create a new one
- Click on the "Deploy Pipeline" button from the top right corner
- click on the 3 dots to open more option, in the top right corner next to the rest of the actions buttons 

| Before | After |
| - | - |
<img width="1176" height="825" alt="image" src="https://github.com/user-attachments/assets/388d7d94-7ae3-4518-952c-e0f55f6669f3" />|<img width="1178" height="685" alt="image" src="https://github.com/user-attachments/assets/8bb499dd-8a44-4819-a6c9-2fbaf5356090" />
<img width="1153" height="816" alt="image" src="https://github.com/user-attachments/assets/3102e028-9b1c-4860-81ca-47e69d1d96a2" />|<img width="1172" height="657" alt="image" src="https://github.com/user-attachments/assets/602562cd-28c3-41a2-8bc7-0cf699298aeb" />

### JSON key override

1. Open the "Databases" tab and establish a connection to a database
2. Go to the "Browse" tab from the main navbar
3. Add a JSON key
5. From the JSON UI editor, try to add key with the same name, Clicking the confirmation checkmark icon should shuold force a confirmation popover

| Before | After |
| - | - |
<img width="1106" height="663" alt="2025-10-06_12-58" src="https://github.com/user-attachments/assets/dfa8b3e4-8c3e-4aa3-853e-45897dfa946b" />|<img width="1112" height="488" alt="2025-10-06_13-01" src="https://github.com/user-attachments/assets/3a4c2bfd-ddd1-44ff-94af-407987cc6408" />

### Delete multiple List keys

**Note: This info popover is visible only on Redis versions less than 6.2**

```
docker run -d --name redis5 -p 6405:6379 redis:5
```

1. Open the "Databases" tab and establish a connection to a database
2. Go to the "Browse" tab from the main navbar
3. Add a LIST key
4. Click on the "Remove" elements button in the top right corner of the Key Details panel. 

It will open a form at the bottom of the page, with an info icon + popover

| Before | After |
| - | - |
<img width="1173" height="798" alt="2025-10-06_13-14" src="https://github.com/user-attachments/assets/2f8888e2-2294-4010-8f91-c386d72614a2" />|<img width="1109" height="691" alt="2025-10-06_13-26" src="https://github.com/user-attachments/assets/93870a45-8013-4c00-917f-c5a99878e9a7" />

### Create Redisearch index

1. Open the "Databases" tab and establish a connection to a database
2. Go to the "Browse" tab from the main navbar
3. Next to the "**Filter**" icon in the top left corner, click on the "**Search by Values or Keys**" icon
4. Click on the "Create Index" button
6. Click on the info icon next to the "**Identifier**" field

| Before | After |
| - | - |
<img width="1171" height="804" alt="image" src="https://github.com/user-attachments/assets/e990dde9-62a4-4c10-98cd-ff7b78b5c731" />|<img width="1176" height="806" alt="2025-10-06_14-02" src="https://github.com/user-attachments/assets/ce2a0e0b-bd4d-4094-abf4-8dd80ddcd269" />

### Redis Copilot

1. Open Redis Copilot from the top right corner
2. Chat with the bot (confirmation popover will appear the first time, or use `generalChatAgreements` in the local storage)
3. Click on the erase icon in the top right corner of the chat (confirmation popover will appear)
4. Click on the "My Data" tab and trigger the info icon on the top right corner (info popover will appear)

| Before | After |
| - | - |
<img width="387" height="714" alt="2025-10-06_14-13" src="https://github.com/user-attachments/assets/e25857d1-9312-4760-99d9-efd8a46bb160" />|<img width="388" height="682" alt="image" src="https://github.com/user-attachments/assets/af2688c1-4385-4934-9dfa-085eee12c78b" />
<img width="393" height="687" alt="2025-10-06_14-08" src="https://github.com/user-attachments/assets/64fc2ba9-7843-4b04-9a7e-5c28e47f4bf7" />|<img width="388" height="539" alt="2025-10-06_14-08_1" src="https://github.com/user-attachments/assets/643b1985-ff67-47e6-bcd2-28ccf3f148f0" />
<img width="392" height="537" alt="image" src="https://github.com/user-attachments/assets/00556331-24f4-4087-b436-28224f7aac8a" />|<img width="389" height="680" alt="image" src="https://github.com/user-attachments/assets/36f66b8e-4ac9-49e9-9395-79dafdd73b5d" />

### Notifications Center

1. Open Redis Insight
2. Open the Notifications Center from the left side nav

| Before | After |
| - | - |
<img width="799" height="823" alt="2025-10-06_14-27" src="https://github.com/user-attachments/assets/6f1393b0-c07c-4aaa-bde0-c283061fd309" />|<img width="662" height="622" alt="2025-10-06_14-29" src="https://github.com/user-attachments/assets/5da97b08-4d61-4cdc-b4a4-e8174c9963af" />
