### PR TITLE
ci: group Dependabot updates and stop generating unmergeable bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,10 @@ updates:
     # Ceiling for the groups below, not a target.
     open-pull-requests-limit: 15
     cooldown:
+      # Patches and minors inherit default-days, which matches min-release-age
+      # in .npmrc. A shorter window proposes versions that npm will not resolve.
       default-days: 3
       semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1
 
     # Majors that are migrations rather than bumps. Minors and patches for
     # these still flow.
@@ -239,10 +239,10 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 10
     cooldown:
+      # Patches and minors inherit default-days, which matches min-release-age
+      # in .npmrc. A shorter window proposes versions that npm will not resolve.
       default-days: 3
       semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1
 
     ignore:
       - dependency-name: 'typescript'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,14 @@
 version: 2
 
-# Two npm entries because the root and api trees have independent lockfiles
-# (12 in total across the repo) and different locked packages. Directories not
-# listed here still receive Dependabot *security* updates, which are enabled
+# The root and api trees have independent lockfiles, so each needs its own
+# entry. Directories absent here still receive security updates, which run
 # repo-wide and ignore this config.
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
-    # Headroom for the family groups plus the four catch-alls. Groups with no
-    # available update produce no PR, so this is a ceiling, not a target.
+    # Ceiling for the groups below, not a target.
     open-pull-requests-limit: 15
     cooldown:
       default-days: 3
@@ -18,14 +16,11 @@ updates:
       semver-minor-days: 3
       semver-patch-days: 1
 
-    # Packages whose major is a migration project rather than a bump. Bumping
-    # any of these in isolation produces a PR that cannot pass CI, so the bot
-    # should not open one; we drive these by hand. Everything else, including
-    # majors, still flows normally.
+    # Majors that are migrations rather than bumps. Minors and patches for
+    # these still flow.
     ignore:
-      # react/react-dom are hard-pinned via `overrides` and held at 18 by
-      # @elastic/eui (peers on react-dom ^16.12) and @testing-library/react 13
-      # (peers on ^18.0.0). The types must move with them or type-check breaks.
+      # Held at 18 by @elastic/eui (peers on react-dom ^16.12) and
+      # @testing-library/react 13 (peers on ^18.0.0), and pinned via overrides.
       - dependency-name: 'react'
         update-types: ['version-update:semver-major']
       - dependency-name: 'react-dom'
@@ -36,21 +31,18 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@testing-library/react'
         update-types: ['version-update:semver-major']
-      # A minor changes compiler behaviour, which shifts the per-file error
-      # counts recorded in .tscheck.rec.json (5,595 errors across 871 files).
-      # The ratchet then fails in both directions, and refreshing baselines
-      # needs a human to judge whether the new errors are real.
+      # A minor shifts the per-file error counts in .tscheck.rec.json, and the
+      # ratchet fails whether counts rise or fall.
       - dependency-name: 'typescript'
         update-types:
           ['version-update:semver-major', 'version-update:semver-minor']
-      # Tracks the Node version pinned in .nvmrc, not npm.
+      # Tracks the Node version in .nvmrc, not npm.
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
-      # Being migrated away from; a major would be wasted work.
+      # Migrating away from this, so a major is wasted work.
       - dependency-name: '@elastic/eui'
         update-types: ['version-update:semver-major']
-      # Native-module ABI is coupled to the Electron version, so this moves as
-      # part of a deliberate Electron upgrade.
+      # Native-module ABI is coupled to the Electron version.
       - dependency-name: 'electron'
         update-types: ['version-update:semver-major']
       # Held at v5; v6 is a routing rewrite.
@@ -58,7 +50,7 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'html-react-parser'
         update-types: ['version-update:semver-major']
-      # Virtualization stack, all react-18-locked.
+      # Virtualization stack, react-18-locked.
       - dependency-name: 'react-virtualized'
         update-types: ['version-update:semver-major']
       - dependency-name: 'react-window'
@@ -67,7 +59,7 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: 'react-vtree'
         update-types: ['version-update:semver-major']
-      # Dev tooling whose majors change CLI/API surface used across scripts.
+      # Majors change CLI surface used across scripts.
       - dependency-name: 'rimraf'
         update-types: ['version-update:semver-major']
       - dependency-name: 'lint-staged'
@@ -77,23 +69,15 @@ updates:
 
     # Grouped by what must move together, not by shared name prefix.
     #
-    # Membership is decided by *pattern specificity*, not by declaration
-    # order. The docs say "included in the first group that it matches", but
-    # the updater scores patterns (exact name 1000, wildcards penalised by
-    # length, bare `*` 1) and assigns each dependency to its highest-scoring
-    # match. See dependabot/dependabot-core#13044 and #14576. Two consequences:
+    # Membership goes to the highest-scoring pattern match rather than to the
+    # first group declared: an exact name outranks a wildcard, which outranks a
+    # bare `*`. Every catch-all therefore declares `patterns: ['*']`. A
+    # catch-all that omits `patterns` outranks the named groups and swallows
+    # them.
     #
-    #   - Every catch-all below carries `patterns: ['*']` so it scores 1 and
-    #     always loses to a named group. A catch-all that omits `patterns`
-    #     entirely wins the comparison instead and silently swallows the named
-    #     groups, which is the bug reported in #14576.
-    #   - Prefer exact names over wildcards where two groups could overlap;
-    #     an exact match at 1000 beats any wildcard deterministically.
-    #
-    # Groups that span prod and dev deliberately omit `dependency-type`: the
-    # catch-alls are split by type, so a coupled pair straddling prod/dev
-    # (ioredis + ioredis-mock, i18next + i18next-cli) could never travel
-    # together otherwise.
+    # Groups spanning prod and dev omit `dependency-type` so a coupled pair
+    # split across the two, such as ioredis and ioredis-mock, can still travel
+    # together.
     groups:
       react:
         patterns: ['react', 'react-dom', '@types/react', '@types/react-dom']
