### PR TITLE
RI-8373 Use a literal encryption key for E2E tests

### DIFF
--- a/.github/workflows/tests-e2e-playwright-chromium.yml
+++ b/.github/workflows/tests-e2e-playwright-chromium.yml
@@ -29,11 +29,8 @@ jobs:
       E2E_CLOUD_DATABASE_PORT: ${{ secrets.E2E_CLOUD_DATABASE_PORT }}
       E2E_CLOUD_DATABASE_NAME: ${{ secrets.E2E_CLOUD_DATABASE_NAME }}
       E2E_CLOUD_API_SECRET_KEY: ${{ secrets.E2E_CLOUD_API_SECRET_KEY }}
-      # A literal, not a secret. It encrypts credentials for the throwaway Redis
-      # containers this job creates and destroys, so there is nothing to protect.
-      # Runs whose actor is dependabot[bot] cannot read Actions secrets, and an
-      # unset secret arrives as an empty string, which sends the API to the OS
-      # keychain that a CI runner does not have.
+      # Not a secret: dependabot[bot] runs cannot read Actions secrets, and this
+      # only encrypts credentials for this job's throwaway Redis containers.
       E2E_RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
       RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
       TEST_BIG_DB_DUMP: ${{ secrets.TEST_BIG_DB_DUMP }}

--- a/.github/workflows/tests-e2e-playwright-chromium.yml
+++ b/.github/workflows/tests-e2e-playwright-chromium.yml
@@ -29,8 +29,13 @@ jobs:
       E2E_CLOUD_DATABASE_PORT: ${{ secrets.E2E_CLOUD_DATABASE_PORT }}
       E2E_CLOUD_DATABASE_NAME: ${{ secrets.E2E_CLOUD_DATABASE_NAME }}
       E2E_CLOUD_API_SECRET_KEY: ${{ secrets.E2E_CLOUD_API_SECRET_KEY }}
-      E2E_RI_ENCRYPTION_KEY: ${{ secrets.E2E_RI_ENCRYPTION_KEY }}
-      RI_ENCRYPTION_KEY: ${{ secrets.E2E_RI_ENCRYPTION_KEY }}
+      # A literal, not a secret. It encrypts credentials for the throwaway Redis
+      # containers this job creates and destroys, so there is nothing to protect.
+      # Runs whose actor is dependabot[bot] cannot read Actions secrets, and an
+      # unset secret arrives as an empty string, which sends the API to the OS
+      # keychain that a CI runner does not have.
+      E2E_RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
+      RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
       TEST_BIG_DB_DUMP: ${{ secrets.TEST_BIG_DB_DUMP }}
 
     outputs:

--- a/.github/workflows/tests-e2e-playwright-docker.yml
+++ b/.github/workflows/tests-e2e-playwright-docker.yml
@@ -29,8 +29,14 @@ jobs:
       E2E_CLOUD_DATABASE_PORT: ${{ secrets.E2E_CLOUD_DATABASE_PORT }}
       E2E_CLOUD_DATABASE_NAME: ${{ secrets.E2E_CLOUD_DATABASE_NAME }}
       E2E_CLOUD_API_SECRET_KEY: ${{ secrets.E2E_CLOUD_API_SECRET_KEY }}
-      E2E_RI_ENCRYPTION_KEY: ${{ secrets.E2E_RI_ENCRYPTION_KEY }}
-      RI_ENCRYPTION_KEY: ${{ secrets.E2E_RI_ENCRYPTION_KEY }}
+      # A literal, not a secret. It encrypts credentials for the throwaway Redis
+      # containers this job creates and destroys, so there is nothing to protect.
+      # Runs whose actor is dependabot[bot] cannot read Actions secrets, and an
+      # unset secret arrives as an empty string, which sends the API to the OS
+      # keychain that a CI runner does not have. The container reads it through
+      # `RI_ENCRYPTION_KEY: $E2E_RI_ENCRYPTION_KEY` in docker.web.docker-compose.yml.
+      E2E_RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
+      RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
       TEST_BIG_DB_DUMP: ${{ secrets.TEST_BIG_DB_DUMP }}
 
     outputs:

--- a/.github/workflows/tests-e2e-playwright-docker.yml
+++ b/.github/workflows/tests-e2e-playwright-docker.yml
@@ -29,12 +29,8 @@ jobs:
       E2E_CLOUD_DATABASE_PORT: ${{ secrets.E2E_CLOUD_DATABASE_PORT }}
       E2E_CLOUD_DATABASE_NAME: ${{ secrets.E2E_CLOUD_DATABASE_NAME }}
       E2E_CLOUD_API_SECRET_KEY: ${{ secrets.E2E_CLOUD_API_SECRET_KEY }}
-      # A literal, not a secret. It encrypts credentials for the throwaway Redis
-      # containers this job creates and destroys, so there is nothing to protect.
-      # Runs whose actor is dependabot[bot] cannot read Actions secrets, and an
-      # unset secret arrives as an empty string, which sends the API to the OS
-      # keychain that a CI runner does not have. The container reads it through
-      # `RI_ENCRYPTION_KEY: $E2E_RI_ENCRYPTION_KEY` in docker.web.docker-compose.yml.
+      # Not a secret: dependabot[bot] runs cannot read Actions secrets, and this
+      # only encrypts credentials for this job's throwaway Redis containers.
       E2E_RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
       RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
       TEST_BIG_DB_DUMP: ${{ secrets.TEST_BIG_DB_DUMP }}

