### PR TITLE
fix(api-rdi): align fallback status checks with Axios error format

### DIFF
--- a/redisinsight/api/src/modules/rdi/client/api/v1/api.rdi.client.spec.ts
+++ b/redisinsight/api/src/modules/rdi/client/api/v1/api.rdi.client.spec.ts
@@ -65,6 +65,9 @@ describe('ApiRdiClient', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedAxios.isAxiosError.mockImplementation((error: unknown) =>
+      Boolean((error as { isAxiosError?: boolean })?.isAxiosError),
+    );
     client = new ApiRdiClient(mockRdiClientMetadata, mockRdi);
   });
 

--- a/redisinsight/api/src/modules/rdi/client/api/v1/api.rdi.client.spec.ts
+++ b/redisinsight/api/src/modules/rdi/client/api/v1/api.rdi.client.spec.ts
@@ -55,7 +55,9 @@ const createMockPostImplementation = (
 const axiosError = (status: number, message = 'Request failed') => ({
   isAxiosError: true,
   message,
-  status,
+  response: {
+    status,
+  },
 });
 
 describe('ApiRdiClient', () => {
@@ -743,7 +745,10 @@ describe('ApiRdiClient', () => {
 
     it('should set dummy authorization headers in dev mode when login is disabled', async () => {
       mockedAxios.post.mockRejectedValueOnce({
-        status: 404,
+        isAxiosError: true,
+        response: {
+          status: 404,
+        },
       });
 
       await client.connect();

--- a/redisinsight/api/src/modules/rdi/client/api/v1/api.rdi.client.ts
+++ b/redisinsight/api/src/modules/rdi/client/api/v1/api.rdi.client.ts
@@ -91,7 +91,10 @@ export class ApiRdiClient extends RdiClient {
       return response.data.access_token;
     } catch (e) {
       // If /login endpoint is not found we assume that RDI is in dev mode
-      if (e.status === HttpStatus.NOT_FOUND) {
+      if (
+        axios.isAxiosError(e) &&
+        e.response?.status === HttpStatus.NOT_FOUND
+      ) {
         return this.loginDev();
       }
 
@@ -247,11 +250,10 @@ export class ApiRdiClient extends RdiClient {
             { ...config.sources[source] },
           );
           sources[source] = response.data;
-        } catch (error: any) {
+        } catch (error: unknown) {
           // Older versions of RDI (below 1.6.0) don't support testing sources connections
           // RDI returns 405 Method Not Allowed for non existing endpoints
-          const status = error?.status;
-          if (status === 405) {
+          if (axios.isAxiosError(error) && error.response?.status === 405) {
             sources[source] = {
               connected: false,
               error:


### PR DESCRIPTION
# What
Updated RDI error handling to align with real Axios error objects.

Docs: 
- https://axios.rest/pages/advanced/error-handling#handling-errors
- https://axios.rest/pages/getting-started/examples/typescript#typing-errors

# Testing

- Updated/validated unit test expectations to reflect Axios-shaped errors (`response.status`) for these flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-handling fix in the RDI HTTP client; restores intended dev-login and legacy-RDI 405 behavior without broader API changes.
> 
> **Overview**
> **RDI API client** fallback paths that depend on HTTP status now read **`response.status`** on real Axios errors instead of a top-level **`status`** field, using **`axios.isAxiosError`** before branching.
> 
> **Login:** A **404** on `/login` still triggers dev-mode dummy JWT auth, but only when the rejection is an Axios error with **`response.status === NOT_FOUND`**.
> 
> **Test source connections:** **405** still maps to the “upgrade to 1.6.0+” message for older RDI; other failures still get the generic connection error. Catch typing moves from **`any`** to **`unknown`**.
> 
> **Tests:** The **`axiosError`** helper and dev-login mock rejections are shaped like Axios errors (**`isAxiosError`**, **`response.status`**), and **`isAxiosError`** is stubbed in **`beforeEach`** so unit tests match production checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6dc81d539e2dda017d67fb77af040f13589ce3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->