### PR TITLE
RI-8373 Re-configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,26 @@ updates:
       # those counts, so it needs the baselines refreshed by hand.
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-minor']
+      # An upgrade needs manual visual work, such as colors and paddings, so the
+      # design system moves by hand. Patch and minor are named rather than
+      # ignoring the package outright: a bare `dependency-name` would also
+      # suppress security updates for it.
+      - dependency-name: '@redis-ui/*'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']
+      # Pre-1.0, so a minor carries breaking editor API changes. The same bump
+      # has twice failed lint, type-check and the Linux build.
+      - dependency-name: 'monaco-editor'
+        update-types: ['version-update:semver-minor']
+      # Follows the monaco-editor API, and pre-1.0 for the same reason.
+      - dependency-name: 'react-monaco-editor'
+        update-types: ['version-update:semver-minor']
+      # Pinned to a prerelease. 3.0.0 changes the tree typings, and leaving a
+      # prerelease for its release counts as neither patch, minor nor major, so
+      # the blanket major rule above does not hold it back. Pinned by version
+      # instead, until someone takes the upgrade with the code changes it needs.
+      - dependency-name: 'react-vtree'
+        versions: ['>= 3.0.0']
 
     # Groups bundle related updates into one pull request. A group opens at most
     # one pull request, so the number of groups here sets how many arrive in a
@@ -92,8 +112,6 @@ updates:
             'react-vtree',
             '@types/react-virtualized',
             '@types/react-window-infinite-loader',
-            '@redis-ui/*',
-            '@redislabsdev/*',
           ]
       # The packaging toolchain and the Electron runtime libraries. electron-builder
       # releases electron-updater and builder-util-runtime in lockstep, and node-abi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      # Overnight, so the batch and the CI it starts finish before the working
+      # day. Without a day and time GitHub picks, which lands it mid-afternoon.
+      time: '02:00'
+      timezone: 'Europe/Sofia'
     # A group only opens a pull request when it has an update available, so this
     # is a cap for a busy week rather than an expected number.
     open-pull-requests-limit: 15
@@ -188,6 +193,9 @@ updates:
       - '/redisinsight/api'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '02:00'
+      timezone: 'Europe/Sofia'
     open-pull-requests-limit: 10
     # Same reason as the root entry.
     rebase-strategy: 'disabled'
@@ -270,6 +278,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '02:00'
+      timezone: 'Europe/Sofia'
     cooldown:
       default-days: 3
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,50 +37,49 @@ updates:
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-minor']
 
-    # Groups bundle related updates into one pull request, by what has to move
-    # together rather than by shared name prefix.
+    # Groups bundle related updates into one pull request. A group opens at most
+    # one pull request, so the number of groups here sets how many arrive in a
+    # week. They are split by what has to move together, and by what a reviewer
+    # checks: a failing `electron` group points at packaging, a failing
+    # `frontend` group points at the renderer.
     #
     # A dependency lands in its most specific matching group, not the first one
     # declared: an exact name beats a wildcard, which beats a bare `*`. The
-    # fallback groups therefore declare `patterns: ['*']` so they score lowest.
-    # A fallback that omits `patterns` outranks the named groups and swallows
-    # them instead.
+    # catch-all therefore declares `patterns: ['*']` so it scores lowest. A
+    # catch-all that omits `patterns` outranks the named groups and swallows them
+    # instead.
     #
     # A group covering both runtime and development dependencies leaves out
-    # `dependency-type`, so a pair split across the two, such as ioredis and
-    # ioredis-mock, can still travel together.
+    # `dependency-type`, so a pair split across the two can still travel
+    # together.
     #
-    # Each group also filters to patch and minor. That repeats the blanket major
-    # rule above on purpose: if the rule is ever narrowed to named packages, the
-    # groups still will not bundle a breaking change.
+    # Only the catch-all omits `update-types`. An update matching no group opens
+    # its own pull request, and a prerelease reaching its release version counts
+    # as a major, so a patch-and-minor filter there would let those escape.
     groups:
-      react:
+      # The renderer: anything whose upgrade shows up as a visual or behavioural
+      # change in the UI.
+      frontend:
         update-types: ['patch', 'minor']
