### PR TITLE
Fix dependabot package-lock.json drift

### DIFF
--- a/redisinsight/api/package-lock.json
+++ b/redisinsight/api/package-lock.json
@@ -6015,6 +6015,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile metadata only; no runtime or dependency version changes.
> 
> **Overview**
> Aligns **`redisinsight/api/package-lock.json`** with npm’s lockfile metadata so Dependabot stops reporting drift.
> 
> The only change is adding **`"hasInstallScript": true`** on the **`better-sqlite3`** lock entry (native addon install). No dependency version or **`package.json`** updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df53c3cd077500c8cea6420e58d67578e025af19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->