### PR TITLE
ci: stop Dependabot proposing major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,10 +87,16 @@ updates:
     # Groups spanning prod and dev omit `dependency-type` so a coupled pair
     # split across the two, such as ioredis and ioredis-mock, can still travel
     # together.
+    #
+    # Every group is limited to patch and minor, so a major matches no group and
+    # arrives on its own. A major is a migration to evaluate in isolation, not
+    # something to bundle with unrelated bumps.
     groups:
       react:
+        update-types: ['patch', 'minor']
         patterns: ['react', 'react-dom', '@types/react', '@types/react-dom']
       redux:
+        update-types: ['patch', 'minor']
         patterns:
           [
             'redux',
@@ -102,11 +108,14 @@ updates:
       # Group identifiers take letters, pipes, underscores and hyphens only, so
       # this cannot be named after the package.
       internationalization:
+        update-types: ['patch', 'minor']
         patterns: ['i18next', 'i18next-cli', 'react-i18next']
       monaco:
+        update-types: ['patch', 'minor']
         patterns: ['monaco-editor', 'monaco-yaml', 'react-monaco-editor']
       # Each companion package is pinned to its host's major.
       virtualization:
+        update-types: ['patch', 'minor']
         patterns:
           [
             'react-virtualized',
@@ -119,10 +128,12 @@ updates:
           ]
       # Isolated so a failing tsc baselines check points at the compiler.
       typescript:
+        update-types: ['patch', 'minor']
         patterns: ['typescript', '@aivenio/tsc-output-parser']
       # Runtime libraries sharing the `electron-` prefix, kept out of the
       # packaging toolchain. Named exactly to avoid colliding with it.
       electron-runtime:
+        update-types: ['patch', 'minor']
         patterns:
           [
             'electron-context-menu',
@@ -135,6 +146,7 @@ updates:
       # electron-builder releases electron-updater and builder-util-runtime in
       # lockstep; node-abi maps Electron versions to native ABI versions.
       electron-build:
+        update-types: ['patch', 'minor']
         patterns:
           [
             'electron',
@@ -147,12 +159,15 @@ updates:
             'node-abi',
           ]
       storybook:
+        update-types: ['patch', 'minor']
         patterns: ['storybook', '@storybook/*', 'eslint-plugin-storybook']
       observability:
+        update-types: ['patch', 'minor']
         patterns: ['@sentry/*', '@opentelemetry/*']
       # Vite builds the renderer, webpack the Electron main and preload
       # bundles, alongside the loaders and plugins pinned to a webpack major.
       build-tooling:
+        update-types: ['patch', 'minor']
         patterns: [
             'vite',
             'vite-*',
@@ -176,6 +191,7 @@ updates:
             '@teamsupercell/typings-for-css-modules-loader',
           ]
       linting:
+        update-types: ['patch', 'minor']
         patterns:
           [
             'eslint',
@@ -186,6 +202,7 @@ updates:
             'lint-staged',
           ]
       testing:
+        update-types: ['patch', 'minor']
         patterns: [
             'jest',
             'jest-*',
@@ -202,13 +219,15 @@ updates:
             '@types/supertest',
           ]
       babel:
+        update-types: ['patch', 'minor']
         patterns: ['@babel/*', 'babel-*']
       redis-ui:
+        update-types: ['patch', 'minor']
         patterns: ['@redis-ui/*', '@redislabsdev/*']
       types:
+        update-types: ['patch', 'minor']
         patterns: ['@types/*']
-      # Split by update-type so a broken minor cannot hold patches back.
-      # Unlocked majors match no catch-all and arrive individually.
+      # Split further so a broken minor cannot hold patches back.
       production-patch:
         dependency-type: 'production'
         update-types: ['patch']
@@ -273,16 +292,23 @@ updates:
       # pull request per dependency spanning both lockfiles, so the packaged app
       # and the api tree cannot land different versions of a native module.
       # Without it each directory gets its own pull request and they drift.
+      #
+      # Majors stay in this group rather than falling through, because a major
+      # arriving outside it would be one pull request per directory again. One
+      # pull request per dependency already keeps these evaluable on their own.
       shared-natives:
         group-by: 'dependency-name'
         patterns: ['better-sqlite3', 'keytar', 'tunnel-ssh']
       typescript:
+        update-types: ['patch', 'minor']
         patterns: ['typescript']
       # rxjs and reflect-metadata are peers pinned to the framework major.
       nestjs:
+        update-types: ['patch', 'minor']
         patterns: ['@nestjs/*', 'rxjs', 'reflect-metadata']
       # Spans prod and dev so ioredis-mock moves with ioredis.
       redis-clients:
+        update-types: ['patch', 'minor']
         patterns:
           [
             'redis',
@@ -292,10 +318,12 @@ updates:
             '@types/ioredis-mock',
           ]
       socketio:
+        update-types: ['patch', 'minor']
         patterns: ['socket.io', 'socket.io-client', 'socket.io-mock']
       # Unit tests run on jest, integration tests on mocha/chai. babel-jest
       # ships from the jest repo and tracks its major, not Babel's.
       testing:
+        update-types: ['patch', 'minor']
         patterns:
           [
             'jest',
@@ -317,8 +345,10 @@ updates:
             'fishery',
           ]
       babel:
+        update-types: ['patch', 'minor']
         patterns: ['@babel/*', 'babel-*']
       types:
+        update-types: ['patch', 'minor']
         patterns: ['@types/*']
       production-patch:
         dependency-type: 'production'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,65 +16,17 @@ updates:
       default-days: 3
       semver-major-days: 7
 
-    # Majors that are migrations rather than bumps. Minors and patches for
-    # these still flow.
     ignore:
-      # Held at 18 by @elastic/eui (peers on react-dom ^16.12) and
-      # @testing-library/react 13 (peers on ^18.0.0), and pinned via overrides.
-      - dependency-name: 'react'
+      # No majors anywhere. A major is a breaking change that needs a branch, a
+      # full test run and an owner, so it belongs in a ticket rather than an
+      # unsolicited pull request. The weekly dependency audit reports which
+      # majors are available so they can be triaged deliberately.
+      - dependency-name: '*'
         update-types: ['version-update:semver-major']
-      - dependency-name: 'react-dom'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/react-dom'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@testing-library/react'
-        update-types: ['version-update:semver-major']
-      # A minor shifts the per-file error counts in .tscheck.rec.json, and the
-      # ratchet fails whether counts rise or fall.
+      # Minors are breaking here too: one shifts the per-file error counts in
+      # .tscheck.rec.json, and the ratchet fails whether counts rise or fall.
       - dependency-name: 'typescript'
-        update-types:
-          ['version-update:semver-major', 'version-update:semver-minor']
-      # Tracks the Node version in .nvmrc, not npm.
-      - dependency-name: '@types/node'
-        update-types: ['version-update:semver-major']
-      # Migrating away from this, so a major is wasted work.
-      - dependency-name: '@elastic/eui'
-        update-types: ['version-update:semver-major']
-      # Native-module ABI is coupled to the Electron version.
-      - dependency-name: 'electron'
-        update-types: ['version-update:semver-major']
-      # Held at v5; v6 is a routing rewrite.
-      - dependency-name: 'react-router-dom'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/react-router-dom'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'html-react-parser'
-        update-types: ['version-update:semver-major']
-      # Virtualization stack, react-18-locked. The types skew from the runtime
-      # unless they are held back too.
-      - dependency-name: 'react-virtualized'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/react-virtualized'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-virtualized-auto-sizer'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-window'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-window-infinite-loader'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/react-window-infinite-loader'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-vtree'
-        update-types: ['version-update:semver-major']
-      # Majors change CLI surface used across scripts.
-      - dependency-name: 'rimraf'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'lint-staged'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@faker-js/faker'
-        update-types: ['version-update:semver-major']
+        update-types: ['version-update:semver-minor']
 
     # Grouped by what must move together, not by shared name prefix.
     #
@@ -88,9 +40,10 @@ updates:
     # split across the two, such as ioredis and ioredis-mock, can still travel
     # together.
     #
-    # Every group is limited to patch and minor, so a major matches no group and
-    # arrives on its own. A major is a migration to evaluate in isolation, not
-    # something to bundle with unrelated bumps.
+    # Every group is limited to patch and minor as well. That overlaps with the
+    # blanket major ignore on purpose: the ignore is the policy, and the filter
+    # keeps the groups correct on their own terms, so narrowing the policy to
+    # named packages later cannot quietly start bundling migrations.
     groups:
       react:
         update-types: ['patch', 'minor']
@@ -264,28 +217,15 @@ updates:
       semver-major-days: 7
 
     ignore:
+      # Same policy as the root entry: majors are tickets, not pull requests.
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+      # Minors that break as hard as a major would.
       - dependency-name: 'typescript'
-        update-types:
-          ['version-update:semver-major', 'version-update:semver-minor']
-      - dependency-name: '@types/node'
-        update-types: ['version-update:semver-major']
-      # Native module compiled against the Electron ABI.
-      - dependency-name: 'better-sqlite3'
-        update-types: ['version-update:semver-major']
-      # A framework major is a migration across every module.
-      - dependency-name: '@nestjs/*'
-        update-types: ['version-update:semver-major']
-      # NestJS peers on rxjs ^7, so a v8 lands outside the supported range.
-      - dependency-name: 'rxjs'
-        update-types: ['version-update:semver-major']
+        update-types: ['version-update:semver-minor']
       # Pre-1.0, so a minor carries breaking schema and driver changes.
       - dependency-name: 'typeorm'
-        update-types:
-          ['version-update:semver-major', 'version-update:semver-minor']
-      - dependency-name: 'rimraf'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@faker-js/faker'
-        update-types: ['version-update:semver-major']
+        update-types: ['version-update:semver-minor']
 
     groups:
       # Declared in both directories at the same version. `group-by` raises one
@@ -293,9 +233,9 @@ updates:
       # and the api tree cannot land different versions of a native module.
       # Without it each directory gets its own pull request and they drift.
       #
-      # Majors stay in this group rather than falling through, because a major
-      # arriving outside it would be one pull request per directory again. One
-      # pull request per dependency already keeps these evaluable on their own.
+      # No update-types filter here. `group-by` already yields one pull request
+      # per dependency, and anything falling outside this group would arrive as
+      # one pull request per directory, which is the drift it prevents.
       shared-natives:
         group-by: 'dependency-name'
         patterns: ['better-sqlite3', 'keytar', 'tunnel-ssh']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,49 +1,54 @@
 version: 2
 
-# Each tree below has its own lockfile, so each needs its own entry.
-# Directories absent here still receive security updates, which run repo-wide
-# and ignore this config.
+# Dependabot configuration: which manifests are watched, how updates are
+# bundled into pull requests, and what is left alone.
+#
+# Each entry below covers manifests that have their own lockfile. Directories
+# absent from this file still receive security updates, which run repo-wide and
+# ignore this configuration.
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
-    # Ceiling for the groups below, not a target.
+    # A group only opens a pull request when it has an update available, so this
+    # is a cap for a busy week rather than an expected number.
     open-pull-requests-limit: 15
     cooldown:
-      # Patches and minors inherit default-days, which matches min-release-age
-      # in .npmrc. A shorter window proposes versions that npm will not resolve.
+      # Days to wait after a release before proposing it. .npmrc sets
+      # min-release-age=3, which stops npm resolving anything newer than that,
+      # so a shorter window here would propose versions nobody can install.
       default-days: 3
-      semver-major-days: 7
 
     ignore:
-      # No majors anywhere. A major is a breaking change that needs a branch, a
-      # full test run and an owner, so it belongs in a ticket rather than an
-      # unsolicited pull request. The weekly dependency audit reports which
-      # majors are available so they can be triaged deliberately.
+      # No major updates, anywhere. A major is a breaking change that needs a
+      # branch, a full test run and someone to own it, so it belongs in planned
+      # work rather than an unsolicited pull request. Patches and minors still
+      # flow for every package.
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
-      # Minors are breaking here too: one shifts the per-file error counts in
-      # .tscheck.rec.json, and the ratchet fails whether counts rise or fall.
+      # CI records a TypeScript error count per file in .tscheck.rec.json and
+      # fails if any count changes in either direction. A compiler minor moves
+      # those counts, so it needs the baselines refreshed by hand.
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-minor']
 
-    # Grouped by what must move together, not by shared name prefix.
+    # Groups bundle related updates into one pull request, by what has to move
+    # together rather than by shared name prefix.
     #
-    # Membership goes to the highest-scoring pattern match rather than to the
-    # first group declared: an exact name outranks a wildcard, which outranks a
-    # bare `*`. Every catch-all therefore declares `patterns: ['*']`. A
-    # catch-all that omits `patterns` outranks the named groups and swallows
-    # them.
+    # A dependency lands in its most specific matching group, not the first one
+    # declared: an exact name beats a wildcard, which beats a bare `*`. The
+    # fallback groups therefore declare `patterns: ['*']` so they score lowest.
+    # A fallback that omits `patterns` outranks the named groups and swallows
+    # them instead.
     #
-    # Groups spanning prod and dev omit `dependency-type` so a coupled pair
-    # split across the two, such as ioredis and ioredis-mock, can still travel
-    # together.
+    # A group covering both runtime and development dependencies leaves out
+    # `dependency-type`, so a pair split across the two, such as ioredis and
+    # ioredis-mock, can still travel together.
     #
-    # Every group is limited to patch and minor as well. That overlaps with the
-    # blanket major ignore on purpose: the ignore is the policy, and the filter
-    # keeps the groups correct on their own terms, so narrowing the policy to
-    # named packages later cannot quietly start bundling migrations.
+    # Each group also filters to patch and minor. That repeats the blanket major
+    # rule above on purpose: if the rule is ever narrowed to named packages, the
+    # groups still will not bundle a breaking change.
     groups:
       react:
         update-types: ['patch', 'minor']
@@ -58,15 +63,16 @@ updates:
             'redux-thunk',
             'redux-mock-store',
           ]
-      # Group identifiers take letters, pipes, underscores and hyphens only, so
-      # this cannot be named after the package.
+      # Group names take letters, pipes, underscores and hyphens only, so this
+      # one cannot be named after the package it covers.
       internationalization:
         update-types: ['patch', 'minor']
         patterns: ['i18next', 'i18next-cli', 'react-i18next']
       monaco:
         update-types: ['patch', 'minor']
         patterns: ['monaco-editor', 'monaco-yaml', 'react-monaco-editor']
-      # Each companion package is pinned to its host's major.
+      # The browser key list renders through these together, and the auto-sizer
+      # and infinite-loader companions are pinned to their host's major.
       virtualization:
         update-types: ['patch', 'minor']
         patterns:
@@ -79,12 +85,14 @@ updates:
             '@types/react-virtualized',
             '@types/react-window-infinite-loader',
           ]