-        patterns: ['react', 'react-dom', '@types/react', '@types/react-dom']
-      redux:
-        update-types: ['patch', 'minor']
-        patterns:
-          [
+        patterns: [
+            'react',
+            'react-dom',
+            '@types/react',
+            '@types/react-dom',
             'redux',
             'react-redux',
             '@reduxjs/toolkit',
             'redux-thunk',
             'redux-mock-store',
-          ]
-      # Group names take letters, pipes, underscores and hyphens only, so this
-      # one cannot be named after the package it covers.
-      internationalization:
-        update-types: ['patch', 'minor']
-        patterns: ['i18next', 'i18next-cli', 'react-i18next']
-      monaco:
-        update-types: ['patch', 'minor']
-        patterns: ['monaco-editor', 'monaco-yaml', 'react-monaco-editor']
-      # The browser key list renders through these together, and the auto-sizer
-      # and infinite-loader companions are pinned to their host's major.
-      virtualization:
-        update-types: ['patch', 'minor']
-        patterns:
-          [
+            'i18next',
+            'i18next-cli',
+            'react-i18next',
+            'monaco-editor',
+            'monaco-yaml',
+            'react-monaco-editor',
+            # The browser key list renders through these together, and the
+            # auto-sizer and infinite-loader companions are pinned to their
+            # host's major.
             'react-virtualized',
             'react-virtualized-auto-sizer',
             'react-window',
@@ -88,30 +87,14 @@ updates:
             'react-vtree',
             '@types/react-virtualized',
             '@types/react-window-infinite-loader',
+            '@redis-ui/*',
+            '@redislabsdev/*',
           ]
-      # On its own, so a failing type-check points at the compiler rather than
-      # at one of the other development dependencies.
-      typescript:
-        update-types: ['patch', 'minor']
-        patterns: ['typescript', '@aivenio/tsc-output-parser']
-      # Runtime libraries that only share the `electron-` prefix, kept apart
-      # from the packaging toolchain below. Named exactly so the two groups
-      # cannot claim each other's packages.
-      electron-runtime:
-        update-types: ['patch', 'minor']
-        patterns:
-          [
-            'electron-context-menu',
-            'electron-debug',
-            'electron-devtools-installer',
-            'electron-log',
-            'electron-store',
-            '@types/electron-store',
-          ]
-      # The packaging toolchain. electron-builder releases electron-updater and
-      # builder-util-runtime in lockstep, and node-abi maps Electron versions to
-      # native module ABI versions.
-      electron-build:
+      # The packaging toolchain and the Electron runtime libraries. electron-builder
+      # releases electron-updater and builder-util-runtime in lockstep, and node-abi
+      # maps Electron versions to native module ABI versions. Kept separate because
+      # a failure here needs an installed app to reproduce.
+      electron:
         update-types: ['patch', 'minor']
         patterns:
           [
@@ -123,17 +106,17 @@ updates:
             'builder-util*',
             '@electron/*',
             'node-abi',
+            'electron-context-menu',
+            'electron-debug',
+            'electron-devtools-installer',
+            'electron-log',
+            'electron-store',
+            '@types/electron-store',
           ]
-      storybook:
-        update-types: ['patch', 'minor']
-        patterns: ['storybook', '@storybook/*', 'eslint-plugin-storybook']
-      observability:
-        update-types: ['patch', 'minor']
-        patterns: ['@sentry/*', '@opentelemetry/*']
-      # Two build pipelines: Vite builds the renderer, webpack builds the
-      # Electron main and preload bundles. The loaders and plugins are pinned to
-      # a webpack major, so they move with it.
-      build-tooling:
+      # Two build pipelines plus the linters and the compiler. Vite builds the
+      # renderer, webpack builds the Electron main and preload bundles. Breakage
+      # here stops the build rather than changing behaviour.
+      tooling:
         update-types: ['patch', 'minor']
         patterns: [
             'vite',
@@ -156,21 +139,25 @@ updates:
             'ts-loader',
             'url-loader',
             '@teamsupercell/typings-for-css-modules-loader',
-          ]
-      linting:
-        update-types: ['patch', 'minor']
-        patterns:
-          [
+            'typescript',
+            '@aivenio/tsc-output-parser',
             'eslint',
             'eslint-*',
             '@typescript-eslint/*',
             'prettier',
             'prettier-*',
             'lint-staged',
+            '@babel/*',
+            'babel-*',
+            'storybook',
+            '@storybook/*',
           ]
+      # Test tooling only. A failure here is usually the test runner rather than
+      # the application, so it stays out of `tooling`.
       testing:
         update-types: ['patch', 'minor']
-        patterns: [
+        patterns:
+          [
             'jest',
             'jest-*',
             'ts-jest',
@@ -181,37 +168,13 @@ updates:
             'ts-mockito',
             'fishery',
             'identity-obj-proxy',
-            # These follow their host package's major, so they belong here
-            # rather than with the other @types packages.
             '@types/jest',
             '@types/supertest',
           ]
-      babel:
-        update-types: ['patch', 'minor']
-        patterns: ['@babel/*', 'babel-*']
-      redis-ui:
-        update-types: ['patch', 'minor']
-        patterns: ['@redis-ui/*', '@redislabsdev/*']
-      types:
-        update-types: ['patch', 'minor']
-        patterns: ['@types/*']
-      # Fallbacks for whatever the groups above do not match, split by patch and
-      # minor so a broken minor cannot hold unrelated patches back.
-      production-patch:
-        dependency-type: 'production'
-        update-types: ['patch']
-        patterns: ['*']
-      production-minor:
-        dependency-type: 'production'
-        update-types: ['minor']
-        patterns: ['*']
-      development-patch:
-        dependency-type: 'development'
-        update-types: ['patch']
-        patterns: ['*']
-      development-minor:
-        dependency-type: 'development'
-        update-types: ['minor']
+      # Everything the groups above do not match, including @types/* and the
+      # observability packages. No `update-types`, so nothing can escape into a
+      # pull request of its own.
+      everything-else:
         patterns: ['*']
 
   # One entry for two lockfiles. /redisinsight is the packaged desktop app's
@@ -251,29 +214,26 @@ updates:
       shared-natives:
         group-by: 'dependency-name'
         patterns: ['better-sqlite3', 'keytar', 'tunnel-ssh']
-      typescript:
-        update-types: ['patch', 'minor']
-        patterns: ['typescript']
-      # rxjs and reflect-metadata are NestJS peer dependencies, pinned to the
-      # framework's major.
-      nestjs:
-        update-types: ['patch', 'minor']
-        patterns: ['@nestjs/*', 'rxjs', 'reflect-metadata']
-      # Covers runtime and development together so ioredis-mock moves with
-      # ioredis.
-      redis-clients:
+      # The API and everything it talks to. rxjs and reflect-metadata are NestJS
+      # peer dependencies pinned to the framework's major, and ioredis-mock moves
+      # with ioredis, so this group leaves out `dependency-type`.
+      backend:
         update-types: ['patch', 'minor']
         patterns:
           [
+            '@nestjs/*',
+            'rxjs',
+            'reflect-metadata',
             'redis',
             'redis-parser',
             'ioredis',
             'ioredis-mock',
             '@types/ioredis-mock',
+            'socket.io',
+            'socket.io-client',
+            'socket.io-mock',
+            'typescript',
           ]
-      socketio:
-        update-types: ['patch', 'minor']
-        patterns: ['socket.io', 'socket.io-client', 'socket.io-mock']
       # Unit tests run on jest, integration tests on mocha and chai. babel-jest
       # ships from the jest repository and follows its major, not Babel's.
       testing:
@@ -298,27 +258,9 @@ updates:
             'nock',
             'fishery',
           ]
-      babel:
-        update-types: ['patch', 'minor']
-        patterns: ['@babel/*', 'babel-*']
-      types:
-        update-types: ['patch', 'minor']
-        patterns: ['@types/*']
-      production-patch:
-        dependency-type: 'production'
-        update-types: ['patch']
-        patterns: ['*']
-      production-minor:
-        dependency-type: 'production'
-        update-types: ['minor']
-        patterns: ['*']
-      development-patch:
-        dependency-type: 'development'
-        update-types: ['patch']
-        patterns: ['*']
-      development-minor:
-        dependency-type: 'development'
-        update-types: ['minor']
+      # Everything the groups above do not match, including @types/* and Babel.
+      # No `update-types`, so nothing can escape into a pull request of its own.
+      everything-else:
         patterns: ['*']
 
   # Actions are versioned through their major tag, so here the majors are the

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,11 @@ updates:
       # instead, until someone takes the upgrade with the code changes it needs.
       - dependency-name: 'react-vtree'
         versions: ['>= 3.0.0']
+      # Held at 9.22.5. 9.22.6 fails the frontend tests, and the components that
+      # render through it need work before it can move.
+      - dependency-name: 'react-virtualized'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']
 
     # Groups bundle related updates into one pull request. A group opens at most
     # one pull request, so the number of groups here sets how many arrive in a
@@ -229,6 +234,14 @@ updates:
         update-types: ['version-update:semver-minor']
       # Pre-1.0, so a minor carries breaking schema and driver changes.
       - dependency-name: 'typeorm'
+        update-types: ['version-update:semver-minor']
+      # A minor on the Redis clients has broken lint, type-check and both builds.
+      # Patches still flow.
+      - dependency-name: 'ioredis'
+        update-types: ['version-update:semver-minor']
+      - dependency-name: 'ioredis-mock'
+        update-types: ['version-update:semver-minor']
+      - dependency-name: 'redis'
         update-types: ['version-update:semver-minor']
 
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -207,16 +207,16 @@ updates:
       - dependency-name: 'typeorm'
         update-types: ['version-update:semver-minor']
       # A minor on the Redis clients has broken lint, type-check and both builds.
-      # Patches still flow.
-      - dependency-name: 'ioredis'
-        update-types: ['version-update:semver-minor']
       - dependency-name: 'ioredis-mock'
         update-types: ['version-update:semver-minor']
       - dependency-name: 'redis'
         update-types: ['version-update:semver-minor']
       # A patch in redisinsight/api/patches/ is keyed to the exact version, so
-      # any bump either fails postinstall or drops the patch. Moving this means
-      # regenerating the patch and relaxing the rule here.
+      # any bump either fails postinstall or drops the patch. Moving these means
+      # regenerating the patch and relaxing the rule together.
+      - dependency-name: 'ioredis'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']
       - dependency-name: 'redis-parser'
         update-types:
           ['version-update:semver-patch', 'version-update:semver-minor']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     # A group only opens a pull request when it has an update available, so this
     # is a cap for a busy week rather than an expected number.
     open-pull-requests-limit: 15
+    # Every pull request from this entry edits the same lockfile, so merging one
+    # conflicts the rest. Automatic rebasing would push a commit to each and run
+    # their pipelines again. Use `@dependabot rebase` on the one being merged.
+    rebase-strategy: 'disabled'
     cooldown:
       # Days to wait after a release before proposing it. .npmrc sets
       # min-release-age=3, which stops npm resolving anything newer than that,
@@ -222,6 +226,8 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
+    # Same reason as the root entry.
+    rebase-strategy: 'disabled'
     cooldown:
       default-days: 3
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,74 +1,57 @@
 version: 2
 
-# Dependabot configuration: which manifests are watched, how updates are
-# bundled into pull requests, and what is left alone.
-#
-# Each entry below covers manifests that have their own lockfile. Directories
-# absent from this file still receive security updates, which run repo-wide and
-# ignore this configuration.
+# One entry per lockfile. Directories absent from this file still get security
+# updates: those run repo-wide and ignore this configuration.
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
       day: 'monday'
-      # Overnight, so the batch and the CI it starts finish before the working
-      # day. Without a day and time GitHub picks, which lands it mid-afternoon.
+      # Overnight, so the batch and its CI finish before the working day.
       time: '02:00'
       timezone: 'Europe/Sofia'
-    # A group only opens a pull request when it has an update available, so this
-    # is a cap for a busy week rather than an expected number.
+    # A cap for a busy week, not an expected number.
     open-pull-requests-limit: 15
-    # Every pull request from this entry edits the same lockfile, so merging one
-    # conflicts the rest. Automatic rebasing would push a commit to each and run
-    # their pipelines again. Use `@dependabot rebase` on the one being merged.
+    # Every pull request here edits the same lockfile, so an automatic rebase of
+    # the whole set follows each merge. Use `@dependabot rebase` when merging.
     rebase-strategy: 'disabled'
     cooldown:
-      # Days to wait after a release before proposing it. .npmrc sets
-      # min-release-age=3, which stops npm resolving anything newer than that,
-      # so a shorter window here would propose versions nobody can install.
+      # Matches min-release-age=3 in .npmrc; anything newer cannot be installed.
       default-days: 3
 
     ignore:
-      # No major updates, anywhere. A major is a breaking change that needs a
-      # branch, a full test run and someone to own it, so it belongs in planned
-      # work rather than an unsolicited pull request. Patches and minors still
-      # flow for every package.
+      # A major needs an owner and a full test run, so it belongs in planned work.
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
-      # CI records a TypeScript error count per file in .tscheck.rec.json and
-      # fails if any count changes in either direction. A compiler minor moves
-      # those counts, so it needs the baselines refreshed by hand.
+      # A compiler minor moves the error counts in .tscheck.rec.json, which CI
+      # compares exactly. The baselines need refreshing by hand.
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-minor']
-      # An upgrade needs manual visual work, such as colors and paddings, so the
-      # design system moves by hand. Patch and minor are named rather than
-      # ignoring the package outright: a bare `dependency-name` would also
-      # suppress security updates for it.
+      # An upgrade needs manual visual work on colors and paddings.
+      #
+      # Every rule below names its update types. A bare `dependency-name` would
+      # also suppress security updates for the package.
       - dependency-name: '@redis-ui/*'
         update-types:
           ['version-update:semver-patch', 'version-update:semver-minor']
-      # Pre-1.0, so a minor carries breaking editor API changes. The same bump
-      # has twice failed lint, type-check and the Linux build.
+      # Pre-1.0: a minor changes the editor API. Twice failed type-check and the
+      # Linux build.
       - dependency-name: 'monaco-editor'
         update-types: ['version-update:semver-minor']
-      # Follows the monaco-editor API, and pre-1.0 for the same reason.
+      # Follows the monaco-editor API.
       - dependency-name: 'react-monaco-editor'
         update-types: ['version-update:semver-minor']
-      # Pinned to a prerelease. 3.0.0 changes the tree typings, and leaving a
-      # prerelease for its release counts as neither patch, minor nor major, so
-      # the blanket major rule above does not hold it back. Pinned by version
-      # instead, until someone takes the upgrade with the code changes it needs.
+      # Held on a prerelease by a patch in patches/. Leaving a prerelease for its
+      # release is neither patch, minor nor major, so only a version pin catches it.
       - dependency-name: 'react-vtree'
         versions: ['>= 3.0.0']
-      # Held at 9.22.5. 9.22.6 fails the frontend tests, and the components that
-      # render through it need work before it can move.
+      # Held at 9.22.5: 9.22.6 fails the frontend tests.
       - dependency-name: 'react-virtualized'
         update-types:
           ['version-update:semver-patch', 'version-update:semver-minor']
-      # A patch in patches/ is keyed to the exact version, so any bump either
-      # fails postinstall or drops the patch. Moving these means regenerating the
-      # patch and relaxing the rule here.
+      # A patch in patches/ is keyed to the exact version. Moving these means
+      # regenerating the patch and relaxing the rule together.
       - dependency-name: 'monaco-yaml'
         update-types:
           ['version-update:semver-patch', 'version-update:semver-minor']
@@ -76,28 +59,14 @@ updates:
         update-types:
           ['version-update:semver-patch', 'version-update:semver-minor']
 
-    # Groups bundle related updates into one pull request. A group opens at most
-    # one pull request, so the number of groups here sets how many arrive in a
-    # week. They are split by what has to move together, and by what a reviewer
-    # checks: a failing `electron` group points at packaging, a failing
-    # `frontend` group points at the renderer.
+    # A group opens at most one pull request, so the number of groups sets how
+    # many arrive in a week. Grouped by what a failure points at.
     #
-    # A dependency lands in its most specific matching group, not the first one
-    # declared: an exact name beats a wildcard, which beats a bare `*`. The
-    # catch-all therefore declares `patterns: ['*']` so it scores lowest. A
-    # catch-all that omits `patterns` outranks the named groups and swallows them
-    # instead.
-    #
-    # A group covering both runtime and development dependencies leaves out
-    # `dependency-type`, so a pair split across the two can still travel
-    # together.
-    #
-    # Only the catch-all omits `update-types`. An update matching no group opens
-    # its own pull request, and a prerelease reaching its release version counts
-    # as a major, so a patch-and-minor filter there would let those escape.
+    # A dependency lands in its most specific matching group: an exact name beats
+    # a wildcard, which beats `*`. A catch-all that omits `patterns` outranks the
+    # named groups and swallows them.
     groups:
-      # The renderer: anything whose upgrade shows up as a visual or behavioural
-      # change in the UI.
+      # Shows up as a visual or behavioural change in the UI.
       frontend:
         update-types: ['patch', 'minor']
         patterns: [
@@ -116,9 +85,7 @@ updates:
             'monaco-editor',
             'monaco-yaml',
             'react-monaco-editor',
-            # The browser key list renders through these together, and the
-            # auto-sizer and infinite-loader companions are pinned to their
-            # host's major.
+            # The browser key list renders through these together.
             'react-virtualized',
             'react-virtualized-auto-sizer',
             'react-window',
@@ -127,10 +94,10 @@ updates:
             '@types/react-virtualized',
             '@types/react-window-infinite-loader',
           ]
-      # The packaging toolchain and the Electron runtime libraries. electron-builder
-      # releases electron-updater and builder-util-runtime in lockstep, and node-abi
-      # maps Electron versions to native module ABI versions. Kept separate because
-      # a failure here needs an installed app to reproduce.
+      # Packaging plus the Electron runtime libraries. electron-builder releases
+      # electron-updater and builder-util-runtime in lockstep, and node-abi maps
+      # Electron versions to native module ABIs. A failure needs an installed app
+      # to reproduce.
       electron:
         update-types: ['patch', 'minor']
         patterns:
@@ -150,9 +117,8 @@ updates:
             'electron-store',
             '@types/electron-store',
           ]
