### PR TITLE
Dedupe concurrent push + pull_request test runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,9 +44,17 @@ on:
         default: false
         type: boolean
 
-# Cancel a previous run workflow
+# Cancel a previous run workflow.
+# Key by head identity (not github.ref) so the push-triggered run and the
+# pull_request-triggered run for the same branch share one concurrency group
+# and cancel each other, instead of running the full suite twice in parallel.
+# - push:         head_ref is empty -> falls back to ref_name (branch name)
+# - pull_request: head_ref is the source branch name
+# Qualify by the head repo so fork PRs that happen to share a branch name
+# (e.g. "main") don't collide and cancel each other's runs; for same-repo
+# events this resolves to github.repository, preserving the push<->PR merge.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# What

`tests.yml` triggers on both `push` (feature branches) and `pull_request` (labeled). Pushing a branch and opening/labeling its PR around the same time fired **two full runs of the suite in parallel** — including the 7-way integration matrix — because the `concurrency` group keyed on `github.ref`, which differs between the two events (`refs/heads/<branch>` vs `refs/pull/<n>/merge`), so they never shared a group.

This keys the concurrency group by **head identity** instead:

```yaml
group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
```

- `push` → `github.head_ref` is empty → falls back to `github.ref_name` (branch)
- `pull_request` → `github.head_ref` is the source branch

Both events now resolve to the same group, so `cancel-in-progress` keeps only the latest run.

**No output is lost:** a single run already emits the full set (coverage/test annotations *and* the PR coverage comment) — verified that the two extra `…annotations` check-runs previously seen only on the push run were a race artifact, not event-specific behaviour.

# Testing

This PR is its own test: the push run and the labeled-PR run for this branch should now land in one concurrency group, so only one full `✅ Tests` run survives for the head commit (instead of the two-per-commit seen on #6029).

---

_No JIRA ticket — branch is ticketless; happy to rename with a ref if one's created._


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only concurrency grouping change; no application runtime or security behavior is affected.
> 
> **Overview**
> **Deduplicates parallel `✅ Tests` runs** when a branch push and a labeled pull request fire around the same time.
> 
> The workflow’s `concurrency.group` no longer keys on `github.ref` (which differs between `push` and `pull_request`, so both runs could execute the full matrix). It now keys on **workflow + head repository + head branch** (`github.head_ref || github.ref_name`), so same-repo push and PR events share one group and `cancel-in-progress` leaves a single surviving run. Inline comments document push vs PR resolution and **fork isolation** via `pull_request.head.repo.full_name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 325c7daa153c55244cd3d482cf47123bf1c0839a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->