@@ -110,8 +94,7 @@ updates:
         patterns: ['i18next', 'i18next-*', 'react-i18next']
       monaco:
         patterns: ['monaco-editor', 'monaco-yaml', 'react-monaco-editor']
-      # The browser key list renders through these together, and each companion
-      # package is pinned to its host's major.
+      # Each companion package is pinned to its host's major.
       virtualization:
         patterns:
           [
@@ -123,15 +106,11 @@ updates:
             '@types/react-virtualized',
             '@types/react-window-infinite-loader',
           ]
-      # Isolated so a failing tsc baselines check is attributable to the
-      # compiler rather than to one of ~50 unrelated dev deps.
+      # Isolated so a failing tsc baselines check points at the compiler.
       typescript:
         patterns: ['typescript', '@aivenio/tsc-output-parser']
-      # Runtime libraries that merely share the `electron-` prefix, kept apart
-      # from the packaging toolchain so a broken electron-log cannot block a
-      # builder upgrade. Named exactly rather than via `electron-*`, which
-      # would collide with electron-build. New electron-* packages fall
-      # through to a catch-all.
+      # Runtime libraries sharing the `electron-` prefix, kept out of the
+      # packaging toolchain. Named exactly to avoid colliding with it.
       electron-runtime:
         patterns:
           [
@@ -142,10 +121,8 @@ updates:
             'electron-store',
             '@types/electron-store',
           ]