-      # Two build pipelines plus the linters and the compiler. Vite builds the
-      # renderer, webpack builds the Electron main and preload bundles. Breakage
-      # here stops the build rather than changing behaviour.
+      # Vite builds the renderer, webpack the Electron main and preload bundles.
+      # Breakage stops the build rather than changing behaviour.
       tooling:
         update-types: ['patch', 'minor']
         patterns: [
@@ -168,8 +134,8 @@ updates:
             'mini-css-extract-plugin',
             '@svgr/webpack',
             'react-refresh',
-            # Loaders are listed by name: a `*-loader` glob also catches
-            # unrelated packages such as react-window-infinite-loader.
+            # Named individually: a `*-loader` glob also catches
+            # react-window-infinite-loader.
             'css-loader',
             'file-loader',
             'style-loader',
@@ -189,8 +155,7 @@ updates:
             'storybook',
             '@storybook/*',
           ]
-      # Test tooling only. A failure here is usually the test runner rather than
-      # the application, so it stays out of `tooling`.
+      # A failure here is usually the runner, not the application.
       testing:
         update-types: ['patch', 'minor']
         patterns:
@@ -208,17 +173,14 @@ updates:
             '@types/jest',
             '@types/supertest',
           ]
-      # Everything the groups above do not match, including @types/* and the
-      # observability packages. No `update-types`, so nothing can escape into a
-      # pull request of its own.
+      # No `update-types`: an update matching no group would open its own pull
+      # request, and a prerelease reaching its release counts as a major.
       everything-else:
         patterns: ['*']
 
