### PR TITLE
fix(deps): dedupe @sentry/core and align the Sentry packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "@redis-ui/styles": "^15.0.0",
         "@redis-ui/table": "^3.7.0",
         "@reduxjs/toolkit": "^2.12.0",
-        "@sentry/electron": "^7.8.0",
-        "@sentry/react": "^10.39.0",
+        "@sentry/electron": "^7.16.0",
+        "@sentry/react": "^10.69.0",
         "@stablelib/snappy": "^1.0.3",
         "@types/json-dup-key-validator": "^1.0.2",
         "ajv": "^8.18.0",
@@ -253,16 +253,44 @@
       }
     },
     "node_modules/@apm-js-collab/code-transformer": {
-      "version": "0.8.2",
-      "resolved": "https://registry.yarnpkg.com/@apm-js-collab/code-transformer/-/code-transformer-0.8.2.tgz",
-      "integrity": "sha1-oxYPFtHE35y4EwNScoetGNAJlNE= sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA=="
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
+      "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.1",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@apm-js-collab/tracing-hooks": {
-      "version": "0.3.1",
-      "resolved": "https://registry.yarnpkg.com/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.3.1.tgz",
-      "integrity": "sha1-QU06k8OhXYvlQ6P6xWH3xgK2pYg= sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@apm-js-collab/code-transformer": "^0.8.0",
+        "@apm-js-collab/code-transformer": "^0.18.0",
         "debug": "^4.4.1",
         "module-details-from-path": "^1.0.4"
       }
