### PR TITLE
RI-7619: replace blue text in WB

### DIFF
--- a/redisinsight/ui/src/pages/workbench/components/wb-no-results-message/WbNoResultsMessage.tsx
+++ b/redisinsight/ui/src/pages/workbench/components/wb-no-results-message/WbNoResultsMessage.tsx
@@ -91,7 +91,7 @@ const WbNoResultsMessage = () => {
               </PrimaryButton>
             </div>
             <Spacer size="s" />
-            <Text color="subdued" textAlign="left" size="xs">
+            <Text textAlign="left" size="xs">
               Or click the icon in the top right corner.
             </Text>
           </FlexItem>


### PR DESCRIPTION
|Before|After|
|-|-|
<img width="842" height="437" alt="Screenshot 2025-10-06 at 16 52 30" src="https://github.com/user-attachments/assets/18f477a1-44e1-48ab-9402-f774521571dd" />|<img width="772" height="395" alt="Screenshot 2025-10-06 at 16 52 22" src="https://github.com/user-attachments/assets/0ac8cf20-2a3f-4203-999f-6a04f9d16280" />