-      # Isolated so a failing tsc baselines check points at the compiler.
+      # On its own, so a failing type-check points at the compiler rather than
+      # at one of the other development dependencies.
       typescript:
         update-types: ['patch', 'minor']
         patterns: ['typescript', '@aivenio/tsc-output-parser']
-      # Runtime libraries sharing the `electron-` prefix, kept out of the
-      # packaging toolchain. Named exactly to avoid colliding with it.
+      # Runtime libraries that only share the `electron-` prefix, kept apart
+      # from the packaging toolchain below. Named exactly so the two groups
+      # cannot claim each other's packages.
       electron-runtime:
         update-types: ['patch', 'minor']
         patterns:
@@ -96,8 +104,9 @@ updates:
             'electron-store',
             '@types/electron-store',
           ]
-      # electron-builder releases electron-updater and builder-util-runtime in
-      # lockstep; node-abi maps Electron versions to native ABI versions.
+      # The packaging toolchain. electron-builder releases electron-updater and
+      # builder-util-runtime in lockstep, and node-abi maps Electron versions to
+      # native module ABI versions.
       electron-build:
         update-types: ['patch', 'minor']
         patterns:
@@ -117,8 +126,9 @@ updates:
       observability:
         update-types: ['patch', 'minor']
         patterns: ['@sentry/*', '@opentelemetry/*']
