### PR TITLE
RI-8373 Run E2E on dependency branches and stop label events cancelling CI runs

### DIFF
--- a/.github/workflows/tests-e2e-playwright-v2.yml
+++ b/.github/workflows/tests-e2e-playwright-v2.yml
@@ -1,7 +1,25 @@
 name: E2E Playwright Tests (v2)
 
+# E2E is expensive, so it does not run on every pull request. These are the only
+# cases where it runs:
+#
+#   1. Dependabot opens a dependency PR. Its branch is `dependabot/**`, and the
+#      push that creates that branch starts this workflow.
+#   2. Dependabot rebases a dependency PR. That is another push to the same
+#      branch, so the run restarts on the new commit.
+#   3. Someone adds `e2e-tests` or `run-all-tests` to a PR.
+#   4. The nightly schedule, at 00:00 UTC.
+#   5. Someone starts it by hand from the Actions tab.
+#
+# `skip-e2e` on a PR overrides cases 1, 2 and 3. It stops a run already going and
+# keeps later ones off.
+#
+# Opening a PR or pushing to it does not start E2E unless the branch is
+# `dependabot/**`. Case 3 is how you ask for it, and removing then re-adding the
+# label is how you rerun it.
+
 on:
-  # Manual trigger
+  # Case 5.
   workflow_dispatch:
     inputs:
       environment:
@@ -15,47 +33,104 @@ on:
         type: boolean
         default: false
 
-  # Trigger on PR with label (remove and re-add label to rerun)
+  # Cases 1 and 2. The branch name is the only way to limit this to Dependabot: a
+  # `pull_request` trigger cannot filter on who opened the PR, so it would start a
+  # run on every PR in the repo just to work out that it is not wanted.
+  push:
+    branches: ['dependabot/**']
+
+  # Case 3, and `skip-e2e`.
   pull_request:
     types: [labeled]
 
-  # Nightly schedule (0 AM UTC)
+  # Case 4.
   schedule:
     - cron: '0 0 * * *'
 
-# Cancel in-progress runs for the same PR/branch
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # One run per branch at a time. A new push replaces the one already going,
+  # which is what case 2 needs.
+  #
+  # The key is the branch rather than the PR so that a push (cases 1 and 2) and a
+  # label (case 3) on the same PR land in the same group. That is what lets
+  # `skip-e2e` stop a run a push started.
+  #
+  # The `-noop-<run id>` on the end puts labels this workflow ignores in a group
+  # of their own, where they cancel nothing. Without it every label added to a PR
+  # would kill the run: the group is worked out before any job `if` is read, so
+  # skipping the jobs is too late. Dependabot adds `dependencies` and `javascript`
+  # twice each within two seconds, so this matters on every dependency PR.
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}${{
+    github.event.action == 'labeled' &&
+    !contains(fromJSON('["e2e-tests","run-all-tests","skip-e2e"]'), github.event.label.name)
+    && format('-noop-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
 jobs:
-  # Check if workflow should run (for PR label trigger)
+  # Works out which case this event is, and whether it runs anything.
   check-trigger:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
+      # A push event carries no PR, so the labels have to be fetched to honour
+      # `skip-e2e` in cases 1 and 2.
+      - name: Read labels for the pushed branch
+        id: pushed-pr
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          labels=$(gh pr list --head "$BRANCH" --state open --json labels \
+            --jq '[.[0].labels[].name] | join(",")' || true)
+          echo "labels=$labels" >> "$GITHUB_OUTPUT"
+
       - name: Check trigger conditions
         id: check
         env:
           EVENT_NAME: ${{ github.event_name }}
-          HAS_E2E_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'e2e-tests') }}
-          HAS_RUN_ALL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}
-          HAS_DEPENDENCIES_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+          ACTION: ${{ github.event.action }}
+          LABEL_ADDED: ${{ github.event.label.name }}
+          PUSHED_PR_LABELS: ${{ steps.pushed-pr.outputs.labels }}
+          HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-e2e') }}
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
-          elif [[ "$EVENT_NAME" == "schedule" ]]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
-          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
-            if [[ "$HAS_E2E_LABEL" == "true" || "$HAS_RUN_ALL_LABEL" == "true" || "$HAS_DEPENDENCIES_LABEL" == "true" ]]; then
-              echo "should_run=true" >> $GITHUB_OUTPUT
-            else
-              echo "should_run=false" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "should_run=false" >> $GITHUB_OUTPUT
-          fi
+          # Case 3. The same list appears in the concurrency group above, next to
+          # `skip-e2e`. Changing one without the other breaks quietly.
+          OPT_IN_LABELS='e2e-tests run-all-tests'
+
+          should_run=false
+          case "$EVENT_NAME" in
+            workflow_dispatch | schedule)
+              # Cases 4 and 5, always.
+              should_run=true
+              ;;
+            push)
+              # Cases 1 and 2. The branch filter has already narrowed this to
+              # dependency branches, so `skip-e2e` is the only thing left to check.
+              if [[ ",$PUSHED_PR_LABELS," != *",skip-e2e,"* ]]; then
+                should_run=true
+              fi
+              ;;
+            pull_request)
+              if [[ "$HAS_SKIP_LABEL" == "true" ]]; then
+                # `skip-e2e` wins, even when an opt-in label arrives after it.
+                should_run=false
+              elif [[ "$ACTION" == "labeled" ]]; then
+                # Case 3. Every other label reaches this point too, in its own
+                # concurrency group, and leaves should_run false.
+                for label in $OPT_IN_LABELS; do
+                  [[ "$LABEL_ADDED" == "$label" ]] && should_run=true
+                done
+              fi
+              ;;
+          esac
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
 
   # Lint and type-check E2E code
   lint:
@@ -168,4 +243,3 @@ jobs:
                   - title: "Electron (Linux)"
                     value: "${{ needs.e2e-electron.result }}"
                     short: true
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,21 @@
 name: ✅ Tests
 
+# Runs on every pull request. Which suites run is decided per PR from the changed
+# files plus these labels: `run-all-tests`, `run-frontend-tests`,
+# `run-backend-tests`, `run-integration-tests`.
+#
+# Three cases:
+#
+#   1. A PR is opened, or a commit is pushed to it. Any run already going is
+#      replaced.
+#   2. One of the four labels above is added, to widen what the PR runs.
+#   3. Any other label is added. Nothing runs. This case exists only so that
+#      labels aimed elsewhere, such as `e2e-tests` or Dependabot's own
+#      `dependencies` and `javascript`, cannot disturb case 1. See the
+#      concurrency note below.
+
 on:
+  # Cases 1, 2 and 3.
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
@@ -39,13 +54,33 @@ on:
         default: false
         type: boolean
 
-# One in-flight run per PR; a new commit cancels the previous run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # One run per PR at a time. A new commit replaces the one already going, which
+  # is case 1.
+  #
+  # The `-noop-<run id>` on the end puts case 3 in a group of its own, where it
+  # cancels nothing. Without it, any label added to a PR would kill the run and
+  # start the whole suite again: the group is worked out before any job `if` is
+  # read, so skipping the jobs is too late. Dependabot adds `dependencies` and
+  # `javascript` twice each within two seconds of opening a PR, so without this
+  # every dependency PR loses the run that opening it started.
+  #
+  # The label list is repeated on the `changes` and `lint` jobs below. Changing
+  # one without the others breaks quietly.
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{
+    github.event.action == 'labeled' &&
+    !contains(fromJSON('["run-all-tests","run-frontend-tests","run-backend-tests","run-integration-tests"]'), github.event.label.name)
+    && format('-noop-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
 jobs:
+  # Skipped in case 3, which is what makes that run do nothing. Every job after
+  # this one skips with it, through `needs`.
   changes:
+    if: >-
+      github.event.action != 'labeled' ||
+      contains(fromJSON('["run-all-tests","run-frontend-tests","run-backend-tests","run-integration-tests"]'), github.event.label.name)
     permissions:
       contents: read
       pull-requests: read
@@ -168,6 +203,11 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   lint:
+    # No `needs`, so it cannot inherit the skip from `changes` and repeats the
+    # same condition to stay out of case 3.
+    if: >-
+      github.event.action != 'labeled' ||
+      contains(fromJSON('["run-all-tests","run-frontend-tests","run-backend-tests","run-integration-tests"]'), github.event.label.name)
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -280,12 +280,15 @@ jobs:
 
   clean:
     uses: ./.github/workflows/clean-deployments.yml
-    if: ${{ always() && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork != true }}
+    # `always()` runs this even when every test job skips, so it needs its own
+    # guard to stay out of case 3 and not delete deployments for a run that does
+    # no work.
+    if: ${{ always() && needs.changes.result != 'skipped' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork != true }}
     permissions:
       actions: write
       contents: read
       deployments: write
-    needs: [frontend-tests, backend-tests, integration-tests]
+    needs: [changes, frontend-tests, backend-tests, integration-tests]
 
   # Remove artifacts from github actions
   remove-artifacts:


### PR DESCRIPTION
# What

Two trigger problems on the PR workflows.

**1. Label events cancel each other's runs.** Adding any label to a PR starts a full pipeline. Every run for one PR shares a concurrency group with `cancel-in-progress: true`, so each new run kills the one before it. Dependabot adds four labels within two seconds (`dependencies`, `javascript`, then both again), so every dependency PR ends up with 9 runs of which 7 are cancelled. No real compute is wasted - the cancelled runs die in ~2s before any job starts - but the check list becomes unreadable. That matters because `main` has **no required status checks**: review is the only gate, so a reviewer being able to read the checks *is* the safety mechanism.

**2. E2E never reruns when the code changes.** It only triggers on `labeled`. Dependabot auto-rebases its PRs when the base moves, and all of them touch `package-lock.json`, so merging one rebases the rest. A dependency PR can therefore be merged with an E2E result belonging to a different commit, or none at all for the new head SHA.

## Changes

- **E2E triggers on pushes to `dependabot/**` instead of on the `dependencies` label.** A branch filter is the only way to express "Dependabot only" - `pull_request` has no filter for who opened a PR, so it would have to start a run on every PR just to work out it isn't wanted. Rebases are pushes too, which fixes problem 2.
- **Label events a workflow doesn't act on go into a throwaway concurrency group** where they cancel nothing. This has to live in the `concurrency` key: the group is resolved *before* any job `if` is read, so gating the jobs is too late.
- **New `skip-e2e` label** turns E2E off for a PR, dependency PRs included.
- Both files now open with a numbered list of the cases in which they run, and each trigger, concurrency clause and job condition names the case it serves.

## Behaviour

### E2E Playwright Tests (v2)

| Scenario | Before | After |
|---|---|---|
| Someone opens a PR | no run | no run |
| Someone pushes to a PR | no run | no run |
| Someone adds `e2e-tests` / `run-all-tests` | runs | runs |
| Push to a PR that opted in | no rerun | no rerun (re-add the label) |
| A label E2E ignores is added | **kills any running E2E, then does nothing** | no-op run, cancels nothing |
| `skip-e2e` is added | n/a | stops the run, keeps it off |
| **Dependabot opens a PR** | **4 runs, 3 cancelled** | **1 run, 0 cancelled** |
| **Dependabot rebases** | **no rerun - result belongs to the old commit** | **reruns on the new commit** |

### ✅ Tests

| Scenario | Before | After |
|---|---|---|
| PR opened, or a commit pushed | runs, replaces the previous run | unchanged |
| A `run-*-tests` label is added | runs, replaces the previous run | unchanged |
| `e2e-tests` is added | **restarts the whole suite** | no-op run |
| A label it ignores is added | **restarts the whole suite** | no-op run |
| **Dependabot opens a PR** | **5 runs, 4 cancelled** | **1 run, 0 cancelled** |
| Dependabot rebases | runs, replaces the previous run | unchanged |

## Examples

**A dependency PR**, using the real timings from #6388:

```
Before                                   After
────────────────────────────────────     ────────────────────────────────────
4 label events in 2s                     1 push to dependabot/…/virtualization
  E2E run A                                E2E: 1 run, completes
  E2E run B, cancels A                   4 label events in 2s
  E2E run C, cancels B                     E2E: 4 no-op runs
  E2E run D, cancels C → completes         ✅ Tests: 4 no-op runs
  ✅ Tests: 5 runs, 4 cancelled           PR opened
                                           ✅ Tests: 1 run, completes
= 9 runs, 7 cancelled                    = 10 runs, 0 cancelled
```

Run count barely moves. What changes is that nothing is destroyed mid-flight, and the 8 no-ops finish in seconds having executed nothing.

**A PR asking for E2E:** adding `e2e-tests` used to start E2E *and* restart `✅ Tests` from scratch. Now `✅ Tests` gets a no-op run and keeps its existing result.

**A rebase:** Dependabot force-pushes `dependabot/npm_and_yarn/babel-…`. Before, `✅ Tests` reran and E2E did not. Now both rerun on the new commit and cancel their previous runs.

# Testing

Verified locally:

- Both files parse as YAML, and all four multi-line expressions fold to single lines. Over-indented continuation lines inside a `>-` block are preserved as literal newlines within `${{ }}`, which was worth checking explicitly.
- `npx prettier --check` clean on both.
- `check-trigger`'s decision logic extracted into a shell harness and run against **15 scenarios** covering every row above, including `skip-e2e` on a pushed branch, the PR-lookup-returns-nothing fallback, and a guard that a label named `skip-e2e-later` does not match `skip-e2e`.

Two things cannot be verified locally and need eyes on the first dependency PR after merge:

1. **That Dependabot's push triggers the workflow at all.** Runs attributed to `dependabot[bot]` get a read-only token and restricted secrets. The current `pull_request` runs work and the restriction keys on the actor rather than the event, so `push` should behave the same - but the failure mode is *silence*.
2. **That `push` and `labeled` share a concurrency group.** `github.ref_name` and `github.event.pull_request.head.ref` should both be `dependabot/npm_and_yarn/…`.

---

Refs #RI-8373

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI trigger and concurrency logic for the main test and E2E workflows, so a mistake could silently skip needed runs or cancel real ones. Behavior on Dependabot push events still needs post-merge verification.
> 
> **Overview**
> Fixes two CI trigger bugs: ignored labels no longer cancel in-flight runs, and Dependabot rebases now re-run E2E on the new commit.
> 
> **E2E** now starts from pushes to `dependabot/**` instead of the `dependencies` label, so opens and rebases both get a fresh run. Adds a `skip-e2e` label that cancels and blocks E2E, including on dependency branches.
> 
> **Both** `tests.yml` and the E2E workflow put labels they ignore into a throwaway `-noop-<run id>` concurrency group, so Dependabot’s burst of labels (and other unrelated labels) no longer kill the real suite. Matching job `if`s keep those no-op runs from doing work, and `clean` is gated so it does not tear down deployments for them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 124cd2e452a56948da6a05578681d93e2d6a08e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->