-  # One entry for two lockfiles. /redisinsight is the packaged desktop app's
-  # manifest and declares better-sqlite3, keytar and tunnel-ssh at the same
-  # versions as the api tree, and its lockfile is the one that ships. Covering
-  # both directories from here lets the shared-natives group below update them
-  # in a single pull request, which separate entries cannot do.
+  # Two lockfiles in one entry. /redisinsight ships the packaged app's lockfile
+  # and declares the same native modules as the api tree, so covering both here
+  # lets shared-natives update them together. Separate entries cannot.
   - package-ecosystem: 'npm'
     directories:
       - '/redisinsight'
@@ -260,17 +222,14 @@ updates:
           ['version-update:semver-patch', 'version-update:semver-minor']
 
     groups:
-      # Declared in both directories at the same version. `group-by` raises a
-      # single pull request per dependency spanning both lockfiles, so the
-      # packaged app and the api tree cannot end up on different versions of a
-      # native module. No update-types filter, because anything falling outside
-      # this group would arrive as one pull request per directory again.
+      # `group-by` raises one pull request per dependency spanning both
+      # lockfiles, so the two trees cannot drift onto different versions. No
+      # update-types filter: anything outside this group arrives per directory.
       shared-natives:
         group-by: 'dependency-name'
         patterns: ['better-sqlite3', 'keytar', 'tunnel-ssh']