-      # Vite builds the renderer, webpack the Electron main and preload
-      # bundles, alongside the loaders and plugins pinned to a webpack major.
+      # Two build pipelines: Vite builds the renderer, webpack builds the
+      # Electron main and preload bundles. The loaders and plugins are pinned to
+      # a webpack major, so they move with it.
       build-tooling:
         update-types: ['patch', 'minor']
         patterns: [
@@ -134,8 +144,8 @@ updates:
             'mini-css-extract-plugin',
             '@svgr/webpack',
             'react-refresh',
-            # Named exactly: a `*-loader` glob also catches unrelated packages
-            # such as react-window-infinite-loader.
+            # Loaders are listed by name: a `*-loader` glob also catches
+            # unrelated packages such as react-window-infinite-loader.
             'css-loader',
             'file-loader',
             'style-loader',
@@ -167,7 +177,8 @@ updates:
             'ts-mockito',
             'fishery',
             'identity-obj-proxy',
-            # Track their host's major, so they travel with it.
+            # These follow their host package's major, so they belong here
+            # rather than with the other @types packages.
             '@types/jest',
             '@types/supertest',
           ]
@@ -180,7 +191,8 @@ updates:
       types:
         update-types: ['patch', 'minor']
         patterns: ['@types/*']
-      # Split further so a broken minor cannot hold patches back.
+      # Fallbacks for whatever the groups above do not match, split by patch and
+      # minor so a broken minor cannot hold unrelated patches back.
       production-patch:
         dependency-type: 'production'
         update-types: ['patch']
