### PR TITLE
RI-8308: Fix Azure Entra ID token reuse across tenants

### DIFF
--- a/redisinsight/api/src/modules/azure/auth/azure-auth.service.spec.ts
+++ b/redisinsight/api/src/modules/azure/auth/azure-auth.service.spec.ts
@@ -527,8 +527,7 @@ describe('AzureAuthService', () => {
   describe('getRedisTokenByAccountId cross-tenant safety', () => {
     const homeTenantId = faker.string.uuid();
     const otherTenantId = faker.string.uuid();
-    // MSAL keys AAD accounts as `<local account id>.<home tenant id>`
-    const homeAccountId = `${faker.string.uuid()}.${homeTenantId}`;
+    const homeAccountId = faker.string.uuid();
     let homeRealmAccount: ReturnType<typeof createMockAccount>;
 
     beforeEach(() => {
@@ -621,18 +620,9 @@ describe('AzureAuthService', () => {
       expect(result?.token).toEqual(mockAccessToken);
     });
 
-    it('should prefer the home realm when no tenant is requested', async () => {
-      // A database with no recorded tenantId, where the cache lists the most
-      // recent sign-in ahead of the home realm.
-      const otherRealmAccount = {
-        ...homeRealmAccount,
-        tenantId: otherTenantId,
-        localAccountId: faker.string.uuid(),
-      };
-      mockTokenCache.getAllAccounts.mockResolvedValue([
-        otherRealmAccount,
-        homeRealmAccount,
-      ]);
+    it('should leave acquisition untouched when no tenant is requested', async () => {
+      // A database with no recorded tenantId has no realm to target, so neither
+      // the authority nor the forced refresh applies.
       mockPca.acquireTokenSilent.mockResolvedValue({
         accessToken: faker.string.alphanumeric(100),
         expiresOn: new Date(),
@@ -642,8 +632,9 @@ describe('AzureAuthService', () => {
       await service.getRedisTokenByAccountId(homeAccountId);
 
       expect(mockPca.acquireTokenSilent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          account: homeRealmAccount,
+        expect.not.objectContaining({
+          authority: expect.anything(),
+          forceRefresh: expect.anything(),
         }),
       );
     });

--- a/redisinsight/api/src/modules/azure/auth/azure-auth.service.spec.ts
+++ b/redisinsight/api/src/modules/azure/auth/azure-auth.service.spec.ts
@@ -389,7 +389,8 @@ describe('AzureAuthService', () => {
     });
 
     it('should emit token acquired event on successful acquisition', async () => {
-      const mockAccount = createMockAccount();
+      const tenantId = faker.string.uuid();
+      const mockAccount = { ...createMockAccount(), tenantId };
       const mockExpiresOn = new Date();
       const mockAccessToken = faker.string.alphanumeric(100);
       mockTokenCache.getAllAccounts.mockResolvedValue([mockAccount]);
@@ -399,7 +400,6 @@ describe('AzureAuthService', () => {
         account: mockAccount,
       } as any);
 
-      const tenantId = faker.string.uuid();
       await service.getRedisTokenByAccountId(
         mockAccount.homeAccountId,
         tenantId,
@@ -428,8 +428,8 @@ describe('AzureAuthService', () => {
     });
 
     it('should acquire silently against the tenant authority when tenantId provided', async () => {
-      const mockAccount = createMockAccount();
       const tenantId = faker.string.uuid();
+      const mockAccount = { ...createMockAccount(), tenantId };
       mockTokenCache.getAllAccounts.mockResolvedValue([mockAccount]);
       mockPca.acquireTokenSilent.mockResolvedValue({
         accessToken: faker.string.alphanumeric(100),
@@ -500,6 +500,168 @@ describe('AzureAuthService', () => {
         }),
       );
     });
+
+    it('should not force a refresh when the requested realm is cached', async () => {
+      const tenantId = faker.string.uuid();
+      const mockAccount = { ...createMockAccount(), tenantId };
+      mockTokenCache.getAllAccounts.mockResolvedValue([mockAccount]);
+      mockPca.acquireTokenSilent.mockResolvedValue({
+        accessToken: faker.string.alphanumeric(100),
+        expiresOn: new Date(),
+        account: mockAccount,
+      } as any);
+
+      await service.getRedisTokenByAccountId(
+        mockAccount.homeAccountId,
+        tenantId,
+      );
+
+      expect(mockPca.acquireTokenSilent).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          forceRefresh: true,
+        }),
+      );
+    });
+  });
+
+  describe('getRedisTokenByAccountId cross-tenant safety', () => {
+    const homeTenantId = faker.string.uuid();
+    const otherTenantId = faker.string.uuid();
+    // MSAL keys AAD accounts as `<local account id>.<home tenant id>`
+    const homeAccountId = `${faker.string.uuid()}.${homeTenantId}`;
+    let homeRealmAccount: ReturnType<typeof createMockAccount>;
+
+    beforeEach(() => {
+      // Signed into the home tenant only: connecting to a database there leaves
+      // a live token for that realm in the cache.
+      homeRealmAccount = {
+        ...createMockAccount(),
+        homeAccountId,
+        tenantId: homeTenantId,
+      };
+      mockTokenCache.getAllAccounts.mockResolvedValue([homeRealmAccount]);
+    });
+
+    it('should force a refresh when the requested tenant has no cached realm', async () => {
+      mockPca.acquireTokenSilent.mockResolvedValue({
+        accessToken: faker.string.alphanumeric(100),
+        expiresOn: new Date(),
+        account: { ...homeRealmAccount, tenantId: otherTenantId },
+      } as any);
+
+      await service.getRedisTokenByAccountId(homeAccountId, otherTenantId);
+
+      expect(mockPca.acquireTokenSilent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authority: `https://login.microsoftonline.com/${otherTenantId}`,
+          forceRefresh: true,
+        }),
+      );
+    });
+
+    it('should reject a token issued for a realm other than the requested tenant', async () => {
+      mockPca.acquireTokenSilent.mockResolvedValue({
+        accessToken: faker.string.alphanumeric(100),
+        expiresOn: new Date(),
+        account: homeRealmAccount,
+      } as any);
+
+      const result = await service.getRedisTokenByAccountId(
+        homeAccountId,
+        otherTenantId,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should not emit the token acquired event for a wrong-realm token', async () => {
+      mockPca.acquireTokenSilent.mockResolvedValue({
+        accessToken: faker.string.alphanumeric(100),
+        expiresOn: new Date(),
+        account: homeRealmAccount,
+      } as any);
+
+      await service.getRedisTokenByAccountId(homeAccountId, otherTenantId);
+
+      expect(mockEventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('should return the token when the realm matches the requested tenant', async () => {
+      const otherRealmAccount = {
+        ...homeRealmAccount,
+        tenantId: otherTenantId,
+        localAccountId: faker.string.uuid(),
+      };
+      const mockAccessToken = faker.string.alphanumeric(100);
+      mockPca.acquireTokenSilent.mockResolvedValue({
+        accessToken: mockAccessToken,
+        expiresOn: new Date(),
+        account: otherRealmAccount,
+      } as any);
+
+      const result = await service.getRedisTokenByAccountId(
+        homeAccountId,
+        otherTenantId,
+      );
+
+      expect(result?.token).toEqual(mockAccessToken);
+      expect(result?.account).toEqual(otherRealmAccount);
+    });
+
+    it('should not reject a home-realm token when no tenant is requested', async () => {
+      const mockAccessToken = faker.string.alphanumeric(100);
+      mockPca.acquireTokenSilent.mockResolvedValue({
+        accessToken: mockAccessToken,
+        expiresOn: new Date(),
+        account: homeRealmAccount,
+      } as any);
+
+      const result = await service.getRedisTokenByAccountId(homeAccountId);
+
+      expect(result?.token).toEqual(mockAccessToken);
+    });
+
+    it('should prefer the home realm when no tenant is requested', async () => {
+      // A database with no recorded tenantId, where the cache lists the most
+      // recent sign-in ahead of the home realm.
+      const otherRealmAccount = {
+        ...homeRealmAccount,
+        tenantId: otherTenantId,
+        localAccountId: faker.string.uuid(),
+      };
+      mockTokenCache.getAllAccounts.mockResolvedValue([
+        otherRealmAccount,
+        homeRealmAccount,
+      ]);
+      mockPca.acquireTokenSilent.mockResolvedValue({
+        accessToken: faker.string.alphanumeric(100),
+        expiresOn: new Date(),
+        account: homeRealmAccount,
+      } as any);
+
+      await service.getRedisTokenByAccountId(homeAccountId);
+
+      expect(mockPca.acquireTokenSilent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          account: homeRealmAccount,
+        }),
+      );
+    });
+
+    it('should reject a wrong-realm management token as well', async () => {
+      mockPca.acquireTokenSilent.mockResolvedValue({
+        accessToken: faker.string.alphanumeric(100),
+        expiresOn: new Date(),
+        account: homeRealmAccount,
+      } as any);
+
+      const result = await service.getManagementTokenByAccountId(
+        homeAccountId,
+        otherTenantId,
+      );
+
+      expect(result).toBeNull();
+    });
   });
 
   describe('getManagementTokenByAccountId', () => {
@@ -546,8 +708,8 @@ describe('AzureAuthService', () => {
     });
 
     it('should acquire silently against the tenant authority when tenantId provided', async () => {
-      const mockAccount = createMockAccount();
       const tenantId = faker.string.uuid();
+      const mockAccount = { ...createMockAccount(), tenantId };
       mockTokenCache.getAllAccounts.mockResolvedValue([mockAccount]);
       mockPca.acquireTokenSilent.mockResolvedValue({
         accessToken: faker.string.alphanumeric(100),

--- a/redisinsight/api/src/modules/azure/auth/azure-auth.service.spec.ts
+++ b/redisinsight/api/src/modules/azure/auth/azure-auth.service.spec.ts
@@ -648,6 +648,50 @@ describe('AzureAuthService', () => {
       );
     });
 
+    it('should accept a token when the tenant is requested as a domain', async () => {
+      // The import and login DTOs accept a tenant domain, which MSAL reports as
+      // the canonical realm GUID.
+      const tenantDomain = 'contoso.onmicrosoft.com';
+      const mockAccessToken = faker.string.alphanumeric(100);
+      mockPca.acquireTokenSilent.mockResolvedValue({
+        accessToken: mockAccessToken,
+        expiresOn: new Date(),
+        account: { ...homeRealmAccount, tenantId: otherTenantId },
+      } as any);
+
+      const result = await service.getRedisTokenByAccountId(
+        homeAccountId,
+        tenantDomain,
+      );
+
+      expect(result?.token).toEqual(mockAccessToken);
+      expect(mockPca.acquireTokenSilent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authority: `https://login.microsoftonline.com/${tenantDomain}`,
+          forceRefresh: true,
+        }),
+      );
+    });
+
+    it('should match the requested realm regardless of GUID casing', async () => {
+      const mockAccessToken = faker.string.alphanumeric(100);
+      mockPca.acquireTokenSilent.mockResolvedValue({
+        accessToken: mockAccessToken,
+        expiresOn: new Date(),
+        account: homeRealmAccount,
+      } as any);
+
+      const result = await service.getRedisTokenByAccountId(
+        homeAccountId,
+        homeTenantId.toUpperCase(),
+      );
+
+      expect(result?.token).toEqual(mockAccessToken);
+      expect(mockPca.acquireTokenSilent).toHaveBeenCalledWith(
+        expect.objectContaining({ account: homeRealmAccount }),
+      );
+    });
+
     it('should reject a wrong-realm management token as well', async () => {
       mockPca.acquireTokenSilent.mockResolvedValue({
         accessToken: faker.string.alphanumeric(100),

--- a/redisinsight/api/src/modules/azure/auth/azure-auth.service.ts
+++ b/redisinsight/api/src/modules/azure/auth/azure-auth.service.ts
@@ -51,6 +51,13 @@ const generateCodeChallenge = (verifier: string): string =>
 const generateUuid = (): string => crypto.randomUUID();
 
 /**
+ * Extract the home tenant from an MSAL account id, which AAD formats as
+ * `<local account id>.<home tenant id>`.
+ */
+const getHomeTenantId = (accountId: string): string | undefined =>
+  accountId.split('.')[1] || undefined;
+
+/**
  * Service for handling Azure Entra ID authentication.
  * Uses MSAL (Microsoft Authentication Library) for OAuth 2.0 flows.
  */
@@ -375,14 +382,15 @@ export class AzureAuthService {
       const accounts = await cache.getAllAccounts();
 
       // A user signed into multiple tenants has one cached record per realm,
-      // all sharing the same homeAccountId. When a tenant is requested, prefer
-      // the record for that realm so silent refresh targets the right tenant
-      // (falling back to any record for the account otherwise).
+      // all sharing the same homeAccountId. Match the requested realm so silent
+      // refresh targets the right tenant, defaulting to the home realm rather
+      // than whichever realm the cache lists first.
       const forAccount = (a: AccountInfo) => a.homeAccountId === accountId;
-      const account =
-        (tenantId &&
-          accounts.find((a) => forAccount(a) && a.tenantId === tenantId)) ||
-        accounts.find(forAccount);
+      const targetTenantId = tenantId || getHomeTenantId(accountId);
+      const realmAccount =
+        targetTenantId &&
+        accounts.find((a) => forAccount(a) && a.tenantId === targetTenantId);
+      const account = realmAccount || accounts.find(forAccount);
       if (!account) {
         this.logger.warn(`Account not found: ${accountId}`);
         return null;
@@ -392,13 +400,31 @@ export class AzureAuthService {
       // authority. Without it, MSAL resolves to the account's home tenant.
       const authority = tenantId ? buildAzureAuthority(tenantId) : undefined;
 
+      // MSAL resolves a cached access token by the realm of the account it is
+      // given and consults the request authority only on a cache miss, so a
+      // record from another realm yields that realm's token. Skipping the cache
+      // leaves the authority to decide which tenant issues the token.
+      const forceRefresh = Boolean(tenantId) && !realmAccount;
+
       const result = await pca.acquireTokenSilent({
         account,
         scopes: [scope],
         ...(authority && { authority }),
+        ...(forceRefresh && { forceRefresh }),
       });
 
       if (!result?.accessToken || !result?.expiresOn || !result?.account) {
+        return null;
+      }
+
+      // The target resource rejects a token from another realm, so report it as
+      // no token: callers then offer interactive re-authentication against the
+      // right tenant instead of failing on an opaque auth error.
+      if (tenantId && result.account.tenantId !== tenantId) {
+        this.logger.warn(
+          `Discarding token issued for tenant ${result.account.tenantId} ` +
+            `while tenant ${tenantId} was requested`,
+        );
         return null;
       }
 

--- a/redisinsight/api/src/modules/azure/auth/azure-auth.service.ts
+++ b/redisinsight/api/src/modules/azure/auth/azure-auth.service.ts
@@ -52,13 +52,6 @@ const generateCodeChallenge = (verifier: string): string =>
 const generateUuid = (): string => crypto.randomUUID();
 
 /**
- * Extract the home tenant from an MSAL account id, which AAD formats as
- * `<local account id>.<home tenant id>`.
- */
-const getHomeTenantId = (accountId: string): string | undefined =>
-  accountId.split('.')[1] || undefined;
-
-/**
  * Compare tenant ids, which AAD reports in either casing.
  */
 const isSameTenant = (a?: string, b?: string): boolean =>
@@ -389,15 +382,14 @@ export class AzureAuthService {
       const accounts = await cache.getAllAccounts();
 
       // A user signed into multiple tenants has one cached record per realm,
-      // all sharing the same homeAccountId. Match the requested realm so silent
-      // refresh targets the right tenant, defaulting to the home realm rather
-      // than whichever realm the cache lists first.
+      // all sharing the same homeAccountId. When a tenant is requested, prefer
+      // the record for that realm so silent refresh targets the right tenant
+      // (falling back to any record for the account otherwise).
       const forAccount = (a: AccountInfo) => a.homeAccountId === accountId;
-      const targetTenantId = tenantId || getHomeTenantId(accountId);
       const realmAccount =
-        targetTenantId &&
+        tenantId &&
         accounts.find(
-          (a) => forAccount(a) && isSameTenant(a.tenantId, targetTenantId),
+          (a) => forAccount(a) && isSameTenant(a.tenantId, tenantId),
         );
       const account = realmAccount || accounts.find(forAccount);
       if (!account) {

--- a/redisinsight/api/src/modules/azure/auth/azure-auth.service.ts
+++ b/redisinsight/api/src/modules/azure/auth/azure-auth.service.ts
@@ -15,6 +15,7 @@ import {
   AZURE_OAUTH_DEEPLINK_REDIRECT_PATH,
   AZURE_OAUTH_SCOPES,
   AZURE_OAUTH_WEB_CALLBACK_ENDPOINT,
+  AZURE_TENANT_GUID_REGEX,
   AzureAuthStatus,
   AzureOAuthRedirectType,
   AzureRedisTokenEvents,
@@ -56,6 +57,12 @@ const generateUuid = (): string => crypto.randomUUID();
  */
 const getHomeTenantId = (accountId: string): string | undefined =>
   accountId.split('.')[1] || undefined;
+
+/**
+ * Compare tenant ids, which AAD reports in either casing.
+ */
+const isSameTenant = (a?: string, b?: string): boolean =>
+  !!a && !!b && a.toLowerCase() === b.toLowerCase();
 
 /**
  * Service for handling Azure Entra ID authentication.
@@ -389,7 +396,9 @@ export class AzureAuthService {
       const targetTenantId = tenantId || getHomeTenantId(accountId);
       const realmAccount =
         targetTenantId &&
-        accounts.find((a) => forAccount(a) && a.tenantId === targetTenantId);
+        accounts.find(
+          (a) => forAccount(a) && isSameTenant(a.tenantId, targetTenantId),
+        );
       const account = realmAccount || accounts.find(forAccount);
       if (!account) {
         this.logger.warn(`Account not found: ${accountId}`);
@@ -417,10 +426,18 @@ export class AzureAuthService {
         return null;
       }
 
+      // A tenant given as a domain has no realm to compare against; there the
+      // request authority alone pins the issuing tenant.
+      const requestedRealm =
+        tenantId && AZURE_TENANT_GUID_REGEX.test(tenantId) ? tenantId : null;
+
       // The target resource rejects a token from another realm, so report it as
       // no token: callers then offer interactive re-authentication against the
-      // right tenant instead of failing on an opaque auth error.
-      if (tenantId && result.account.tenantId !== tenantId) {
+      // right tenant instead of an opaque auth error.
+      if (
+        requestedRealm &&
+        !isSameTenant(result.account.tenantId, requestedRealm)
+      ) {
         this.logger.warn(
           `Discarding token issued for tenant ${result.account.tenantId} ` +
             `while tenant ${tenantId} was requested`,

--- a/redisinsight/api/src/modules/azure/constants.ts
+++ b/redisinsight/api/src/modules/azure/constants.ts
@@ -152,6 +152,11 @@ export const AUTODISCOVERY_MAX_CONCURRENT_REQUESTS = 20;
 export const AZURE_SUBSCRIPTION_ID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// MSAL reports the realm that issued a token as a GUID, so only a tenant given
+// in this form can be compared against it.
+export const AZURE_TENANT_GUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // A tenant id is either a GUID or a domain (e.g. your-tenant.onmicrosoft.com).
 // MSAL accepts both as the authority path segment.
 export const AZURE_TENANT_ID_REGEX =


### PR DESCRIPTION
# What

Connecting to an Entra ID database in one tenant while a live token for another realm sits in the MSAL cache returned that cached token. MSAL resolves a cached access token by the realm of the account it is given and consults the request authority only on a cache miss, so the per-tenant authority we pass had no effect. Redis rejected the wrong-tenant credential as a generic "Authentication failed" with no re-auth affordance, leaving an app restart as the only recovery.

In `getTokenByAccountId`:

- Force a refresh when the requested realm is not cached, so the tenant authority decides which tenant issues the token. This keeps the legitimate silent cross-tenant path working instead of always falling back to an interactive sign-in.
- Discard a token issued for a realm other than the one requested. Callers then surface interactive re-authentication scoped to the right tenant rather than failing on an opaque auth error.
- Default account selection to the home realm instead of whichever realm the cache lists first. This is the same defect in reverse, hit by databases with no recorded `tenantId`.

Follow-up to RI-8308 (#6194).
Refs #6047

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication token selection and validation for Azure Entra ID; incorrect behavior could block connections or still leak wrong-tenant tokens.
> 
> **Overview**
> Fixes **cross-tenant MSAL cache misuse** when silently acquiring Redis and management tokens for a specific `tenantId`.
> 
> `getTokenByAccountId` now picks the cached account for the requested realm using **case-insensitive** tenant matching, sets **`forceRefresh: true`** when that realm is not cached (so the per-tenant authority actually issues the token), and **drops** tokens whose issued realm does not match a requested tenant **GUID**—returning `null` so callers can prompt re-auth instead of failing with a wrong credential. Tenant **domains** still rely on authority only (no realm comparison). **`AZURE_TENANT_GUID_REGEX`** was added for that distinction.
> 
> Extensive **unit tests** cover force-refresh behavior, wrong-realm rejection, event emission, domain/casing edge cases, and management tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8de9274a6083c73f8eee7960153f7cd38083a9d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->