### PR TITLE
chore(api): drop the glob override and stop deep-importing from @nestjs/swagger

### DIFF
--- a/redisinsight/api/package-lock.json
+++ b/redisinsight/api/package-lock.json
@@ -3864,22 +3864,6 @@
         }
       }
     },
-    "node_modules/@nestjs/cli/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28= sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@nestjs/cli/node_modules/fork-ts-checker-webpack-plugin": {
       "version": "9.1.0",
       "resolved": "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-9.1.0.tgz",
@@ -3921,39 +3905,18 @@
       }
     },
     "node_modules/@nestjs/cli/node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.yarnpkg.com/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha1-T4JlduTrmcfa04N5PS+fCPZ+UKY= sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@nestjs/cli/node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha1-lodgMPRQUCBH/H6Mf8+M6BJOQ64= sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-      "dev": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3966,10 +3929,11 @@
       "dev": true
     },
     "node_modules/@nestjs/cli/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha1-QP037f/PrkspQDecByLcbuqnXyQ= sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -4014,16 +3978,17 @@
       }
     },
     "node_modules/@nestjs/cli/node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha1-S2VyN2z9i4EfypzR9cJLPLrA/hA= sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4070,18 +4035,6 @@
       "dev": true,
       "peerDependencies": {
         "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/@nestjs/cli/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ= sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@nestjs/cli/node_modules/tsconfig-paths": {
@@ -11121,9 +11074,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha1-k6libOXl5mvU24aEnnUV6SNApwc= sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }

--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -60,9 +60,6 @@
     "supertest": {
       "form-data": "^4.0.4"
     },
-    "@nestjs/cli": {
-      "glob": "11.1.0"
-    },
     "@nestjs/swagger": {
       "js-yaml": "^4.3.0"
     },

--- a/redisinsight/api/src/decorators/api-endpoint.decorator.ts
+++ b/redisinsight/api/src/decorators/api-endpoint.decorator.ts
@@ -1,6 +1,10 @@
 import { applyDecorators, HttpCode } from '@nestjs/common';
-import { ApiExcludeEndpoint, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { ApiResponseOptions } from '@nestjs/swagger/dist/decorators/api-response.decorator';
+import {
+  ApiExcludeEndpoint,
+  ApiOperation,
+  ApiResponse,
+  ApiResponseOptions,
+} from '@nestjs/swagger';
 import config, { Config } from 'src/utils/config';
 import { BuildType } from 'src/modules/server/models/server';
 


### PR DESCRIPTION
# What

Follow-up to the two review comments on #6342, each in its own commit.

## 1. Drop the `@nestjs/cli` glob override

`redisinsight/api/package.json` pinned `glob` to `11.1.0` inside `@nestjs/cli`. Tracing it back, that arrived as a yarn resolution in #5208 (RI-7742) and was translated verbatim to an npm override by the yarn-to-npm migration in #6216.

Its purpose was **GHSA-5j98-mcp5-4vw2** (high, `glob` command injection via `-c/--cmd`), which affects `>= 11.0.0, < 11.1.0` and is patched in exactly `11.1.0`. `@nestjs/cli` declared `glob 11.0.1` at the time, inside that range, so the pin pushed it up and out. It was a forward pin, not a hold-back.

That has now inverted. `@nestjs/cli@11.0.24`, which #6342 brought in, declares `glob 13.0.6` - outside the advisory range. The pin no longer protects anything and only stops the CLI running against the version it ships with, on every local `nest build` and `start:dev`.

**Ordering mattered here:** removing this before #6342 landed would have reopened the advisory, because the CLI declared `glob 11.0.3` on the previous `main`. It is only safe now.

## 2. Import `ApiResponseOptions` from the package root

`api-endpoint.decorator.ts` reached into `@nestjs/swagger/dist/decorators/api-response.decorator`. Version 11.4.3 added an `exports` map listing only `.`, `./plugin` and `./package.json`, so that subpath is no longer a public entry point.

Nothing breaks today: the binding is used only in a type position, so the import is elided, and the api resolves modules with the classic algorithm, which ignores `exports` maps. It is a tripwire rather than a live fault - changing `moduleResolution`, enabling `verbatimModuleSyntax`, or moving the api build to SWC would each turn it into a failure, with a confusing error.

The type is re-exported from the root (`index.d.ts` → `./decorators` → `./api-response.decorator`), so the public import is equivalent.

# Testing

- **glob resolution.** The regenerated api lockfile puts `glob 13.0.6` under `@nestjs/cli`, matching what it declares. Checked every `glob` copy in the tree for the advisory range `[11.0.0, 11.1.0)`: **none**. The other copies are 7.2.3, and 10.5.0 under `mocha` and `typeorm`, all outside it.
- **Type-check.** `npm run type-check --prefix redisinsight/api` reports 3992 errors, exactly the recorded baseline, so no new errors and no baseline refresh. This runs against the installed `@nestjs/swagger@11.4.6` with its `exports` map in place, which is the case the old deep import would eventually have failed on.
- **No deep imports remain.** `grep -rn "@nestjs/swagger/dist" redisinsight/api/src` returns nothing.
- `npx eslint` on the changed file and `npx prettier --check` on all three files pass.
- Lockfile regenerated with npm 11.13.0 from `redisinsight/api`, with `postinstall` intact.

Not covered by CI: whether `@nestjs/cli` 11.0.24 behaves correctly with `glob 13.0.6`. It is the combination upstream ships and tests, which is the argument for removing the override rather than keeping it, but a local `nest build` in `redisinsight/api` is worth a spot check.

---

Refs #6342

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tooling lockfile cleanup and a type-only import path change; no runtime API or security-sensitive logic changes.
> 
> **Overview**
> Removes the **`@nestjs/cli` → `glob` 11.1.0** npm override now that the CLI depends on **`glob` 13.0.6**, which is outside the patched advisory range. The lockfile updates nested `@nestjs/cli` dependencies accordingly (e.g. `glob` 13.0.6, bumped `lru-cache`, `path-scurry`, `minipass`) and drops transitive packages tied to the old `glob` 11 tree.
> 
> **`api-endpoint.decorator.ts`** now imports **`ApiResponseOptions`** from **`@nestjs/swagger`** instead of a **`dist/decorators/...`** path, aligning with the package’s public `exports` map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67c0abb87eab09a7faa260d74dc72d75e28c708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->