@@ -198,11 +210,11 @@ updates:
         update-types: ['minor']
         patterns: ['*']
 
-  # One entry for both lockfiles. /redisinsight is the packaged Electron app's
+  # One entry for two lockfiles. /redisinsight is the packaged desktop app's
   # manifest and declares better-sqlite3, keytar and tunnel-ssh at the same
-  # versions as the api tree; its lockfile is the one that ships. Covering both
-  # directories here lets the shared-natives group below bump them in a single
-  # pull request, which a separate entry per directory cannot do.
+  # versions as the api tree, and its lockfile is the one that ships. Covering
+  # both directories from here lets the shared-natives group below update them
+  # in a single pull request, which separate entries cannot do.
   - package-ecosystem: 'npm'
     directories:
       - '/redisinsight'
@@ -211,16 +223,13 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 10
     cooldown:
-      # Patches and minors inherit default-days, which matches min-release-age
-      # in .npmrc. A shorter window proposes versions that npm will not resolve.
       default-days: 3
-      semver-major-days: 7
 
     ignore:
-      # Same policy as the root entry: majors are tickets, not pull requests.
+      # Same policy as the root entry.
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
-      # Minors that break as hard as a major would.
+      # As above: a compiler minor moves the recorded error counts.
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-minor']
       # Pre-1.0, so a minor carries breaking schema and driver changes.