-      # The API and everything it talks to. rxjs and reflect-metadata are NestJS
-      # peer dependencies pinned to the framework's major, and ioredis-mock moves
-      # with ioredis, so this group leaves out `dependency-type`.
+      # rxjs and reflect-metadata are NestJS peers pinned to its major. No
+      # `dependency-type`, so ioredis-mock can travel with ioredis.
       backend:
         update-types: ['patch', 'minor']
         patterns:
@@ -288,8 +247,8 @@ updates:
             'socket.io-mock',
             'typescript',
           ]
-      # Unit tests run on jest, integration tests on mocha and chai. babel-jest
-      # ships from the jest repository and follows its major, not Babel's.
+      # Unit tests on jest, integration on mocha and chai. babel-jest follows
+      # jest's major, not Babel's.
       testing:
         update-types: ['patch', 'minor']
         patterns:
@@ -312,14 +271,12 @@ updates:
             'nock',
             'fishery',
           ]
-      # Everything the groups above do not match, including @types/* and Babel.
-      # No `update-types`, so nothing can escape into a pull request of its own.
+      # No `update-types`, for the same reason as the root entry.
       everything-else:
         patterns: ['*']
 
-  # Actions are versioned through their major tag, so here the majors are the
-  # upgrades worth taking and are deliberately not ignored. One group keeps a
-  # week's action bumps in a single pull request.
+  # Actions are versioned by major tag, so majors are the upgrades worth taking
+  # and are deliberately not ignored here.
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,15 @@ updates:
       - dependency-name: 'react-virtualized'
         update-types:
           ['version-update:semver-patch', 'version-update:semver-minor']