--- a/.github/workflows/tests-e2e-playwright-electron.yml
+++ b/.github/workflows/tests-e2e-playwright-electron.yml
@@ -29,8 +29,13 @@ jobs:
       E2E_CLOUD_DATABASE_PORT: ${{ secrets.E2E_CLOUD_DATABASE_PORT }}
       E2E_CLOUD_DATABASE_NAME: ${{ secrets.E2E_CLOUD_DATABASE_NAME }}
       E2E_CLOUD_API_SECRET_KEY: ${{ secrets.E2E_CLOUD_API_SECRET_KEY }}
-      E2E_RI_ENCRYPTION_KEY: ${{ secrets.E2E_RI_ENCRYPTION_KEY }}
-      RI_ENCRYPTION_KEY: ${{ secrets.E2E_RI_ENCRYPTION_KEY }}
+      # A literal, not a secret. It encrypts credentials for the throwaway Redis
+      # containers this job creates and destroys, so there is nothing to protect.
+      # Runs whose actor is dependabot[bot] cannot read Actions secrets, and an
+      # unset secret arrives as an empty string, which sends the API to the OS
+      # keychain that a CI runner does not have.
+      E2E_RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
+      RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
       TEST_BIG_DB_DUMP: ${{ secrets.TEST_BIG_DB_DUMP }}
       # Environment variables needed for Electron/AppImage on Linux (from repository variables)
       DBUS_SESSION_BUS_ADDRESS: ${{ vars.DBUS_SESSION_BUS_ADDRESS || 'unix:path=/dev/null' }}
@@ -153,7 +158,8 @@ jobs:
           # Electron uses HTTPS (with TLS certificates)
           RI_ELECTRON_API_URL: 'https://localhost:5530'
           RI_SOCKETS_CORS: 'true'
-          RI_ENCRYPTION_KEY: ${{ secrets.E2E_RI_ENCRYPTION_KEY }}
+          # Matches the job-level value; see the note there.
+          RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
           RI_ENCRYPTION_KEYTAR: 'false'
           # Disable TLS certificate validation for self-signed certs (like old tests do)
           NODE_TLS_REJECT_UNAUTHORIZED: '0'

--- a/.github/workflows/tests-e2e-playwright-electron.yml
+++ b/.github/workflows/tests-e2e-playwright-electron.yml
@@ -29,11 +29,8 @@ jobs:
       E2E_CLOUD_DATABASE_PORT: ${{ secrets.E2E_CLOUD_DATABASE_PORT }}
       E2E_CLOUD_DATABASE_NAME: ${{ secrets.E2E_CLOUD_DATABASE_NAME }}
       E2E_CLOUD_API_SECRET_KEY: ${{ secrets.E2E_CLOUD_API_SECRET_KEY }}
-      # A literal, not a secret. It encrypts credentials for the throwaway Redis
-      # containers this job creates and destroys, so there is nothing to protect.
-      # Runs whose actor is dependabot[bot] cannot read Actions secrets, and an
-      # unset secret arrives as an empty string, which sends the API to the OS
-      # keychain that a CI runner does not have.
+      # Not a secret: dependabot[bot] runs cannot read Actions secrets, and this
+      # only encrypts credentials for this job's throwaway Redis containers.
       E2E_RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
       RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
       TEST_BIG_DB_DUMP: ${{ secrets.TEST_BIG_DB_DUMP }}
@@ -158,7 +155,6 @@ jobs:
           # Electron uses HTTPS (with TLS certificates)
           RI_ELECTRON_API_URL: 'https://localhost:5530'
           RI_SOCKETS_CORS: 'true'
-          # Matches the job-level value; see the note there.
           RI_ENCRYPTION_KEY: 'e2e-tests-encryption-key'
           RI_ENCRYPTION_KEYTAR: 'false'
           # Disable TLS certificate validation for self-signed certs (like old tests do)


### PR DESCRIPTION
# What

E2E has never passed on a Dependabot PR. Across the whole history of the workflow: **23 failures, 70 cancellations, 0 successes** for `dependabot[bot]` runs, while every success belongs to a human actor.

The cause is that runs whose actor is `dependabot[bot]` cannot read Actions secrets, so `E2E_RI_ENCRYPTION_KEY` resolves to an empty string. With no key the API falls back to the OS keychain, which a CI runner doesn't have, and every request touching a saved connection answers `503 KeytarUnavailable`. Playwright then hits `maxFailures: 20` and abandons the rest of the suite - which is why these runs always report an identical `21 failed / 6 passed / 273 did not run`.

That key encrypts credentials for Redis containers that live for the duration of one job, so it protects nothing. This makes it a literal in the three E2E job files. E2E now works for every actor, and an unset secret can no longer become an empty string.

# Testing

Not provable on this PR: adding `e2e-tests` here makes me the actor, and secrets already work for human actors.

For `pull_request` events reusable workflows resolve from the PR's own commit, so a Dependabot PR only picks this up once its branch contains it. After merge, run `@dependabot rebase` on #6399 (three dev-only patch bumps) and check its E2E goes green.

---

Refs #RI-8373

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that hardcodes a non-production encryption key used solely for ephemeral E2E Redis containers; no production auth or secret handling is affected.
> 
> **Overview**
> Makes E2E Playwright jobs runnable for `dependabot[bot]` by replacing `secrets.E2E_RI_ENCRYPTION_KEY` with a hardcoded `'e2e-tests-encryption-key'` in the Chromium, Docker, and Electron workflows.
> 
> Dependabot cannot read Actions secrets, so the previous secret resolved empty and the API fell back to keytar (unavailable in CI), causing mass `KeytarUnavailable` failures. The key only encrypts credentials for throwaway Redis containers in that job, so it is no longer treated as a secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eaaecf4f95f37e256ec3d4d1717d5dc2e944f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->