### PR TITLE
fix(configs): use modern module resolution in the build config project

### DIFF
--- a/configs/tsconfig.json
+++ b/configs/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
-    "moduleResolution": "node16",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,

--- a/configs/tsconfig.json
+++ b/configs/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "CommonJS",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
# What

## The background

When code says `import { thing } from 'some-package'`, TypeScript has to go and find `thing`. The rule it follows is the `moduleResolution` setting, and there are two eras of it:

- **`"node"`** - the legacy rule. Poke around inside the package's folders looking for matching filenames.
- **`"nodenext"`** - the modern rule. Read the package's own declaration of what it publishes, and use only that.

Modern packages ship an `exports` map: a list saying *these are my official entry points, and here is where each one lives*. The legacy rule does not read that list at all.

## What broke

`@sentry/webpack-plugin@5.4.0` was restructured upstream. It no longer contains the implementation; it is now a thin forwarder:

```ts
// @sentry/webpack-plugin@5.4.0 -> dist/types/index.d.ts
export * from "@sentry/bundler-plugins/webpack";
```

`@sentry/bundler-plugins` publishes `./webpack` **only** through its `exports` map. There is no folder of that name to stumble across. Forwarding like that only resolves if you read the declaration.

Under the legacy rule TypeScript found nothing, so the re-export produced nothing, and it reported every member as missing:

```
configs/webpack.config.main.prod.ts(6,10): error TS2305: Module
'"@sentry/webpack-plugin"' has no exported member 'sentryWebpackPlugin'
```

Which is misleading. `sentryWebpackPlugin` is there. We were looking the wrong way.

## Why this is worth doing on its own merits

**It was going to happen regardless of Sentry.** Tested against TypeScript 5.9, the previous `moduleResolution: "node"` produces the identical error with no dependency change involved. The legacy setting was already incompatible with a compiler upgrade; the Dependabot PR just surfaced it first. Every package that modernises this way will trip it again.

**The legacy rule hides problems in both directions.** As well as missing official entry points, it happily resolves paths a package never meant to expose. Those keep working until something changes the resolver, then break together. There was one of those in the api tree until recently, reaching into `@nestjs/swagger/dist/...`.

## Why `nodenext` specifically

The files in `configs/` are executed by **Node**, through `ts-node`, during the desktop build. Nothing bundles them. The type checker should therefore model Node's resolution, which is what `nodenext` does, tracking the version pinned in `.nvmrc` (24.16.0).

`bundler` would be wrong here: it permits specifiers Node rejects at runtime. It is the right choice for `redisinsight/ui`, whose sources Vite processes, not for build scripts Node runs.

Both settings move together because they have to. An intermediate `moduleResolution: "node16"` with `module: "CommonJS"` passes on TypeScript 4.9 but fails on 5.9 with `TS5110: Option 'module' must be set to 'Node16' when option 'moduleResolution' is set to 'Node16'`.

# Testing

This tsconfig is not only the type-check gate - it is also `TS_NODE_PROJECT` for `build:main`, `build:main:stage` and `build:stage`, so a mistake here could break the desktop build rather than just a check. Verified accordingly:

**The build output is unchanged.** Built the main bundle twice, once with each setting:

```
module CommonJS / moduleResolution node       -> main.js  sha256 857a6470...572d18c3
module nodenext / moduleResolution nodenext   -> main.js  sha256 857a6470...572d18c3
```

Byte-for-byte identical. `moduleResolution` affects only where the checker looks, never the emitted code. 
**Forward-compatible:** 0 errors under TypeScript 5.9 as well as the currently-resolved 4.9.5.

**Other projects unaffected:** api 3992 and desktop 311, both exact baselines. ui unchanged.

`prettier --check` passes.

## Incidentally

This unblocks #6374. That PR should go green on rebase once this lands, with no changes of its own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1ff7b5013162819a0a8f70dd0311ad4e7a94a064. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->