@@ -228,25 +237,24 @@ updates:
         update-types: ['version-update:semver-minor']
 
     groups:
-      # Declared in both directories at the same version. `group-by` raises one
-      # pull request per dependency spanning both lockfiles, so the packaged app
-      # and the api tree cannot land different versions of a native module.
-      # Without it each directory gets its own pull request and they drift.
-      #
-      # No update-types filter here. `group-by` already yields one pull request
-      # per dependency, and anything falling outside this group would arrive as
-      # one pull request per directory, which is the drift it prevents.
+      # Declared in both directories at the same version. `group-by` raises a
+      # single pull request per dependency spanning both lockfiles, so the
+      # packaged app and the api tree cannot end up on different versions of a
+      # native module. No update-types filter, because anything falling outside
+      # this group would arrive as one pull request per directory again.
       shared-natives:
         group-by: 'dependency-name'
         patterns: ['better-sqlite3', 'keytar', 'tunnel-ssh']
       typescript:
         update-types: ['patch', 'minor']
         patterns: ['typescript']
-      # rxjs and reflect-metadata are peers pinned to the framework major.
+      # rxjs and reflect-metadata are NestJS peer dependencies, pinned to the
+      # framework's major.
       nestjs:
         update-types: ['patch', 'minor']
         patterns: ['@nestjs/*', 'rxjs', 'reflect-metadata']
-      # Spans prod and dev so ioredis-mock moves with ioredis.
+      # Covers runtime and development together so ioredis-mock moves with
+      # ioredis.
       redis-clients:
         update-types: ['patch', 'minor']
         patterns:
@@ -260,8 +268,8 @@ updates:
       socketio:
         update-types: ['patch', 'minor']
         patterns: ['socket.io', 'socket.io-client', 'socket.io-mock']