-      # The packaging toolchain, which electron-builder releases in lockstep
-      # (electron-updater and builder-util-runtime ship with it). node-abi maps
-      # Electron versions to native ABI versions, so it has to track the
-      # Electron bump for native rebuilds to resolve.
+      # electron-builder releases electron-updater and builder-util-runtime in
+      # lockstep; node-abi maps Electron versions to native ABI versions.
       electron-build:
         patterns:
           [
@@ -162,9 +139,8 @@ updates:
         patterns: ['storybook', '@storybook/*', 'eslint-plugin-storybook']
       observability:
         patterns: ['@sentry/*', '@opentelemetry/*']
-      # Both build pipelines plus the loaders and plugins pinned to a webpack
-      # major: Vite builds the renderer, webpack builds the Electron main and
-      # preload bundles.
+      # Vite builds the renderer, webpack the Electron main and preload
+      # bundles, alongside the loaders and plugins pinned to a webpack major.
       build-tooling:
         patterns: [
             'vite',
@@ -179,8 +155,8 @@ updates:
             'mini-css-extract-plugin',
             '@svgr/webpack',
             'react-refresh',
-            # Loaders are named explicitly: a `*-loader` glob would also catch
-            # unrelated packages such as react-window-infinite-loader.
+            # Named exactly: a `*-loader` glob also catches unrelated packages
+            # such as react-window-infinite-loader.
             'css-loader',
             'file-loader',
             'style-loader',
@@ -210,8 +186,7 @@ updates:
             'ts-mockito',
             'fishery',
             'identity-obj-proxy',
-            # These track their host package's major, so they travel with it
-            # rather than with the rest of @types/*.
+            # Track their host's major, so they travel with it.
             '@types/jest',
             '@types/supertest',
           ]
@@ -221,9 +196,8 @@ updates:
         patterns: ['@redis-ui/*', '@redislabsdev/*']
       types:
         patterns: ['@types/*']
-      # Split by update-type so a patch bundle stays mergeable on green and a
-      # broken minor cannot hold unrelated patches hostage. Unlocked majors
-      # match no catch-all and so arrive individually.
+      # Split by update-type so a broken minor cannot hold patches back.
+      # Unlocked majors match no catch-all and arrive individually.
       production-patch:
         dependency-type: 'production'
         update-types: ['patch']
@@ -258,13 +232,13 @@ updates:
           ['version-update:semver-major', 'version-update:semver-minor']
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
-      # Native module compiled against the Electron ABI; moves with Electron.
+      # Native module compiled against the Electron ABI.
       - dependency-name: 'better-sqlite3'
         update-types: ['version-update:semver-major']
-      # Framework major is a migration across every module.
+      # A framework major is a migration across every module.
       - dependency-name: '@nestjs/*'
         update-types: ['version-update:semver-major']
-      # Pre-1.0, so a minor carries breaking schema/driver changes.
+      # Pre-1.0, so a minor carries breaking schema and driver changes.
       - dependency-name: 'typeorm'
         update-types:
           ['version-update:semver-major', 'version-update:semver-minor']
@@ -276,13 +250,10 @@ updates:
     groups:
       typescript:
         patterns: ['typescript']
-      # rxjs and reflect-metadata are NestJS peer dependencies pinned to the
-      # framework major, so they cannot move independently of it.
+      # rxjs and reflect-metadata are peers pinned to the framework major.
       nestjs:
         patterns: ['@nestjs/*', 'rxjs', 'reflect-metadata']
-      # The Redis clients are the core of the product, so they get a
-      # reviewable PR of their own rather than riding in a catch-all. Spans
-      # prod and dev so ioredis-mock moves with ioredis.
+      # Spans prod and dev so ioredis-mock moves with ioredis.
       redis-clients:
         patterns:
           [
@@ -294,9 +265,8 @@ updates:
           ]
       socketio:
         patterns: ['socket.io', 'socket.io-*']
-      # Unit tests run on jest, integration tests on mocha/chai. babel-jest is
-      # released from the jest repo and tracks its major, so it belongs here
-      # rather than with the Babel presets.
+      # Unit tests run on jest, integration tests on mocha/chai. babel-jest
+      # ships from the jest repo and tracks its major, not Babel's.
       testing:
         patterns:
           [

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,176 @@
 version: 2
 
+# Two npm entries because the root and api trees have independent lockfiles
+# (12 in total across the repo) and different locked packages. Directories not
+# listed here still receive Dependabot *security* updates, which are enabled
+# repo-wide and ignore this config.
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+    # Groups collapse the weekly run into a handful of PRs, so the limit needs
+    # headroom for the family groups plus the two catch-alls.
+    open-pull-requests-limit: 10
     cooldown:
       default-days: 3
       semver-major-days: 7
       semver-minor-days: 3
       semver-patch-days: 1
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+    # Packages whose major is a migration project rather than a bump. Bumping
+    # any of these in isolation produces a PR that cannot pass CI, so the bot
+    # should not open one; we drive these by hand. Everything else, including
+    # majors, still flows normally.
+    ignore:
+      # react/react-dom are hard-pinned via `overrides` and held at 18 by
+      # @elastic/eui (peers on react-dom ^16.12) and @testing-library/react 13
+      # (peers on ^18.0.0). The types must move with them or type-check breaks.
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@testing-library/react'
+        update-types: ['version-update:semver-major']
+      # Being migrated away from; a major would be wasted work.
+      - dependency-name: '@elastic/eui'
+        update-types: ['version-update:semver-major']
+      # Native-module ABI is coupled to the Electron version, so this moves as
+      # part of a deliberate Electron upgrade.
+      - dependency-name: 'electron'
+        update-types: ['version-update:semver-major']
+      # Held at v5; v6 is a routing rewrite.
+      - dependency-name: 'react-router-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'html-react-parser'
+        update-types: ['version-update:semver-major']
+      # Virtualization stack, all react-18-locked.
+      - dependency-name: 'react-virtualized'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-window'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-window-infinite-loader'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-vtree'
+        update-types: ['version-update:semver-major']
+      # Dev tooling whose majors change CLI/API surface used across scripts.
+      - dependency-name: 'rimraf'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'lint-staged'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@faker-js/faker'
+        update-types: ['version-update:semver-major']
+
+    # First match wins, so family groups are listed before the catch-alls. This
+    # keeps coupled packages in one PR instead of the split pairs Dependabot
+    # produces on its own (e.g. electron-builder arriving twice in one week).
+    groups:
+      react:
+        patterns: ['react', 'react-dom', '@types/react', '@types/react-dom']
+      electron-build:
+        patterns:
+          [
+            'electron',
+            'electron-*',
+            '@electron/*',
+            'app-builder-lib',
+            'builder-util*',
+          ]
+      storybook:
+        patterns: ['storybook', '@storybook/*', 'eslint-plugin-storybook']
+      build-tooling:
+        patterns:
+          [
+            'vite',
+            'vite-*',
+            '@vitejs/*',
+            'esbuild',
+            'esbuild-*',
+            'rollup',
+            'webpack',
+            'webpack-*',
+          ]
+      linting:
+        patterns:
+          [
+            'eslint',
+            'eslint-*',
+            '@typescript-eslint/*',
+            'prettier',
+            'prettier-*',
+            'lint-staged',
+          ]
+      testing:
+        patterns:
+          ['jest', 'jest-*', 'ts-jest', '@testing-library/*', '@faker-js/faker']
+      babel:
+        patterns: ['@babel/*', 'babel-*']
+      observability:
+        patterns: ['@sentry/*', '@opentelemetry/*']
+      redis-ui:
+        patterns: ['@redis-ui/*', '@redislabsdev/*']
+      types:
+        patterns: ['@types/*']
+      production:
+        dependency-type: 'production'
+        patterns: ['*']
+      development:
+        dependency-type: 'development'
+        patterns: ['*']
+
+  - package-ecosystem: 'npm'
+    directory: '/redisinsight/api'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+    open-pull-requests-limit: 5
     cooldown:
       default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
+
+    ignore:
+      # Native module compiled against the Electron ABI; moves with Electron.
+      - dependency-name: 'better-sqlite3'
+        update-types: ['version-update:semver-major']
+      # Framework major is a migration across every module.
+      - dependency-name: '@nestjs/*'
+        update-types: ['version-update:semver-major']
+      # Pre-1.0, so a minor carries breaking schema/driver changes.
+      - dependency-name: 'typeorm'
+        update-types:
+          ['version-update:semver-major', 'version-update:semver-minor']
+      - dependency-name: 'rimraf'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@faker-js/faker'
+        update-types: ['version-update:semver-major']
+
+    groups:
+      nestjs:
+        patterns: ['@nestjs/*']
+      testing:
+        patterns: ['jest', 'jest-*', 'ts-jest', '@faker-js/faker', 'supertest']
+      babel:
+        patterns: ['@babel/*', 'babel-*']
+      types:
+        patterns: ['@types/*']
+      production:
+        dependency-type: 'production'
+        patterns: ['*']
+      development:
+        dependency-type: 'development'
+        patterns: ['*']
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 3
+    groups:
+      github-actions:
+        patterns: ['*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@types/react-virtualized'
         update-types: ['version-update:semver-major']
+      - dependency-name: 'react-virtualized-auto-sizer'
+        update-types: ['version-update:semver-major']
       - dependency-name: 'react-window'
         update-types: ['version-update:semver-major']
       - dependency-name: 'react-window-infinite-loader'
@@ -247,6 +249,9 @@ updates:
       # A framework major is a migration across every module.
       - dependency-name: '@nestjs/*'
         update-types: ['version-update:semver-major']
+      # NestJS peers on rxjs ^7, so a v8 lands outside the supported range.
+      - dependency-name: 'rxjs'
+        update-types: ['version-update:semver-major']
       # Pre-1.0, so a minor carries breaking schema and driver changes.
       - dependency-name: 'typeorm'
         update-types:
@@ -295,6 +300,7 @@ updates:
             'chai-*',
             'nyc',
             'nock',
+            'fishery',
           ]
       babel:
         patterns: ['@babel/*', 'babel-*']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 
-# The root and api trees have independent lockfiles, so each needs its own
-# entry. Directories absent here still receive security updates, which run
-# repo-wide and ignore this config.
+# Each tree below has its own lockfile, so each needs its own entry.
+# Directories absent here still receive security updates, which run repo-wide
+# and ignore this config.
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
@@ -223,6 +223,38 @@ updates:
         patterns: ['*']
       development-minor:
         dependency-type: 'development'
+        update-types: ['minor']
+        patterns: ['*']
+
+  # The packaged Electron app's manifest, holding three native modules. Its
+  # lockfile is the one that ships, so these have to track the copies in the api
+  # tree rather than drift from them. Declaring the entry also applies the
+  # ignore rules below to security updates, which reach this directory either
+  # way.
+  - package-ecosystem: 'npm'
+    directory: '/redisinsight'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
+
+    ignore:
+      # Mirrors the api entry: the ABI is coupled to the Electron version.
+      - dependency-name: 'better-sqlite3'
+        update-types: ['version-update:semver-major']
+
+    # No devDependencies here, so the development catch-alls are omitted.
+    groups:
+      production-patch:
+        dependency-type: 'production'
+        update-types: ['patch']
+        patterns: ['*']
+      production-minor:
+        dependency-type: 'production'
         update-types: ['minor']
         patterns: ['*']
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,14 +48,21 @@ updates:
       # Held at v5; v6 is a routing rewrite.
       - dependency-name: 'react-router-dom'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-router-dom'
+        update-types: ['version-update:semver-major']
       - dependency-name: 'html-react-parser'
         update-types: ['version-update:semver-major']
-      # Virtualization stack, react-18-locked.
+      # Virtualization stack, react-18-locked. The types skew from the runtime
+      # unless they are held back too.
       - dependency-name: 'react-virtualized'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-virtualized'
         update-types: ['version-update:semver-major']
       - dependency-name: 'react-window'
         update-types: ['version-update:semver-major']
       - dependency-name: 'react-window-infinite-loader'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-window-infinite-loader'
         update-types: ['version-update:semver-major']
       - dependency-name: 'react-vtree'
         update-types: ['version-update:semver-major']
@@ -93,7 +100,7 @@ updates:
       # Group identifiers take letters, pipes, underscores and hyphens only, so
       # this cannot be named after the package.
       internationalization:
-        patterns: ['i18next', 'i18next-*', 'react-i18next']
+        patterns: ['i18next', 'i18next-cli', 'react-i18next']
       monaco:
         patterns: ['monaco-editor', 'monaco-yaml', 'react-monaco-editor']
       # Each companion package is pinned to its host's major.
@@ -266,7 +273,7 @@ updates:
             '@types/ioredis-mock',
           ]
       socketio:
-        patterns: ['socket.io', 'socket.io-*']
+        patterns: ['socket.io', 'socket.io-client', 'socket.io-mock']
       # Unit tests run on jest, integration tests on mocha/chai. babel-jest
       # ships from the jest repo and tracks its major, not Babel's.
       testing:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    # Groups collapse the weekly run into a handful of PRs, so the limit needs
-    # headroom for the family groups plus the two catch-alls.
-    open-pull-requests-limit: 10
+    # Headroom for the family groups plus the four catch-alls. Groups with no
+    # available update produce no PR, so this is a ceiling, not a target.
+    open-pull-requests-limit: 15
     cooldown:
       default-days: 3
       semver-major-days: 7
@@ -35,6 +35,16 @@ updates:
       - dependency-name: '@types/react-dom'
         update-types: ['version-update:semver-major']
       - dependency-name: '@testing-library/react'
+        update-types: ['version-update:semver-major']
+      # A minor changes compiler behaviour, which shifts the per-file error
+      # counts recorded in .tscheck.rec.json (5,595 errors across 871 files).
+      # The ratchet then fails in both directions, and refreshing baselines
+      # needs a human to judge whether the new errors are real.
+      - dependency-name: 'typescript'
+        update-types:
+          ['version-update:semver-major', 'version-update:semver-minor']
+      # Tracks the Node version pinned in .nvmrc, not npm.
+      - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
       # Being migrated away from; a major would be wasted work.
       - dependency-name: '@elastic/eui'
@@ -65,26 +75,82 @@ updates:
       - dependency-name: '@faker-js/faker'
         update-types: ['version-update:semver-major']
 
-    # First match wins, so family groups are listed before the catch-alls. This
-    # keeps coupled packages in one PR instead of the split pairs Dependabot
-    # produces on its own (e.g. electron-builder arriving twice in one week).
+    # Grouped by what must move together, not by shared name prefix. First
+    # match wins, so a group that would swallow a later group's packages is
+    # listed after it (observability before build-tooling, for instance, so
+    # @sentry/webpack-plugin is not caught by `*-webpack-plugin`).
+    #
+    # Groups that span prod and dev deliberately omit `dependency-type`: the
+    # catch-alls are split by type, so a coupled pair straddling prod/dev
+    # (ioredis + ioredis-mock, i18next + i18next-cli) could never travel
+    # together otherwise.
     groups:
       react:
         patterns: ['react', 'react-dom', '@types/react', '@types/react-dom']
+      redux:
+        patterns:
+          [
+            'redux',
+            'react-redux',
+            '@reduxjs/toolkit',
+            'redux-thunk',
+            'redux-mock-store',
+          ]
+      i18n:
+        patterns: ['i18next', 'i18next-*', 'react-i18next']
+      monaco:
+        patterns: ['monaco-editor', 'monaco-yaml', 'react-monaco-editor']
+      # The browser key list renders through these together, and each companion
+      # package is pinned to its host's major.
+      virtualization:
+        patterns:
+          [
+            'react-virtualized',
+            'react-virtualized-auto-sizer',
+            'react-window',
+            'react-window-infinite-loader',
+            'react-vtree',
+            '@types/react-virtualized',
+            '@types/react-window-infinite-loader',
+          ]
+      # Isolated so a failing tsc baselines check is attributable to the
+      # compiler rather than to one of ~50 unrelated dev deps.
+      typescript:
+        patterns: ['typescript', '@aivenio/tsc-output-parser']
+      # Runtime libraries that merely share the `electron-` prefix. Listed
+      # before electron-build so a broken electron-log cannot block a builder
+      # upgrade. New electron-* packages fall through to a catch-all.
+      electron-runtime:
+        patterns:
+          [
+            'electron-context-menu',
+            'electron-debug',
+            'electron-devtools-installer',
+            'electron-log',
+            'electron-store',
+          ]
+      # The packaging toolchain, which electron-builder releases in lockstep
+      # (electron-updater and builder-util-runtime ship with it).
       electron-build:
         patterns:
           [
             'electron',
-            'electron-*',
-            '@electron/*',
+            'electron-builder',
+            'electron-builder-notarize',
+            'electron-updater',
             'app-builder-lib',
             'builder-util*',
+            '@electron/*',
           ]
       storybook:
         patterns: ['storybook', '@storybook/*', 'eslint-plugin-storybook']
+      observability:
+        patterns: ['@sentry/*', '@opentelemetry/*']
+      # Both build pipelines plus the loaders and plugins pinned to a webpack
+      # major: Vite builds the renderer, webpack builds the Electron main and
+      # preload bundles.
       build-tooling:
-        patterns:
-          [
+        patterns: [
             'vite',
             'vite-*',
             '@vitejs/*',
@@ -93,6 +159,18 @@ updates:
             'rollup',
             'webpack',
             'webpack-*',
+            '*-webpack-plugin',
+            'mini-css-extract-plugin',
+            '@svgr/webpack',
+            'react-refresh',
+            # Loaders are named explicitly: a `*-loader` glob would also catch
+            # unrelated packages such as react-window-infinite-loader.
+            'css-loader',
+            'file-loader',
+            'style-loader',
+            'ts-loader',
+            'url-loader',
+            '@teamsupercell/typings-for-css-modules-loader',
           ]
       linting:
         patterns:
@@ -106,27 +184,49 @@ updates:
           ]
       testing:
         patterns:
-          ['jest', 'jest-*', 'ts-jest', '@testing-library/*', '@faker-js/faker']
+          [
+            'jest',
+            'jest-*',
+            'ts-jest',
+            '@testing-library/*',
+            '@faker-js/faker',
+            'msw',
+            'supertest',
+            'ts-mockito',
+            'fishery',
+            'identity-obj-proxy',
+          ]
       babel:
         patterns: ['@babel/*', 'babel-*']
-      observability:
-        patterns: ['@sentry/*', '@opentelemetry/*']
       redis-ui:
         patterns: ['@redis-ui/*', '@redislabsdev/*']
       types:
         patterns: ['@types/*']
-      production:
+      # Split by update-type so a patch bundle stays mergeable on green and a
+      # broken minor cannot hold unrelated patches hostage. Unlocked majors
+      # match no catch-all and so arrive individually.
+      production-patch:
         dependency-type: 'production'
+        update-types: ['patch']
         patterns: ['*']
-      development:
+      production-minor:
+        dependency-type: 'production'
+        update-types: ['minor']
+        patterns: ['*']
+      development-patch:
         dependency-type: 'development'
+        update-types: ['patch']
+        patterns: ['*']
+      development-minor:
+        dependency-type: 'development'
+        update-types: ['minor']
         patterns: ['*']
 
   - package-ecosystem: 'npm'
     directory: '/redisinsight/api'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 8
     cooldown:
       default-days: 3
       semver-major-days: 7
@@ -134,6 +234,11 @@ updates:
       semver-patch-days: 1
 
     ignore:
+      - dependency-name: 'typescript'
+        update-types:
+          ['version-update:semver-major', 'version-update:semver-minor']
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
       # Native module compiled against the Electron ABI; moves with Electron.
       - dependency-name: 'better-sqlite3'
         update-types: ['version-update:semver-major']
@@ -150,19 +255,54 @@ updates:
         update-types: ['version-update:semver-major']
 
     groups:
+      typescript:
+        patterns: ['typescript']
       nestjs:
         patterns: ['@nestjs/*']
+      # The Redis clients are the core of the product, so they get a
+      # reviewable PR of their own rather than riding in a catch-all. Spans
+      # prod and dev so ioredis-mock moves with ioredis.
+      redis-clients:
+        patterns: ['redis', 'redis-parser', 'ioredis', 'ioredis-mock']
+      socketio:
+        patterns: ['socket.io', 'socket.io-*']
+      # Unit tests run on jest, integration tests on mocha/chai.
       testing:
-        patterns: ['jest', 'jest-*', 'ts-jest', '@faker-js/faker', 'supertest']
+        patterns:
+          [
+            'jest',
+            'jest-*',
+            'ts-jest',
+            '@faker-js/faker',
+            'supertest',
+            'mocha',
+            'mocha-*',
+            '@mochajs/*',
+            'ts-mocha',
+            'chai',
+            'chai-*',
+            'nyc',
+            'nock',
+          ]
       babel:
         patterns: ['@babel/*', 'babel-*']
       types:
         patterns: ['@types/*']
-      production:
+      production-patch:
         dependency-type: 'production'
+        update-types: ['patch']
         patterns: ['*']
-      development:
+      production-minor:
+        dependency-type: 'production'
+        update-types: ['minor']
+        patterns: ['*']
+      development-patch:
         dependency-type: 'development'
+        update-types: ['patch']
+        patterns: ['*']
+      development-minor:
+        dependency-type: 'development'
+        update-types: ['minor']
         patterns: ['*']
 
   - package-ecosystem: 'github-actions'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -226,43 +226,18 @@ updates:
         update-types: ['minor']
         patterns: ['*']
 
-  # The packaged Electron app's manifest, holding three native modules. Its
-  # lockfile is the one that ships, so these have to track the copies in the api
-  # tree rather than drift from them. Declaring the entry also applies the
-  # ignore rules below to security updates, which reach this directory either
-  # way.
+  # One entry for both lockfiles. /redisinsight is the packaged Electron app's
+  # manifest and declares better-sqlite3, keytar and tunnel-ssh at the same
+  # versions as the api tree; its lockfile is the one that ships. Covering both
+  # directories here lets the shared-natives group below bump them in a single
+  # pull request, which a separate entry per directory cannot do.
   - package-ecosystem: 'npm'
-    directory: '/redisinsight'
+    directories:
+      - '/redisinsight'
+      - '/redisinsight/api'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 3
-    cooldown:
-      default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1
-
-    ignore:
-      # Mirrors the api entry: the ABI is coupled to the Electron version.
-      - dependency-name: 'better-sqlite3'
-        update-types: ['version-update:semver-major']
-
-    # No devDependencies here, so the development catch-alls are omitted.
-    groups:
-      production-patch:
-        dependency-type: 'production'
-        update-types: ['patch']
-        patterns: ['*']
-      production-minor:
-        dependency-type: 'production'
-        update-types: ['minor']
-        patterns: ['*']
-
-  - package-ecosystem: 'npm'
-    directory: '/redisinsight/api'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 8
+    open-pull-requests-limit: 10
     cooldown:
       default-days: 3
       semver-major-days: 7
@@ -294,6 +269,13 @@ updates:
         update-types: ['version-update:semver-major']
 
     groups:
+      # Declared in both directories at the same version. `group-by` raises one
+      # pull request per dependency spanning both lockfiles, so the packaged app
+      # and the api tree cannot land different versions of a native module.
+      # Without it each directory gets its own pull request and they drift.
+      shared-natives:
+        group-by: 'dependency-name'
+        patterns: ['better-sqlite3', 'keytar', 'tunnel-ssh']
       typescript:
         patterns: ['typescript']
       # rxjs and reflect-metadata are peers pinned to the framework major.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,10 +75,20 @@ updates:
       - dependency-name: '@faker-js/faker'
         update-types: ['version-update:semver-major']
 
-    # Grouped by what must move together, not by shared name prefix. First
-    # match wins, so a group that would swallow a later group's packages is
-    # listed after it (observability before build-tooling, for instance, so
-    # @sentry/webpack-plugin is not caught by `*-webpack-plugin`).
+    # Grouped by what must move together, not by shared name prefix.
+    #
+    # Membership is decided by *pattern specificity*, not by declaration
+    # order. The docs say "included in the first group that it matches", but
+    # the updater scores patterns (exact name 1000, wildcards penalised by
+    # length, bare `*` 1) and assigns each dependency to its highest-scoring
+    # match. See dependabot/dependabot-core#13044 and #14576. Two consequences:
+    #
+    #   - Every catch-all below carries `patterns: ['*']` so it scores 1 and
+    #     always loses to a named group. A catch-all that omits `patterns`
+    #     entirely wins the comparison instead and silently swallows the named
+    #     groups, which is the bug reported in #14576.
+    #   - Prefer exact names over wildcards where two groups could overlap;
+    #     an exact match at 1000 beats any wildcard deterministically.
     #
     # Groups that span prod and dev deliberately omit `dependency-type`: the
     # catch-alls are split by type, so a coupled pair straddling prod/dev
@@ -117,9 +127,11 @@ updates:
       # compiler rather than to one of ~50 unrelated dev deps.
       typescript:
         patterns: ['typescript', '@aivenio/tsc-output-parser']
-      # Runtime libraries that merely share the `electron-` prefix. Listed
-      # before electron-build so a broken electron-log cannot block a builder
-      # upgrade. New electron-* packages fall through to a catch-all.
+      # Runtime libraries that merely share the `electron-` prefix, kept apart
+      # from the packaging toolchain so a broken electron-log cannot block a
+      # builder upgrade. Named exactly rather than via `electron-*`, which
+      # would collide with electron-build. New electron-* packages fall
+      # through to a catch-all.
       electron-runtime:
         patterns:
           [
@@ -128,9 +140,12 @@ updates:
             'electron-devtools-installer',
             'electron-log',
             'electron-store',
+            '@types/electron-store',
           ]
       # The packaging toolchain, which electron-builder releases in lockstep
-      # (electron-updater and builder-util-runtime ship with it).
+      # (electron-updater and builder-util-runtime ship with it). node-abi maps
+      # Electron versions to native ABI versions, so it has to track the
+      # Electron bump for native rebuilds to resolve.
       electron-build:
         patterns:
           [
@@ -141,6 +156,7 @@ updates:
             'app-builder-lib',
             'builder-util*',
             '@electron/*',
+            'node-abi',
           ]
       storybook:
         patterns: ['storybook', '@storybook/*', 'eslint-plugin-storybook']
@@ -183,8 +199,7 @@ updates:
             'lint-staged',
           ]
       testing:
