### PR TITLE
RI-7608: Fix FT.SEARCH result table cell text and popover

### DIFF
--- a/redisinsight/ui/src/components/base/text/MultilineEllipsisText.tsx
+++ b/redisinsight/ui/src/components/base/text/MultilineEllipsisText.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components'
+
+import { ColorText } from './ColorText'
+import { theme } from '@redis-ui/styles'
+
+export const lineHeightSizes = ['xs', 's', 'm', 'l'] as const
+export type LineHeightType = (typeof lineHeightSizes)[number]
+
+export const paddingBlockSizes = ['none', 'xs', 's', 'm'] as const
+export type PaddingBlockType = (typeof paddingBlockSizes)[number]
+
+const multiLineEllipsisStyles = {
+  lineHeight: {
+    xs: theme.core.space.space100,
+    s: theme.core.space.space150,
+    m: theme.core.space.space200,
+    l: theme.core.space.space250,
+  },
+  paddingBlock: {
+    none: theme.core.space.space000,
+    xs: theme.core.space.space010,
+    s: theme.core.space.space025,
+    m: theme.core.space.space050,
+  },
+}
+
+const MultilineEllipsisText = styled(ColorText) <{
+  lineCount?: number
+  lineHeight?: LineHeightType
+  paddingBlock?: PaddingBlockType
+}>`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: ${({ lineCount = 5 }) => lineCount};
+  line-height: ${({ lineHeight = 'l' }) =>
+    multiLineEllipsisStyles.lineHeight[lineHeight]};
+  text-overflow: ellipsis;
+  overflow: hidden;
+  padding-block: ${({ paddingBlock = 'none' }) =>
+    multiLineEllipsisStyles.paddingBlock[paddingBlock]};
+`
+
+export default MultilineEllipsisText

--- a/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
+++ b/redisinsight/ui/src/packages/redisearch/src/components/TableResult/TableResult.tsx
@@ -2,14 +2,22 @@ import React, { useEffect, useState } from 'react'
 import parse from 'html-react-parser'
 import cx from 'classnames'
 import { flatten, isArray, isEmpty, map, uniq } from 'lodash'
-import { Table, ColumnDefinition } from 'uiSrc/components/base/layout/table'
+import styled from 'styled-components'
 
-import { ColorText } from '../../../../../components/base/text/ColorText'
-import { IconButton } from '../../../../../components/base/forms/buttons'
-import { CopyIcon } from '../../../../../components/base/icons'
-import { RiTooltip } from '../../../../../components/base/tooltip/RITooltip'
-import { CommandArgument, Command } from '../../constants'
-import { formatLongName, replaceSpaces } from '../../utils'
+import { Table, ColumnDefinition } from 'uiSrc/components/base/layout/table'
+import { ColorText } from 'uiSrc/components/base/text/ColorText'
+import { IconButton } from 'uiSrc/components/base/forms/buttons'
+import { CopyIcon } from 'uiSrc/components/base/icons'
+import { RiTooltip } from 'uiSrc/components/base/tooltip/RITooltip'
+import {
+  CommandArgument,
+  Command,
+} from 'uiSrc/packages/redisearch/src/constants'
+import {
+  formatLongName,
+  replaceSpaces,
+} from 'uiSrc/packages/redisearch/src/utils'
+import MultilineEllipsisText from 'uiSrc/components/base/text/MultilineEllipsisText'
 
 export interface Props {
   query: string
@@ -17,6 +25,11 @@ export interface Props {
   matched?: number
   cursorId?: null | number
 }
+
+const EllipsisText = styled(ColorText)`
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
 
 const noResultsMessage = 'No results found.'
 
@@ -76,16 +89,19 @@ const TableResult = React.memo((props: Props) => {
               data-testid={`query-column-${title}`}
             >
               <RiTooltip
-                position="bottom"
+                position="left"
                 title={title}
-                className="text-multiline-ellipsis"
                 anchorClassName={cx('tooltip')}
-                content={formatLongName(value.toString())}
+                content={
+                  <MultilineEllipsisText lineCount={7} paddingBlock="s">
+                    {formatLongName(value.toString())}
+                  </MultilineEllipsisText>
+                }
               >
                 <div className="copy-btn-wrapper">
-                  <ColorText className={cx('cell', 'test')}>
+                  <EllipsisText className={cx('cell', 'test')}>
                     {cellContent}
-                  </ColorText>
+                  </EllipsisText>
                   <IconButton
                     icon={CopyIcon}
                     aria-label="Copy result"

--- a/redisinsight/ui/src/packages/redisearch/src/styles/styles.scss
+++ b/redisinsight/ui/src/packages/redisearch/src/styles/styles.scss
@@ -85,12 +85,6 @@ html {
   display: inline-block !important;
 }
 
-// The style applies to the last div element in the tooltip, 
-// which is the one containing the text
-.euiToolTipPopover.text-multiline-ellipsis > div:last-child {
-  @include eui.multiline-ellipsis($line-count: 7, $line-height: 1.5rem);
-}
-
 .cell {
   position: relative;
 }

--- a/redisinsight/ui/src/styles/mixins/_eui.scss
+++ b/redisinsight/ui/src/styles/mixins/_eui.scss
@@ -86,12 +86,3 @@ $euiBreakpointKeys: map-keys($euiBreakpoints);
   $alpha: 1 - $factor;
   color: rgba($color, $alpha);
 }
-
-@mixin multiline-ellipsis($line-count, $line-height) {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: $line-count;
-  line-height: $line-height;
-  text-overflow: ellipsis;
-  overflow: hidden;
-}


### PR DESCRIPTION
### Fix the result table for the FT.SEARCH command to display text properly when it's longer
1. Fix the cell text instead of hiding the overflow, to show an ellipsis and a copy button
2. Fix the cell text popover content to show on the left and if bigger than the container, to apply multiline ellipsis

Note: In order to test this locally `yarn build:statics` must be ran

It can be tested on the sample bycicle data by running this command:
`FT.SEARCH idx:smpl_bicycle "@brand:Trek"`

| Before | After | 
| --- | --- |
| <img width="1718" height="472" alt="image" src="https://github.com/user-attachments/assets/d42263a5-c9f3-4f7b-9ba0-bf9be4839de4" /> | <img width="2030" height="620" alt="image" src="https://github.com/user-attachments/assets/b4edafee-1148-4e08-b8f4-d283617ad5d7" /> |