@@ -4718,16 +4746,18 @@
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz",
-      "integrity": "sha1-wbA0beM2ulWvLVp5cIggN7rt7AU= sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.211.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.211.0.tgz",
-      "integrity": "sha1-MtntmJOZVqhNTi/14BWYy50o10Q= sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==",
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -4735,21 +4765,11 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.8.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
-      "integrity": "sha1-JDge84i8KNU/qNrXLf0UKazIIBY= sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.8.0.tgz",
-      "integrity": "sha1-9uht42iL21Smyo9JNTY6W1iK6Rw= sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -4761,12 +4781,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.211.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.211.0.tgz",
-      "integrity": "sha1-1F4g6vp1tdPoqXRaYgUzKJPFXzc= sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==",
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.211.0",
-        "import-in-the-middle": "^2.0.0",
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
         "require-in-the-middle": "^8.0.0"
       },
       "engines": {
@@ -4776,379 +4797,30 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.58.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.58.0.tgz",
-      "integrity": "sha1-49yG6/p9cv6GGmOxwkoGL662Sow= sha512-fjpQtH18J6GxzUZ+cwNhWUpb71u+DzT7rFkg5pLssDGaEber91Y2WNGdpVpwGivfEluMlNMZumzjEqfg8DeKXQ==",
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.54.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.54.0.tgz",
-      "integrity": "sha1-hzEoUIRLbFeXbQC9MlbVVlBUN3I= sha512-43RmbhUhqt3uuPnc16cX6NsxEASEtn8z/cYV8Zpt6EP4p2h9s4FNuJ4Q9BbEQ2C0YlCCB/2crO1ruVz/hWt8fA==",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@types/connect": "3.4.38"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.28.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.28.0.tgz",
-      "integrity": "sha1-uFe7A45KKjtyePPaiaHiELsVM54= sha512-ExXGBp0sUj8yhm6Znhf9jmuOaGDsYfDES3gswZnKr4MCqoBWQdEFn6EoDdt5u+RdbxQER+t43FoUihEfTSqsjA==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.59.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-express/-/instrumentation-express-0.59.0.tgz",
-      "integrity": "sha1-wqx9y0+ZBJJlGECM3077BG5yQ4I= sha512-pMKV/qnHiW/Q6pmbKkxt0eIhuNEtvJ7sUAyee192HErlr+a1Jx+FZ3WjfmzhQL1geewyGEiPGkmjjAgNY8TgDA==",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-fs": {
-      "version": "0.30.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.30.0.tgz",
-      "integrity": "sha1-Xijt3gWR3E/6RxqGpo+R5zf+Mfs= sha512-n3Cf8YhG7reaj5dncGlRIU7iT40bxPOjsBEA5Bc1a1g6e9Qvb+JFJ7SEiMlPbUw4PBmxE3h40ltE8LZ3zVt6OA==",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.211.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.54.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.54.0.tgz",
-      "integrity": "sha1-nzrQztv+UBHv5Ovcdshac6C5Z6Y= sha512-8dXMBzzmEdXfH/wjuRvcJnUFeWzZHUnExkmFJ2uPfa31wmpyBCMxO59yr8f/OXXgSogNgi/uPo9KW9H7LMIZ+g==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.58.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.58.0.tgz",
-      "integrity": "sha1-PKKUukEOBMkg3IKrTKoj7BwuGi4= sha512-+yWVVY7fxOs3j2RixCbvue8vUuJ1inHxN2q1sduqDB0Wnkr4vOzVKRYl/Zy7B31/dcPS72D9lo/kltdOTBM3bQ==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.57.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.57.0.tgz",
-      "integrity": "sha1-J7OkSlFESvMQCjIfLkBiPonlu3U= sha512-Os4THbvls8cTQTVA8ApLfZZztuuqGEeqog0XUnyRW7QVF0d/vOVBEcBCk1pazPFmllXGEdNbbat8e2fYIWdFbw==",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.211.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-http/-/instrumentation-http-0.211.0.tgz",
-      "integrity": "sha1-LxL4Pwwh03kX/ZcQ+1t1XyiFjPY= sha512-n0IaQ6oVll9PP84SjbOCwDjaJasWRHi6BLsbMLiT6tNj7QbVOkuA5sk/EfZczwI0j5uTKl1awQPivO/ldVtsqA==",
-      "dependencies": {
-        "@opentelemetry/core": "2.5.0",
-        "@opentelemetry/instrumentation": "0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0",
-        "forwarded-parse": "2.1.2"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.5.0.tgz",
-      "integrity": "sha1-OyrGz0ce2ahe6oNgSKTed6LlSdM= sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
-      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.59.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.59.0.tgz",
-      "integrity": "sha1-Uw0Gqme3PqcyQUVXrevh3efeQw8= sha512-875UxzBHWkW+P4Y45SoFM2AR8f8TzBMD8eO7QXGCyFSCUMP5s9vtt/BS8b/r2kqLyaRPK6mLbdnZznK3XzQWvw==",
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/redis-common": "^0.38.2",
-        "@opentelemetry/semantic-conventions": "^1.33.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-kafkajs": {
-      "version": "0.20.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.20.0.tgz",
-      "integrity": "sha1-Uh2wbRDTn0LoQs4zblweSLPaKVY= sha512-yJXOuWZROzj7WmYCUiyT27tIfqBrVtl1/TwVbQyWPz7rL0r1Lu7kWjD0PiVeTCIL6CrIZ7M2s8eBxsTAOxbNvw==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.30.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.55.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.55.0.tgz",
-      "integrity": "sha1-/vwX2FShB9masNvIkz1Yl+/OGr0= sha512-FtTL5DUx5Ka/8VK6P1VwnlUXPa3nrb7REvm5ddLUIeXXq4tb9pKd+/ThB1xM/IjefkRSN3z8a5t7epYw1JLBJQ==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.33.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.59.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.59.0.tgz",
-      "integrity": "sha1-ffiFD6GTqPWQ4/vKsAAW4l2ycEE= sha512-K9o2skADV20Skdu5tG2bogPKiSpXh4KxfLjz6FuqIVvDJNibwSdu5UvyyBzRVp1rQMV6UmoIk6d3PyPtJbaGSg==",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.36.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-      "version": "0.55.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.55.0.tgz",
-      "integrity": "sha1-d21fEBeK372nKGtPMa3ei7UY1Vo= sha512-FDBfT7yDGcspN0Cxbu/k8A0Pp1Jhv/m7BMTzXGpcb8ENl3tDj/51U65R5lWzUH15GaZA15HQ5A5wtafklxYj7g==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.64.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.64.0.tgz",
-      "integrity": "sha1-ACfBP911BusfYYmYJF7dJEzCPMc= sha512-pFlCJjweTqVp7B220mCvCld1c1eYKZfQt1p3bxSbcReypKLJTwat+wbL2YZoX9jPi5X2O8tTKFEOahO5ehQGsA==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.57.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.57.0.tgz",
-      "integrity": "sha1-LOPzu/ZqJVlYw6ESqSB5iY1p9iQ= sha512-MthiekrU/BAJc5JZoZeJmo0OTX6ycJMiP6sMOSRTkvz5BrPMYDqaJos0OgsLPL/HpcgHP7eo5pduETuLguOqcg==",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.57.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.57.0.tgz",
-      "integrity": "sha1-dNQqHG0gruk5lvi29re2lGl0h1Q= sha512-HFS/+FcZ6Q7piM7Il7CzQ4VHhJvGMJWjx7EgCkP5AnTntSN5rb5Xi3TkYJHBKeR27A0QqPlGaCITi93fUDs++Q==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0",
-        "@types/mysql": "2.15.27"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.57.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.57.0.tgz",
-      "integrity": "sha1-ko7aR8b0qxk9M2P8qwHYGnCtxGs= sha512-nHSrYAwF7+aV1E1V9yOOP9TchOodb6fjn4gFvdrdQXiRE7cMuffyLLbCZlZd4wsspBzVwOXX8mpURdRserAhNA==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0",
-        "@opentelemetry/sql-common": "^0.41.2"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.63.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.63.0.tgz",
-      "integrity": "sha1-hSylUZ11bGE7ufMVOl5wwrgF5c8= sha512-dKm/ODNN3GgIQVlbD6ZPxwRc3kleLf95hrRWXM+l8wYo+vSeXtEpQPT53afEf6VFWDVzJK55VGn8KMLtSve/cg==",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.34.0",
-        "@opentelemetry/sql-common": "^0.41.2",
-        "@types/pg": "8.15.6",
-        "@types/pg-pool": "2.0.7"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.59.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.59.0.tgz",
-      "integrity": "sha1-RMG9eFLNrb53wb36lBhVKAElWM8= sha512-JKv1KDDYA2chJ1PC3pLP+Q9ISMQk6h5ey+99mB57/ARk0vQPGZTTEb4h4/JlcEpy7AYT8HIGv7X6l+br03Neeg==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/redis-common": "^0.38.2",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.30.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.30.0.tgz",
-      "integrity": "sha1-SokGtTIsSt1BMubghsI+F7wjYms= sha512-bZy9Q8jFdycKQ2pAsyuHYUHNmCxCOGdG6eg1Mn75RvQDccq832sU5OWOBnc12EFUELI6icJkhR7+EQKMBam2GA==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0",
-        "@types/tedious": "^4.0.14"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-undici": {
-      "version": "0.21.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.21.0.tgz",
-      "integrity": "sha1-3LQ6Nkw554IXlGrreqCRVuVfTGw= sha512-gok0LPUOTz2FQ1YJMZzaHcOzDFyT64XJ8M9rNkugk923/p6lDGms/cRW1cqgqp6N6qcd6K6YdVHwPEhnx9BWbw==",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/semantic-conventions": "^1.24.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.7.0"
-      }
-    },
-    "node_modules/@opentelemetry/redis-common": {
-      "version": "0.38.3",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz",
-      "integrity": "sha1-MaBGSkipkcKUCGFONyXZTbfBGu4= sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==",
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha1-m8tlirYlTzMJn0qVVEtA1vU8yUY= sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
-      "dependencies": {
-        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -5159,12 +4831,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.8.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
-      "integrity": "sha1-7JwdaeLm+6JWyd8Mjo1n1COG1Ss= sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -5175,25 +4849,12 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha1-sE5xUcWROnoAbU9GVHnade+5ino= sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/sql-common": {
-      "version": "0.41.2",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
-      "integrity": "sha1-f0oUFmz9bJ/+iQltscx16vZEOxk= sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.1.0"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
@@ -5334,44 +4995,6 @@
       "resolved": "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.25.tgz",
       "integrity": "sha1-8Hf9wLXQB40wiTOW/0gnoT+Z6Bc= sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
       "dev": true
-    },
-    "node_modules/@prisma/instrumentation": {
-      "version": "7.2.0",
-      "resolved": "https://registry.yarnpkg.com/@prisma/instrumentation/-/instrumentation-7.2.0.tgz",
-      "integrity": "sha1-lAmkNtj5jolQyGWa7roEXEoH6JE= sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.207.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.8"
-      }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
-      "version": "0.207.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
-      "integrity": "sha1-rpkcUe7dpVrwN6Pm/B69sSson0k= sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.207.0",
-      "resolved": "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
-      "integrity": "sha1-GlqSHATxcf8oCW+jIK9xPzyH7BQ= sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.207.0",
-        "import-in-the-middle": "^2.0.0",
-        "require-in-the-middle": "^8.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -6982,52 +6605,6 @@
       "integrity": "sha1-YN6JG7Emq/3FQQ/cYWasoGXxCgw= sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true
     },
-    "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.39.0",
-      "resolved": "https://registry.yarnpkg.com/@sentry-internal/browser-utils/-/browser-utils-10.39.0.tgz",
-      "integrity": "sha1-ILidyXp8N/R7WZxCiQxzril0cuY= sha512-W6WODonMGiI13Az5P7jd/m2lj/JpIyuVKg7wE4X+YdlMehLspAv6I7gRE4OBSumS14ZjdaYDpD/lwtnBwKAzcA==",
-      "dependencies": {
-        "@sentry/core": "10.39.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "10.39.0",
-      "resolved": "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-10.39.0.tgz",
-      "integrity": "sha1-EJ4X/VWDc3cNMZDL+EpbiSE78Iw= sha512-cRXmmDeOr5FzVsBNRLU4WDEuC3fhuD0XV362EWl4DI3XBGao8ukaueKcLIKic5WZx6uXimjWw/UJmDLgxeCqkg==",
-      "dependencies": {
-        "@sentry/core": "10.39.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "10.39.0",
-      "resolved": "https://registry.yarnpkg.com/@sentry-internal/replay/-/replay-10.39.0.tgz",
-      "integrity": "sha1-ZTmYUMjK53tPY3vEwgSjAg8hmQk= sha512-obZoYOrUfxIYBHkmtPpItRdE38VuzF1VIxSgZ8Mbtq/9UvCWh+eOaVWU2stN/cVu1KYuYX0nQwBvdN28L6y/JA==",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "10.39.0",
-        "@sentry/core": "10.39.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.39.0",
-      "resolved": "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-10.39.0.tgz",
-      "integrity": "sha1-bcOFDGhbtS0DbUYhlU63d7ahtzo= sha512-TTiX0XWCcqTqFGJjEZYObk93j/sJmXcqPzcu0cN2mIkKnnaHDY3w74SHZCshKqIr0AOQdt1HDNa36s3TCdt0Jw==",
-      "dependencies": {
-        "@sentry-internal/replay": "10.39.0",
-        "@sentry/core": "10.39.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry/babel-plugin-component-annotate": {
       "version": "5.3.0",
       "resolved": "https://registry.yarnpkg.com/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.3.0.tgz",
@@ -7038,15 +6615,30 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.39.0",
-      "resolved": "https://registry.yarnpkg.com/@sentry/browser/-/browser-10.39.0.tgz",
-      "integrity": "sha1-nejhlK6VU3GOo6NJ8qZOUDQrekc= sha512-I50W/1PDJWyqgNrGufGhBYCmmO3Bb159nx2Ut2bKoVveTfgH/hLEtDyW0kHo8Fu454mW+ukyXfU4L4s+kB9aaw==",
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.67.0.tgz",
+      "integrity": "sha512-/ZhsAvte4rYhg0A0RtSFFgAgXhyMOfQIeOAfMfptN+X6IVSYOfkA9jtrP+Ej4+6vlaUFWRir1HweF56y63dEEA==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.39.0",
-        "@sentry-internal/feedback": "10.39.0",
-        "@sentry-internal/replay": "10.39.0",
-        "@sentry-internal/replay-canvas": "10.39.0",
-        "@sentry/core": "10.39.0"
+        "@sentry/browser-utils": "10.67.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0",
+        "@sentry/feedback": "10.67.0",
+        "@sentry/replay": "10.67.0",
+        "@sentry/replay-canvas": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.67.0.tgz",
+      "integrity": "sha512-HUzaf0xAnPAB+OHBkD7N1Py+CTbD5InHulQ/pdhX4JctWtxuwD8odMD1LzdPnW8J6gVHlDVvcVBR8mXMZYSLSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0"
       },
       "engines": {
         "node": ">=18"
@@ -7328,25 +6920,39 @@
       "integrity": "sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I= sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@sentry/core": {
-      "version": "10.39.0",
-      "resolved": "https://registry.yarnpkg.com/@sentry/core/-/core-10.39.0.tgz",
-      "integrity": "sha1-UqT8lI4+Nh4exKaZnCQD74z4Oug= sha512-xCLip2mBwCdRrvXHtVEULX0NffUTYZZBhEUGht0WFL+GNdNQ7gmBOGOczhZlrf2hgFFtDO0fs1xiP9bqq5orEQ==",
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/electron": {
-      "version": "7.8.0",
-      "resolved": "https://registry.yarnpkg.com/@sentry/electron/-/electron-7.8.0.tgz",
-      "integrity": "sha1-627JL9v8OI2YEPcsiaCJQ0guBUo= sha512-uIyG2RW9P7pr+EGRndSeVT9+6vpgdMFc7CmAKvhKVm5M9QRo1L5cxZHJRc6pgIiW7EBNXUGF2hEHC9GJpPzYDw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-7.16.0.tgz",
+      "integrity": "sha512-GgnsAGynr1IKfakRuW5AGlxQsIZi0cFUyzcn9ekrYy1cIyb85piVLN5u7W9pXzSzKopaGrxXBWubPBSRagyXjA==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.39.0",
-        "@sentry/core": "10.39.0",
-        "@sentry/node": "10.39.0"
+        "@sentry/browser": "10.67.0",
+        "@sentry/core": "10.67.0",
+        "@sentry/node": "10.67.0"
       },
       "peerDependencies": {
-        "@sentry/node-native": "10.39.0"
+        "@sentry/node-native": "10.67.0"
       },
       "peerDependenciesMeta": {
         "@sentry/node-native": {
@@ -7354,143 +6960,204 @@
         }
       }
     },
-    "node_modules/@sentry/node": {
-      "version": "10.39.0",
-      "resolved": "https://registry.yarnpkg.com/@sentry/node/-/node-10.39.0.tgz",
-      "integrity": "sha1-1js0V3FaoSh63LmyPoRQ44NDI4g= sha512-dx66DtU/xkCTPEDsjU+mYSIEbzu06pzKNQcDA2wvx7wvwsUciZ5yA32Ce/o6p2uHHgy0/joJX9rP5J/BIijaOA==",
+    "node_modules/@sentry/feedback": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.67.0.tgz",
+      "integrity": "sha512-I4ML2/SF3enwikb6ZSoRiqolQrx0zSzTSnUgwCmugICF/jpHW0th1pCray9R+t1Zzibw/Dpj4t/DNXaSDRa2MA==",
+      "license": "MIT",
       "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^2.5.0",
-        "@opentelemetry/core": "^2.5.0",
-        "@opentelemetry/instrumentation": "^0.211.0",
-        "@opentelemetry/instrumentation-amqplib": "0.58.0",
-        "@opentelemetry/instrumentation-connect": "0.54.0",
-        "@opentelemetry/instrumentation-dataloader": "0.28.0",
-        "@opentelemetry/instrumentation-express": "0.59.0",
-        "@opentelemetry/instrumentation-fs": "0.30.0",
-        "@opentelemetry/instrumentation-generic-pool": "0.54.0",
-        "@opentelemetry/instrumentation-graphql": "0.58.0",
-        "@opentelemetry/instrumentation-hapi": "0.57.0",
-        "@opentelemetry/instrumentation-http": "0.211.0",
-        "@opentelemetry/instrumentation-ioredis": "0.59.0",
-        "@opentelemetry/instrumentation-kafkajs": "0.20.0",
-        "@opentelemetry/instrumentation-knex": "0.55.0",
-        "@opentelemetry/instrumentation-koa": "0.59.0",
-        "@opentelemetry/instrumentation-lru-memoizer": "0.55.0",
-        "@opentelemetry/instrumentation-mongodb": "0.64.0",
-        "@opentelemetry/instrumentation-mongoose": "0.57.0",
-        "@opentelemetry/instrumentation-mysql": "0.57.0",
-        "@opentelemetry/instrumentation-mysql2": "0.57.0",
-        "@opentelemetry/instrumentation-pg": "0.63.0",
-        "@opentelemetry/instrumentation-redis": "0.59.0",
-        "@opentelemetry/instrumentation-tedious": "0.30.0",
-        "@opentelemetry/instrumentation-undici": "0.21.0",
-        "@opentelemetry/resources": "^2.5.0",
-        "@opentelemetry/sdk-trace-base": "^2.5.0",
-        "@opentelemetry/semantic-conventions": "^1.39.0",
-        "@prisma/instrumentation": "7.2.0",
-        "@sentry/core": "10.39.0",
-        "@sentry/node-core": "10.39.0",
-        "@sentry/opentelemetry": "10.39.0",
-        "import-in-the-middle": "^2.0.6",
-        "minimatch": "^9.0.0"
+        "@sentry/core": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.67.0.tgz",
+      "integrity": "sha512-SFKpZGqOCEFSmP93NdDP6ikZp4NS7A/JR8+2ofK3jF6Y9Vyox7pX0pxdOnPLpFcPtMybMahfWqSAWJvsFs4RmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0",
+        "@sentry/node-core": "10.67.0",
+        "@sentry/opentelemetry": "10.67.0",
+        "@sentry/server-utils": "10.67.0",
+        "import-in-the-middle": "^3.0.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.39.0",
-      "resolved": "https://registry.yarnpkg.com/@sentry/node-core/-/node-core-10.39.0.tgz",
-      "integrity": "sha1-9xtzUUh2DLHQk/4wF2pJ6SjWq7g= sha512-xdeBG00TmtAcGvXnZNbqOCvnZ5kY3s5aT/L8wUQ0w0TT2KmrC9XL/7UHUfJ45TLbjl10kZOtaMQXgUjpwSJW+g==",
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.67.0.tgz",
+      "integrity": "sha512-dBHHRwZyan1pOnFJ+sNBvR8TkXbZAfZU/jpxmALS3JZ2/8AGR7cQKL+b7SleKuJ7iUDZyklN3Nqi0i5JkcA+HA==",
+      "license": "MIT",
       "dependencies": {
-        "@apm-js-collab/tracing-hooks": "^0.3.1",
-        "@sentry/core": "10.39.0",
-        "@sentry/opentelemetry": "10.39.0",
-        "import-in-the-middle": "^2.0.6"
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0",
+        "@sentry/opentelemetry": "10.67.0",
+        "import-in-the-middle": "^3.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
         "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
         "@opentelemetry/instrumentation": ">=0.57.1 <1",
-        "@opentelemetry/resources": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/semantic-conventions": "^1.39.0"
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
           "optional": true
         },
-        "@opentelemetry/context-async-hooks": {
+        "@opentelemetry/core": {
           "optional": true
         },
-        "@opentelemetry/core": {
+        "@opentelemetry/exporter-trace-otlp-http": {
           "optional": true
         },
         "@opentelemetry/instrumentation": {
           "optional": true
         },
-        "@opentelemetry/resources": {
-          "optional": true
-        },
         "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        },
-        "@opentelemetry/semantic-conventions": {
           "optional": true
         }
       }
     },
-    "node_modules/@sentry/node/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.39.0",
-      "resolved": "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-10.39.0.tgz",
-      "integrity": "sha1-qIbxxRGx2OqWw8AW+Ov9ICRL234= sha512-eU8t/pyxjy7xYt6PNCVxT+8SJw5E3pnupdcUNN4ClqG4O5lX4QCDLtId48ki7i30VqrLtR7vmCHMSvqXXdvXPA==",
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.67.0.tgz",
+      "integrity": "sha512-oLTOrAK1rOqmYRktOJZwz37B1seXPx1W2FTMVtzTVNjMFA/LZwGzePeZzhUOgzZgfLHixMd/ceWtGqoxAndcjQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.39.0"
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
         "@opentelemetry/core": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/semantic-conventions": "^1.39.0"
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.39.0",
-      "resolved": "https://registry.yarnpkg.com/@sentry/react/-/react-10.39.0.tgz",
-      "integrity": "sha1-GryVRZ4v1F4ijc2xRTqIFzN/GBg= sha512-qxReWHFhDcXNGEyAlYzhR7+K70es+vXaSknTZui1q7TfQwCT1rZlLKn/K8GDpNsb35RC5QhiIphU6pKbyYgZqw==",
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.69.0.tgz",
+      "integrity": "sha512-f0Il/JMteHjdWPNZQB3rtp1Pcj2Leb3p0KSZuv3rh0EUril9CbWtQVy5zJhoAppi+MWWmgRWa+6BpHbQf+ABQA==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.39.0",
-        "@sentry/core": "10.39.0"
+        "@sentry/browser": "10.69.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/@sentry/browser": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.69.0.tgz",
+      "integrity": "sha512-8391tnm96YbR7b8SYfEA/NEIZuyb2r3SZrtAT0bhZtjlujcYWjo7gugQvk8sWLU9cAa/euD00eJoIoJvNfpd7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0",
+        "@sentry/feedback": "10.69.0",
+        "@sentry/replay": "10.69.0",
+        "@sentry/replay-canvas": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/@sentry/browser-utils": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.69.0.tgz",
+      "integrity": "sha512-e/u1Abj0zRPwR/deGZAP3GOULrsx67/XXnM5Skniqs4uxTsdNtPek1Nef0tpxwaQJYxwh6pWdhswLPPbbPOgBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/@sentry/feedback": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.69.0.tgz",
+      "integrity": "sha512-qrGz5Qaw93/IhMjlFN6uIaXeHwgHDaKGa6FkTAP6PonpkvSbGGqan6xfsENxzj9HUVoli1lZ6tMRDnt2qtSPhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/@sentry/replay": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.69.0.tgz",
+      "integrity": "sha512-uRhmNhtFGPOlM0iniVmWKAX3KVXI0le41yYK/iKdPjinT9jA3ZrmykO/Fv1v/KI5znOtwa9D6eHRnDTTMRxFrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react/node_modules/@sentry/replay-canvas": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.69.0.tgz",
+      "integrity": "sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.69.0",
+        "@sentry/replay": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.67.0.tgz",
+      "integrity": "sha512-nkEUgPCR82EcyJkCf3XCE9H0R5KisCqyCAaSGxe7NpAoQbvASHx4MUNgXVAn+D0M494gvPZh6lFH7JgzqTcSqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.67.0",
+        "@sentry/core": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.67.0.tgz",
+      "integrity": "sha512-neNA4T6MFtZzMdKYetiR+LZd9BNSd0q2szMn0wk+A15PqHE/IN7a34V6JZc9rCtmzB0wldh0eWGOBb49MSNKjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.67.0",
+        "@sentry/replay": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/rollup-plugin": {
@@ -7512,6 +7179,21 @@
         "rollup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.67.0.tgz",
+      "integrity": "sha512-GQ9t+RSTx5s3b/aZrLFuL4nrwPLMah5NiZk5cjxJmgmOSgm3nMdO8gdqCedDch5B13F3YsxtaQYjSJnzLz8M5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.1",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/vite-plugin": {
@@ -8902,6 +8584,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha1-W6fzvE+73q/43e2VLl/yzFP42Fg= sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -8910,6 +8593,7 @@
       "version": "24.13.0",
       "resolved": "https://registry.yarnpkg.com/@types/node/-/node-24.13.0.tgz",
       "integrity": "sha1-jTV7uur8zWNp2d5ChGfWm+/cyxk= sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -9525,22 +9209,6 @@
       "resolved": "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz",
       "integrity": "sha1-MbfKZAcSij0rvCf+LSGzRTl/YZc= sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
-    "node_modules/@types/mysql": {
-      "version": "2.15.27",
-      "resolved": "https://registry.yarnpkg.com/@types/mysql/-/mysql-2.15.27.tgz",
-      "integrity": "sha1-+xOw6GFNOdQvQPOBIX7DIVkV8ek= sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/mysql/node_modules/@types/node": {
-      "version": "24.13.0",
-      "resolved": "https://registry.yarnpkg.com/@types/node/-/node-24.13.0.tgz",
-      "integrity": "sha1-jTV7uur8zWNp2d5ChGfWm+/cyxk= sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
     "node_modules/@types/node": {
       "version": "14.14.10",
       "resolved": "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz",
@@ -9568,50 +9236,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz",
       "integrity": "sha1-57Wuu6wVD4tf3UpG5/C9jmXhkQk= sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
-    },
-    "node_modules/@types/pg": {
-      "version": "8.15.6",
-      "resolved": "https://registry.yarnpkg.com/@types/pg/-/pg-8.15.6.tgz",
-      "integrity": "sha1-TfdZC5rFV8vlR54AdOwVQMvdrZs= sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
-      "dependencies": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^2.2.0"
-      }
-    },
-    "node_modules/@types/pg-pool": {
-      "version": "2.0.7",
-      "resolved": "https://registry.yarnpkg.com/@types/pg-pool/-/pg-pool-2.0.7.tgz",
-      "integrity": "sha1-wXlFp0Ry2aO+r45m1apvyTgyhzQ= sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
-      "dependencies": {
-        "@types/pg": "*"
-      }
-    },
-    "node_modules/@types/pg-pool/node_modules/@types/node": {
-      "version": "24.13.0",
-      "resolved": "https://registry.yarnpkg.com/@types/node/-/node-24.13.0.tgz",
-      "integrity": "sha1-jTV7uur8zWNp2d5ChGfWm+/cyxk= sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
-    "node_modules/@types/pg-pool/node_modules/@types/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.yarnpkg.com/@types/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha1-i9A9OsaxkUOo3n1mqdE9oyzZFSY= sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "dependencies": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^2.2.0"
-      }
-    },
-    "node_modules/@types/pg/node_modules/@types/node": {
-      "version": "24.13.0",
-      "resolved": "https://registry.yarnpkg.com/@types/node/-/node-24.13.0.tgz",
-      "integrity": "sha1-jTV7uur8zWNp2d5ChGfWm+/cyxk= sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
     },
     "node_modules/@types/prismjs": {
       "version": "1.26.0",
@@ -9879,22 +9503,6 @@
       "dev": true,
       "dependencies": {
         "@types/superagent": "*"
-      }
-    },
-    "node_modules/@types/tedious": {
-      "version": "4.0.14",
-      "resolved": "https://registry.yarnpkg.com/@types/tedious/-/tedious-4.0.14.tgz",
-      "integrity": "sha1-hoEY56Z4CCWMBRWOnK2JyliirsE= sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/tedious/node_modules/@types/node": {
-      "version": "24.13.0",
-      "resolved": "https://registry.yarnpkg.com/@types/node/-/node-24.13.0.tgz",
-      "integrity": "sha1-jTV7uur8zWNp2d5ChGfWm+/cyxk= sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
-      "dependencies": {
-        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/text-encoding": {
@@ -10599,6 +10207,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha1-TOecib5Ar+ev6POtuQKh8c6awIo= sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10614,14 +10223,6 @@
       "dependencies": {
         "acorn": "^8.1.0",
         "acorn-walk": "^8.0.2"
-      }
-    },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha1-frFVexugXvGLXtDsZ1kb+rBGiO8= sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-import-phases": {
@@ -11264,6 +10865,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.4",
       "resolved": "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz",
@@ -11698,7 +11308,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4= sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4= sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -11791,6 +11402,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -12322,8 +11934,9 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
-      "resolved": "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha1-s8pRAYQziSWa3n2Ix3vQbOVYSco= sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/classnames": {
       "version": "2.3.2",
@@ -14952,10 +14565,10 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha1-9lfNepRI3N2pwHCjy3Xl3B6F9bE= sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "dev": true
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -16137,10 +15750,10 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.yarnpkg.com/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha1-kUGSNPgE2FKoLc7sPhbNwiz52uc= sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
-      "dev": true,
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -16164,7 +15777,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM= sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -16764,11 +16376,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/forwarded-parse": {
-      "version": "2.1.2",
-      "resolved": "https://registry.yarnpkg.com/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
-      "integrity": "sha1-CFEe3aqi3f1WuhETju598RegkyU= sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -18518,14 +18125,17 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "2.0.6",
-      "resolved": "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
-      "integrity": "sha1-GXIze/4CDQX2teAgwTM0VnQ2Mk8= sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
         "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/import-local": {
@@ -21435,7 +21045,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha1-VnY+wJoPqAkd8nh5/ZTRkHjADZE= sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -22068,6 +21677,15 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/methods": {
@@ -22848,8 +22466,9 @@
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
-      "resolved": "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-      "integrity": "sha1-tmL9zZP2yD0/JSidoM6ByNloW5Q= sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/moment": {
       "version": "2.29.4",
@@ -24063,34 +23682,6 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
-    "node_modules/pg-int8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha1-lDvUY79bcbQXARX4D478mgwOt4w= sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/pg-protocol": {
-      "version": "1.14.0",
-      "resolved": "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.14.0.tgz",
-      "integrity": "sha1-wfBFt0J0sAcHjGhxRxQfeF9ZuN4= sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA=="
-    },
-    "node_modules/pg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz",
-      "integrity": "sha1-LQJQ1jZFT3z6O2rgOC/fqAYyVKM= sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "postgres-array": "~2.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.4",
-        "postgres-interval": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/php-serialize": {
       "version": "5.1.3",
       "resolved": "https://registry.yarnpkg.com/php-serialize/-/php-serialize-5.1.3.tgz",
@@ -24903,41 +24494,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha1-cjwJkgg2um0+WvAZ+SvAlxwC5RQ= sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-    },
-    "node_modules/postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha1-SPj84FT7xpZxmZMpuINLdyZS2C4= sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postgres-bytea": {
-      "version": "1.0.1",
-      "resolved": "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
-      "integrity": "sha1-xAs9oCIsUA/x5RxdcBS2C3lpfHo= sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postgres-date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha1-UbwIYAYAXlBhxZHO5yfyUxv2Qag= sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postgres-interval": {
-      "version": "1.2.0",
-      "resolved": "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz",
-      "integrity": "sha1-tGDILLFYdQd4iBmgaqD//bNURpU= sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -26744,8 +26300,9 @@
     },
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
-      "resolved": "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
-      "integrity": "sha1-294lh/ZpOYYm1WsgyGirh78BzOQ= sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
         "module-details-from-path": "^1.0.3"
@@ -27640,6 +27197,12 @@
         "node": "^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -28029,7 +27592,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM= sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
       }
     },
     "form-data": "^4.0.6",
+    "@sentry/core": "10.69.0",
     "@types/react": "18.2.1",
     "@types/react-dom": "18.2.1"
   },
@@ -272,8 +273,8 @@
     "@redis-ui/styles": "^15.0.0",
     "@redis-ui/table": "^3.7.0",
     "@reduxjs/toolkit": "^2.12.0",
-    "@sentry/electron": "^7.8.0",
-    "@sentry/react": "^10.39.0",
+    "@sentry/electron": "^7.16.0",
+    "@sentry/react": "^10.69.0",
     "@stablelib/snappy": "^1.0.3",
     "@types/json-dup-key-validator": "^1.0.2",
     "ajv": "^8.18.0",


### PR DESCRIPTION
# What

Unblocks #6356 and #6279, which both fail `type-check / tsc baselines` with:

```
Property '_notifyingListeners' is protected but type 'Scope' is not a class derived from 'Scope'
Error: There are more TS errors than previously recorded
```

That is not a type error in our code. It is two copies of `@sentry/core` in the tree, each defining its own `Scope` class. TypeScript refuses to pass one where the other is expected, because `protected` members require shared class ancestry rather than a matching shape.

## Why it happens

`@sentry/electron` and `@sentry/react` each pin `@sentry/core` to an **exact** version. On `main` both happen to ask for `10.39.0`, so npm hoists a single copy and everything type-checks:

| | `@sentry/electron` | pins core | `@sentry/react` | pins core | copies of core |
| --- | --- | --- | --- | --- | --- |
| `main` | 7.8.0 | `10.39.0` | 10.39.0 | `10.39.0` | **1** |
| #6356 | 7.16.0 | `10.67.0` | 10.69.0 | `10.69.0` | **10** |

So the alignment on `main` is coincidence rather than design, and any independent bump of either package breaks it. #6356 bumps both together and still fails, because the versions they pin have diverged upstream. This will recur on every future Sentry bump until the tree is pinned.

## What this does

Moves `@sentry/electron` and `@sentry/react` together and adds one `overrides` entry so the tree holds a single `@sentry/core` regardless of what each package asks for:

```json
"overrides": {
  "@sentry/core": "10.69.0"
}
```

`overrides` is already used in this manifest for the same purpose, for example `semver`, `form-data` and the nested `prismjs` and `path-to-regexp` entries.

Pinned to an exact version rather than a range on purpose: when these packages diverge again, the pin should fail visibly instead of quietly nesting copies. That matches the existing entries in the block, which are exact for the same reason.

## Worth a reviewer's attention

This overrides an exact upstream pin: `@sentry/electron@7.16.0` asks for `@sentry/core@10.67.0` and gets `10.69.0`. They are two patch releases apart on the same minor line, so the risk is small, but it is deliberately overruling what its authors shipped against.

Sentry initialises in the Electron main process, so if the override were wrong, error reporting would stop silently rather than fail loudly. A green type-check is necessary but not sufficient here. Someone should run the packaged app and confirm an error still reaches Sentry before this is relied on.

`@sentry/browser`, `@sentry/browser-utils`, `@sentry/feedback`, `@sentry/replay` and `@sentry/replay-canvas` remain duplicated at 10.67.0 and 10.69.0. That is deliberate: only `Scope` from `@sentry/core` crosses the boundary that produced the error, and the baselines confirm nothing else regressed. Overriding all of them would widen the blast radius for no evidence of a problem.

# Testing

Ran every project in the baseline gate against the change. All four match their recorded counts exactly, so no baseline refresh is needed:

| Project | Recorded errors | Result |
| --- | --- | --- |
| ui | 1292 | no new errors |
| api | 3992 | no new errors |
| desktop | 311 | no new errors |
| configs | 0 | clean |

Also checked:

- The tree holds exactly **one** `@sentry/core` at `10.69.0`, down from ten copies.
- `package-lock.json` retains all 19 `"libc"` entries, so musl and arm packaging is unaffected. Regenerated with npm 11.13.0.
- `npx prettier --check` passes on both changed files.

Not covered by CI, and the reason for the reviewer note above: whether Sentry still reports from the packaged desktop build.

One incidental finding while testing this, worth its own issue rather than fixing here: when `tsc` runs out of memory, it exits with no output, and `scripts/ts-error-check.ts` reads the empty output as every error being fixed. The first local run reported "Great! You fixed 1292 errors!" purely because `tsc` had crashed. A heap exhaustion should not be able to read as success.

## Follow-up

Once this is on `main`, #6356 and #6279 should both go green on rebase. #6279 carries the `@opentelemetry/core` advisory fix, which is transitive and only reachable through that PR.

---

Refs #6356, #6279

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Overrides `@sentry/electron`'s pinned core version and changes error-reporting dependencies; runtime Sentry behavior in the packaged Electron app should be verified manually.
> 
> **Overview**
> Bumps **`@sentry/electron`** to `^7.16.0` and **`@sentry/react`** to `^10.69.0`, and adds an npm **`overrides`** pin so **`@sentry/core`** resolves to a single **`10.69.0`** copy. That addresses duplicate `Scope` types from multiple `@sentry/core` versions that break `tsc` baselines when electron and react pin different core releases.
> 
> The lockfile refresh pulls in the newer Sentry stack (including a slimmer OpenTelemetry footprint under `@sentry/node`) as a consequence of those version bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0571e16ca2651a6e152a4fb9e6878e959c7cd66f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->