-        patterns:
-          [
+        patterns: [
             'jest',
             'jest-*',
             'ts-jest',
@@ -195,6 +210,10 @@ updates:
             'ts-mockito',
             'fishery',
             'identity-obj-proxy',
+            # These track their host package's major, so they travel with it
+            # rather than with the rest of @types/*.
+            '@types/jest',
+            '@types/supertest',
           ]
       babel:
         patterns: ['@babel/*', 'babel-*']
@@ -257,24 +276,38 @@ updates:
     groups:
       typescript:
         patterns: ['typescript']
+      # rxjs and reflect-metadata are NestJS peer dependencies pinned to the
+      # framework major, so they cannot move independently of it.
       nestjs:
-        patterns: ['@nestjs/*']
+        patterns: ['@nestjs/*', 'rxjs', 'reflect-metadata']
       # The Redis clients are the core of the product, so they get a
       # reviewable PR of their own rather than riding in a catch-all. Spans
       # prod and dev so ioredis-mock moves with ioredis.
       redis-clients:
-        patterns: ['redis', 'redis-parser', 'ioredis', 'ioredis-mock']
+        patterns:
+          [
+            'redis',
+            'redis-parser',
+            'ioredis',
+            'ioredis-mock',
+            '@types/ioredis-mock',
+          ]
       socketio:
         patterns: ['socket.io', 'socket.io-*']
-      # Unit tests run on jest, integration tests on mocha/chai.
+      # Unit tests run on jest, integration tests on mocha/chai. babel-jest is
+      # released from the jest repo and tracks its major, so it belongs here
+      # rather than with the Babel presets.
       testing:
         patterns:
           [
             'jest',
             'jest-*',
             'ts-jest',
+            'babel-jest',
+            '@types/jest',
             '@faker-js/faker',
             'supertest',
+            '@types/supertest',
             'mocha',
             'mocha-*',
             '@mochajs/*',

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,7 +90,9 @@ updates:
             'redux-thunk',
             'redux-mock-store',
           ]
-      i18n:
+      # Group identifiers take letters, pipes, underscores and hyphens only, so
+      # this cannot be named after the package.
+      internationalization:
         patterns: ['i18next', 'i18next-*', 'react-i18next']
       monaco:
         patterns: ['monaco-editor', 'monaco-yaml', 'react-monaco-editor']


### PR DESCRIPTION
# What

Dependabot currently opens **one PR per outdated package**, weekly - roughly 5-8 PRs a week. Of the last 200 it opened, **162 merged and 31 were closed without merging**. This PR reworks `.github/dependabot.yml` to address the three reasons those 31 existed.

## 1. It was opening PRs that can never merge

**Example - #6303, "bump react-dom and @types/react-dom".**

Dependabot proposed `react-dom` 18.2.0 → 19.2.8 while leaving `react` at 18, because something else in the tree blocks React 19. React has never supported a split major. The PR was broken the moment it was created:

- `@elastic/eui@34.6.0`, which most of the UI is built on, requires `react-dom ^16.12`
- `@testing-library/react@13`, which every UI test uses, requires `react-dom ^18`
- Six Workbench plugins still call `ReactDOM.render`, which React 19 deleted

Nobody could have merged it. It sat open for 10 days with a failing check. And it isn't a one-off: **every major-version PR in the sample was closed unmerged** - `rimraf 3→6`, `lint-staged 16→17`, `electron 39→42`, `@elastic/eui`, `html-react-parser 1→6`, and more.

**Fix:** an `ignore` list of 25 packages whose major is a migration project rather than a bump. Dependabot no longer opens those PRs; we upgrade them by hand when we choose to.

```yaml
- dependency-name: 'react-dom'
  update-types: ['version-update:semver-major']
```

Patches and minors still flow normally for all of them. Only the major is suppressed.

TypeScript gets stricter treatment - minors are suppressed too. CI gates on recorded TypeScript error counts (`.tscheck.rec.json`: **5,595 errors across 871 files**) and fails whether counts go *up* ("more TS errors than recorded") or *down* ("baseline is outdated"). A TypeScript minor shifts those counts nearly every time, and resolving it means a human deciding whether each new error is real.

## 2. One upgrade was arriving as several PRs

**Example - #6300 and #6301, both open right now:**

- #6301: bump `app-builder-lib` and `electron-builder`
- #6300: bump `builder-util-runtime`, `electron-updater` and `electron-builder`

That is **one** electron-builder upgrade split across two PRs that both touch `electron-builder`. They conflict; whichever merges second needs a rebase.

**Fix:** `groups`. Packages that must move together now arrive in a single PR:

```yaml
electron-build:
  patterns: ['electron', 'electron-builder', 'electron-updater',
             'app-builder-lib', 'builder-util*', '@electron/*']
```

There are 20 groups at root and 11 for the api - `react`, `redux`, `storybook`, `linting`, `testing`, `observability`, `virtualization`, `redis-clients` and so on. Anything unmatched falls into a catch-all bundle, so the long tail of small packages arrives as a couple of PRs instead of a dozen.

**The subtle part: group by coupling, not by name.** A first draft used `electron-*`, which quietly swallowed `electron-log`, `electron-store` and `electron-context-menu` - runtime libraries unrelated to packaging. That would let a broken `electron-log` block the builder upgrade, i.e. exactly the problem being fixed. Same class of bug with `*-loader`, which matched `react-window-infinite-loader` (a React list component, not a webpack loader). Both were found by simulating the group matcher against the real dependency lists.

### Why the catch-alls are split by patch vs minor

Bundling has a downside, and there's evidence for it here. #6281 was a 12-package bundle:

```
type-check / tsc baselines      FAILURE
docker-build / Docker Build     FAILURE
Build Linux / Build linux x64   FAILURE
E2E Chromium (Web Build)        FAILURE
```

Closed. Nothing in it indicates which of the 12 broke it, and the 11 innocent packages died with it.

So each catch-all is split by release type: a **patch** bundle (bug fixes only, merge on green) and a **minor** bundle (new behaviour, usually 1-4 packages, worth reading). A broken minor can no longer hold unrelated patches back.

## 3. The api folder wasn't covered

The repo has **12 independent lockfiles**. The old config listed only the root one, and the root lockfile contains no `typeorm` and no `@nestjs/core` - so nothing in `redisinsight/api` was receiving version updates. It only received *security* updates, which GitHub runs repo-wide regardless of config.

This adds an entry for `/redisinsight/api` with its own groups and ignore list (`better-sqlite3`, `@nestjs/*`, `typeorm`). Plugin folders and `tests/e2e-playwright` stay security-only for now.

## Net effect

| Before | After |
|---|---|
| #6303 react-dom major | never created |
| #6301 app-builder-lib + electron-builder | one `electron-build` PR |
| #6300 builder-util-runtime + electron-updater + electron-builder | ↑ same PR |
| #6279 @opentelemetry/core + @sentry/electron | one `observability` PR |
| #6304 github/codeql-action | one `github-actions` PR with all action bumps |
| #6277 webpack + @nestjs/cli in api | one api `nestjs` PR |

Roughly **5-8 PRs/week → 3-5**, with the unmergeable ones gone.

## Deliberately unchanged

- **Security updates.** They run repo-wide, ignore this config, and stay one-per-PR so each fix lands independently. #6309 (`postcss`) is one of these - a transitive dependency, unaffected by any of this.
- The `cooldown` settings (3 days for patches, 7 for majors), which mirror `min-release-age=3` in `.npmrc`.
- The weekly schedule.
- Minor and patch updates for every package, including the 25 with ignored majors.

# Testing

Dependabot config can't be exercised by CI, so verification was done three ways:

1. **Schema validity** - YAML parses; every `groups` sub-key is one of the six the options reference allows (`applies-to`, `dependency-type`, `patterns`, `exclude-patterns`, `update-types`, `group-by`); all `update-types` values are `patch`/`minor`/`major`. `npx prettier --check` passes, which the lint job would otherwise fail on.

2. **Group matcher simulation** - the first-match-wins matching was replayed against the real `package.json` files to confirm every group resolves to the intended packages and no group steals another's. This is what caught the `electron-*` and `*-loader` over-matches; both were fixed and re-verified.

3. **Live run** - once merged, the config takes effect on the next weekly run (Dependabot reads `dependabot.yml` from the default branch only). It can be triggered early via **Insights → Dependency graph → Dependabot → Check for updates**.

One limitation worth stating: the patch/minor catch-all split **cannot** be verified locally, because `update-types` is evaluated against the actual available version bump rather than the package. The keys and values are schema-valid, but the first live run is the real test.

The 7 currently-open Dependabot PRs will not retro-group. #6303, #6301 and #6300 should be closed by hand; the next weekly run regenerates the rest as groups.

---

Refs #6303

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Dependabot configuration; no runtime or application code changes, with security updates still repo-wide and unaffected.
> 
> **Overview**
> **Expands `.github/dependabot.yml` from a minimal root-only setup into a multi-tree policy** that cuts noise and avoids PRs that can never merge.
> 
> The root npm entry now caps open PRs, aligns cooldown with `.npmrc` `min-release-age`, and **ignores semver-major (and TypeScript minor) updates** for packages tied to migrations—React 18, Electron ABI, EUI, virtualization, etc.—while patches/minors still flow.
> 
> **Dependency updates are grouped by coupling** (e.g. `electron-build`, `observability`, `build-tooling`) instead of one PR per package, with **patch vs minor catch-alls** split by prod/dev so a failing minor bundle does not block unrelated patches.
> 
> A **second npm entry covers `/redisinsight` and `/redisinsight/api` together**, using `group-by: dependency-name` for shared natives (`better-sqlite3`, `keytar`, `tunnel-ssh`) plus NestJS/redis/testing groups and api-specific ignores.
> 
> **GitHub Actions bumps are grouped** into a single weekly `github-actions` PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd4771263f0e6b8074326bef555926b8a12e0c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->