+      # A patch in patches/ is keyed to the exact version, so any bump either
+      # fails postinstall or drops the patch. Moving these means regenerating the
+      # patch and relaxing the rule here.
+      - dependency-name: 'monaco-yaml'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']
+      - dependency-name: '@elastic/eui'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']
 
     # Groups bundle related updates into one pull request. A group opens at most
     # one pull request, so the number of groups here sets how many arrive in a
@@ -243,6 +252,12 @@ updates:
         update-types: ['version-update:semver-minor']
       - dependency-name: 'redis'
         update-types: ['version-update:semver-minor']
+      # A patch in redisinsight/api/patches/ is keyed to the exact version, so
+      # any bump either fails postinstall or drops the patch. Moving this means
+      # regenerating the patch and relaxing the rule here.
+      - dependency-name: 'redis-parser'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']
 
     groups:
       # Declared in both directories at the same version. `group-by` raises a


### PR DESCRIPTION
# What

Re-configures Dependabot so a week of dependency updates arrives as a handful of reviewable pull requests instead of seventeen, and records why certain packages are held back.

**Groups: 33 → 10.** A group opens at most one pull request, so the number of groups sets how many arrive. The root entry keeps `frontend`, `electron`, `tooling` and `testing` plus a catch-all; the api entry keeps `shared-natives`, `backend` and `testing` plus a catch-all. Split by what a failure points at rather than by name prefix. Neither catch-all filters `update-types`, because an update matching no group opens its own pull request - and a prerelease reaching its release counts as a major, which is how #6401 escaped the blanket major rule.