-      # Unit tests run on jest, integration tests on mocha/chai. babel-jest
-      # ships from the jest repo and tracks its major, not Babel's.
+      # Unit tests run on jest, integration tests on mocha and chai. babel-jest
+      # ships from the jest repository and follows its major, not Babel's.
       testing:
         update-types: ['patch', 'minor']
         patterns:
@@ -307,6 +315,9 @@ updates:
         update-types: ['minor']
         patterns: ['*']
 
+  # Actions are versioned through their major tag, so here the majors are the
+  # upgrades worth taking and are deliberately not ignored. One group keeps a
+  # week's action bumps in a single pull request.
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
# What

Follow-up to #6330, based on what its first grouped run produced.

The intent is that patch and minor updates land automatically for everything, while majors are handled deliberately. The first run showed the config was not doing that: **18 major bumps arrived inside five group pull requests**, including `ioredis` 5→6 and `redis` 4→6 bundled together in #6344, and seven majors at once in #6349 (`jest` 29→30, `chai` 4→6 and friends). #6344, #6346 and #6349 all failed CI. They are migration bundles, not flakes.

Two changes:

1. **Majors are ignored outright** on both npm entries. A major is a breaking change needing a branch, a full test run and an owner, so it belongs in planned work. Worth noting: *every* major Dependabot has ever raised on this repo was closed unmerged, so those pull requests were never providing the testing, just an unowned to-do list.
2. **Every named group filters to patch and minor.** This overlaps with the rule above on purpose: if the policy is ever narrowed to named packages, the groups still will not bundle a breaking change.

Grouping is otherwise untouched. Patterns are byte-identical to `main`, so patch and minor updates keep arriving as the same bundles.

The blanket rule subsumes 25 enumerated per-package major rules, which all reduced to the same policy. What survives is the three minor-scoped rules it does not cover: `typescript` in both entries, because a compiler minor moves the `.tscheck.rec.json` counts, and `typeorm`, which is pre-1.0 so its minors break.

`github-actions` is unchanged and still takes majors, since actions are versioned through their major tag.

## Visibility

Blocking majors means they stop being visible, so drift needs to surface elsewhere. That is a follow-up extending [scripts/dependency-audit-report.mjs](scripts/dependency-audit-report.mjs) to report available majors alongside the existing vulnerability report, deliberately not in this pull request. Until it lands, `npm audit` in the Monday report remains the safety net for a CVE fixed only in a next major.

# Testing

Dependabot configuration cannot be exercised by CI, so this was verified three ways:

1. **Grouping preserved.** Parsed this branch against `main` and compared group by group: every `patterns` list is identical.
2. **The policy holds.** Both npm entries carry the blanket rule, and replaying all 18 majors observed in the first run against the new config, **18 of 18** are now blocked.
3. **Comments.** Rewritten for a reader with no context, with no drifting counts and no claims about work that has not landed.

One non-comment cleanup worth flagging: `semver-major-days` is dropped from both npm entries. No major can reach them now, so a major cooldown reads as though some still arrive.

`npx prettier --check` passes, which the lint job would otherwise fail on.

## Open pull requests

#6343, #6344, #6349, #6350 and #6352 are the five major bundles. Closing them is cleaner than untangling; Dependabot keeps one pull request per group per directory, so the next run replaces them with patch and minor only. #6351, #6354, #6355 and #6357 are ordinary and unaffected.

---

Refs #6330

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.github/dependabot.yml` changes automation policy; no runtime, auth, or dependency lockfile updates in this PR.
> 
> **Overview**
> Tightens **Dependabot** so npm PRs no longer bundle or propose **semver-major** upgrades, after grouped runs still shipped majors (e.g. `ioredis`/`redis`, `jest`/`chai`) that failed CI.
> 
> Both root and **redisinsight** npm entries now use a blanket `ignore` on `*` for **version-update:semver-major**, replacing many per-package major blocks. **Patch/minor** flow is unchanged; **typescript** (and **typeorm** on the api tree) still ignore **minors** for baseline/typeorm reasons. Every named **group** adds `update-types: ['patch', 'minor']` as a second guard so groups cannot re-bundle breaking bumps if the global rule is narrowed later. **`semver-major-days`** is removed from cooldown because majors never reach these entries.
> 
> Comments are rewritten for clarity; **github-actions** still allows major tag bumps. Group **patterns** are unchanged from `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a6e2055fdba83dd2345514de2eddc60eda0bd4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->