### PR TITLE
fix(api): restore named enum schemas for NodeRole and HealthStatus

### DIFF
--- a/redisinsight/api/src/modules/cluster-monitor/models/cluster-node-details.ts
+++ b/redisinsight/api/src/modules/cluster-monitor/models/cluster-node-details.ts
@@ -48,7 +48,6 @@ export class ClusterNodeDetails {
   port: number;
 
   @ApiProperty({
-    type: String,
     enum: NodeRole,
     enumName: 'NodeRole',
     description: 'Node role in cluster',
@@ -63,7 +62,6 @@ export class ClusterNodeDetails {
   primary?: string;
 
   @ApiProperty({
-    type: String,
     enum: HealthStatus,
     enumName: 'HealthStatus',
     description: "Node's current health status",


### PR DESCRIPTION
# What

`@ApiProperty` on `ClusterNodeDetails.role` / `.health` passed `type: String`
alongside `enum` + `enumName`. Those two options are mutually exclusive: an
explicit `type` overwrites the reflected enum type that Nest's schema resolver
needs, so it inlines the enum instead of registering
`components/schemas/NodeRole` / `HealthStatus`.

Without those named schemas, `@hey-api/openapi-ts` has nothing to emit, and the
generated `apiClient` stopped exporting both enums — breaking the UI
type-check in `src/mocks/factories/cluster/ClusterNodeDetails.factory.ts` and
`src/mocks/handlers/analytics/clusterDetailsHandlers.ts` (4 × TS2305).

Dropping `type: String` matches the other 62 `enumName` usages in the codebase
and the shape Nest documents. Spec-only change; no runtime behaviour changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Swagger/OpenAPI decorator-only change on DTO metadata; no request handling, auth, or data logic is modified.
> 
> **Overview**
> Fixes OpenAPI generation for **`ClusterNodeDetails.role`** and **`.health`** by removing **`type: String`** from their `@ApiProperty` decorators while keeping **`enum`** + **`enumName`**.
> 
> Nest’s schema resolver treats an explicit `type` as overriding the reflected enum, which inlined those enums instead of registering **`components/schemas/NodeRole`** and **`HealthStatus`**. That broke **`@hey-api/openapi-ts`** exports and caused UI **`TS2305`** errors in cluster mocks/handlers. **No runtime API behavior changes**—OpenAPI/Swagger metadata only, aligned with other `enumName` usages in the API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcc6ba55da8a820c13eb09fe7e6ebeadd7d6d9d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->