**The batch lands overnight** - Monday 02:00 Europe/Sofia. Creating last week's batch took ~25 minutes and each E2E run takes ~35, so everything is settled by around 03:00 instead of arriving mid-afternoon on a Tuesday.

**No automatic rebasing.** Every pull request from the npm entries edits `package-lock.json`, so merging one conflicts the rest and Dependabot pushes a rebase commit to each. Since #6406 runs E2E on pushes to `dependabot/**`, each of those starts a full E2E suite. Conflicted pull requests now wait for `@dependabot rebase` on the one being merged.

**An ignore list carrying its reasons**, so nobody retries a bump that is known to fail:

| Dependency | Held back | Why |
|---|---|---|
| `@redis-ui/*` | patch, minor | An upgrade needs manual visual work on colors and paddings. |
| `monaco-editor` | minor | Pre-1.0, so a minor changes the editor API. Failed type-check and the Linux build in #6346 and #6386. |
| `react-monaco-editor` | minor | Follows the monaco-editor API. |
| `react-virtualized` | patch, minor | Held at 9.22.5; 9.22.6 fails the frontend tests (#6388). |
| `ioredis`, `ioredis-mock`, `redis` | minor | A minor broke lint, type-check and both builds (#6387). |
| `monaco-yaml`, `@elastic/eui`, `redis-parser`, `react-vtree` | patch, minor (`react-vtree` by version) | Each carries a `patch-package` patch keyed to an exact version, so a bump either fails `postinstall` or silently drops the patch. |

Every rule names its update types. A bare `dependency-name` would also suppress **security** updates for the package. Moving a patched package means regenerating its patch *and* relaxing the rule here - the two have to change together.

## Effect on last week's batch

Simulated against the 17 pull requests from 2026-08-11, which carried 71 package bumps between them:

| | Result |
|---|---|
| `tooling` | 21 packages |
| `everything-else` (root) | 27 packages |
| `testing` | 6 packages |
| `electron` | 2 packages |
| `frontend` | 1 package |
| `everything-else` (api) | 2 packages |
| `backend` | 1 package |
| `shared-natives` | 1 package |
| **Total** | **8 pull requests, down from 17** |

Ten bumps disappear rather than becoming pull requests: the four `@redis-ui` packages, both monaco packages, the three Redis clients, and `react-virtualized`. Those are #6396, #6386, #6387 and #6388 - the four closed by hand last week. `react-vtree` (#6401) goes too, via the version pin.

Two caveats: 8 is an upper bound for *that* week, since the batch was truncated at the 15-pull-request limit and some updates were never proposed. And `tooling` at 21 packages and `everything-else` at 27 are large - one red pipeline instead of six clear signals. Worth revisiting after a real Monday rather than pre-emptively splitting them.

# Testing

Config only. Verified locally: the file parses, no pattern appears in two groups within an entry, both catch-alls omit `update-types`, every package carrying a `patch-package` patch is covered by an ignore rule, and the comment trim left the parsed configuration byte-identical. Prettier clean.

On merge Dependabot re-runs within seconds, closes the open pull requests whose groups no longer exist or whose packages are now ignored, and opens the consolidated set. Confirm the count is 6-8 rather than 17, then merge one and check the others gain no new commits.

Note that merging triggers an immediate off-schedule run, so the first batch arrives on merge rather than at 02:00.

---

Refs #RI-8373

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to `.github/dependabot.yml`; main impact is operational (PR volume, merge/rebase workflow) rather than runtime behavior, with ignores written to avoid blanket security suppression.
> 
> **Overview**
> Reconfigures **Dependabot** so weekly dependency noise drops from many small PRs to a smaller set grouped by *what breaks* (UI, Electron, build tooling, tests, backend), with **`everything-else`** catch-alls instead of per–dependency-type patch/minor buckets.
> 
> **Scheduling and merge behavior:** npm and GitHub Actions updates run **Monday 02:00 Europe/Sofia**. **`rebase-strategy: disabled`** on the npm lockfile entries so merging one bump does not auto-rebase the rest and retrigger full E2E on every open Dependabot branch—use **`@dependabot rebase`** when landing a PR.
> 
> **Documented ignores** block known-bad bumps (e.g. **`@redis-ui/*`**, Monaco stack, **`react-virtualized`**, **`react-vtree`** via version pin, patch-locked packages like **`monaco-yaml`** / **`@elastic/eui`**, and API Redis clients / **`ioredis`** / **`redis-parser`**) while keeping security updates by scoping rules to specific semver update types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5abab152553e028857807b93287ff913ac5e807f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->