### PR TITLE
RI-8373 Gate merges on one check and move the Tests label trigger out

### DIFF
--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -44,4 +44,7 @@ jobs:
       contents: read
       checks: write
     with:
-      short_rte_list: true
+      # Full RTE list on release PRs, as `should-run` does.
+      short_rte_list: >-
+        ${{ !(startsWith(github.head_ref, 'release/') || github.head_ref == 'latest' ||
+        startsWith(github.base_ref, 'release/') || github.base_ref == 'latest') }}

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -3,24 +3,20 @@ name: ✅ Tests (on demand)
 # Runs a suite the changed files did not ask for: the frontend tests on a
 # backend-only PR, say. `run-all-tests` runs all three.
 #
-# Suites are called directly, not through `tests.yml`, so no check here shares a
-# name with one from there and the merge gate stays in `tests.yml`.
+# Suites are called directly, not through `tests.yml`, so the merge gate and its
+# check names stay there.
 #
-# `pull_request` cannot filter by label, so every label starts a run and the jobs
-# below decide if there is work. Dependabot's labels land here and skip.
-#
-# Nothing here runs on `always()`. A run that skips every job must do nothing at
-# all: most runs are labels this workflow has no interest in. The deployment
-# records these suites leave behind are cleared by the next run of `tests.yml`.
+# Every label starts a run here: `pull_request` cannot filter by label. Most are
+# labels this ignores. Those runs must do nothing, so no job uses `always()`.
 
 on:
   pull_request:
     types: [labeled]
 
 concurrency:
-  # Keyed by label so one request does not cancel another, and deliberately not
-  # the group `tests.yml` uses: a label must never cancel a suite in progress.
-  # Cancelling is off because a cancelled check does not pass branch protection.
+  # Keyed by label so requests do not cancel each other. Never share the group
+  # `tests.yml` uses: a label must not cancel a suite in progress. Cancelling is
+  # off because a cancelled check does not pass branch protection.
   group: tests-on-demand-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
   cancel-in-progress: false
 
@@ -35,8 +31,8 @@ jobs:
     uses: ./.github/workflows/tests-backend.yml
     secrets: inherit
 
-  # Off for forks, as in `tests.yml`: no secrets there, and the `production`
-  # environment these tests deploy to only accepts branches from this repo.
+  # Off for forks, as in `tests.yml`. Forks get no secrets, and `production` only
+  # accepts branches from this repo.
   integration:
     if: >-
       github.event.pull_request.head.repo.fork != true &&

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -8,6 +8,10 @@ name: ✅ Tests (on demand)
 #
 # `pull_request` cannot filter by label, so every label starts a run and the jobs
 # below decide if there is work. Dependabot's labels land here and skip.
+#
+# Nothing here runs on `always()`. A run that skips every job must do nothing at
+# all: most runs are labels this workflow has no interest in. The deployment
+# records these suites leave behind are cleared by the next run of `tests.yml`.
 
 on:
   pull_request:
@@ -45,14 +49,3 @@ jobs:
       checks: write
     with:
       short_rte_list: true
-
-  # The suites above leave the same deployment records a run of `tests.yml` does,
-  # so clean up after them here too. `always()` because only one suite runs.
-  clean:
-    uses: ./.github/workflows/clean-deployments.yml
-    if: ${{ always() && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork != true }}
-    permissions:
-      actions: write
-      contents: read
-      deployments: write
-    needs: [frontend, backend, integration]

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -1,0 +1,53 @@
+name: ✅ Tests (on demand)
+
+# Runs a suite that a pull request's own changes did not call for. A backend-only
+# PR skips the frontend tests; `run-frontend-tests` is how someone asks for them
+# anyway, and the other way round.
+#
+# `run-all-tests` asks for all three.
+#
+# The suites are called straight from here rather than through `tests.yml`, so
+# nothing in this workflow reports a check that `tests.yml` also reports. The
+# merge gate, `All required checks pass`, belongs to `tests.yml` alone and is
+# never produced by a label.
+#
+# `pull_request` cannot filter on which label was added, so every label starts a
+# run and the three jobs below decide whether any of them has work. Dependabot
+# adds `dependencies` and `javascript` twice each when it opens a PR, and those
+# four events land here rather than on the suite.
+
+on:
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  # Keyed by label as well as PR, so asking for the frontend suite does not stop
+  # the backend suite someone asked for a moment earlier.
+  #
+  # Cancelling is off: Dependabot's labels arrive within seconds of each other,
+  # and a cancelled check does not count as passing for branch protection the way
+  # a skipped one does. These runs finish in seconds, so queueing costs nothing.
+  group: tests-on-demand-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+  cancel-in-progress: false
+
+jobs:
+  frontend:
+    if: contains(fromJSON('["run-all-tests","run-frontend-tests"]'), github.event.label.name)
+    uses: ./.github/workflows/tests-frontend.yml
+    secrets: inherit
+
+  backend:
+    if: contains(fromJSON('["run-all-tests","run-backend-tests"]'), github.event.label.name)
+    uses: ./.github/workflows/tests-backend.yml
+    secrets: inherit
+
+  integration:
+    if: contains(fromJSON('["run-all-tests","run-integration-tests"]'), github.event.label.name)
+    uses: ./.github/workflows/tests-integration.yml
+    secrets: inherit
+    permissions:
+      actions: write
+      contents: read
+      checks: write
+    with:
+      short_rte_list: true

--- a/.github/workflows/tests-on-demand.yml
+++ b/.github/workflows/tests-on-demand.yml
@@ -1,32 +1,22 @@
 name: ✅ Tests (on demand)
 
-# Runs a suite that a pull request's own changes did not call for. A backend-only
-# PR skips the frontend tests; `run-frontend-tests` is how someone asks for them
-# anyway, and the other way round.
+# Runs a suite the changed files did not ask for: the frontend tests on a
+# backend-only PR, say. `run-all-tests` runs all three.
 #
-# `run-all-tests` asks for all three.
+# Suites are called directly, not through `tests.yml`, so no check here shares a
+# name with one from there and the merge gate stays in `tests.yml`.
 #
-# The suites are called straight from here rather than through `tests.yml`, so
-# nothing in this workflow reports a check that `tests.yml` also reports. The
-# merge gate, `All required checks pass`, belongs to `tests.yml` alone and is
-# never produced by a label.
-#
-# `pull_request` cannot filter on which label was added, so every label starts a
-# run and the three jobs below decide whether any of them has work. Dependabot
-# adds `dependencies` and `javascript` twice each when it opens a PR, and those
-# four events land here rather than on the suite.
+# `pull_request` cannot filter by label, so every label starts a run and the jobs
+# below decide if there is work. Dependabot's labels land here and skip.
 
 on:
   pull_request:
     types: [labeled]
 
 concurrency:
-  # Keyed by label as well as PR, so asking for the frontend suite does not stop
-  # the backend suite someone asked for a moment earlier.
-  #
-  # Cancelling is off: Dependabot's labels arrive within seconds of each other,
-  # and a cancelled check does not count as passing for branch protection the way
-  # a skipped one does. These runs finish in seconds, so queueing costs nothing.
+  # Keyed by label so one request does not cancel another, and deliberately not
+  # the group `tests.yml` uses: a label must never cancel a suite in progress.
+  # Cancelling is off because a cancelled check does not pass branch protection.
   group: tests-on-demand-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
   cancel-in-progress: false
 
@@ -41,8 +31,12 @@ jobs:
     uses: ./.github/workflows/tests-backend.yml
     secrets: inherit
 
+  # Off for forks, as in `tests.yml`: no secrets there, and the `production`
+  # environment these tests deploy to only accepts branches from this repo.
   integration:
-    if: contains(fromJSON('["run-all-tests","run-integration-tests"]'), github.event.label.name)
+    if: >-
+      github.event.pull_request.head.repo.fork != true &&
+      contains(fromJSON('["run-all-tests","run-integration-tests"]'), github.event.label.name)
     uses: ./.github/workflows/tests-integration.yml
     secrets: inherit
     permissions:
@@ -51,3 +45,14 @@ jobs:
       checks: write
     with:
       short_rte_list: true
+
+  # The suites above leave the same deployment records a run of `tests.yml` does,
+  # so clean up after them here too. `always()` because only one suite runs.
+  clean:
+    uses: ./.github/workflows/clean-deployments.yml
+    if: ${{ always() && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork != true }}
+    permissions:
+      actions: write
+      contents: read
+      deployments: write
+    needs: [frontend, backend, integration]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,11 @@
 name: ✅ Tests
 
-# Runs on every pull request. Which suites run is decided per PR from the changed
-# files plus these labels: `run-all-tests`, `run-frontend-tests`,
-# `run-backend-tests`, `run-integration-tests`.
+# Runs on every pull request. The changed files pick the suites; the
+# `run-*-tests` labels can widen that.
 #
-# A PR being opened, or a commit pushed to it, starts a run and replaces any run
-# already going. The changed files decide which suites it runs.
-#
-# The labels are read here so that one stays in effect for later pushes, but they
-# do not start a run: no label reaches this workflow. `tests-on-demand.yml` owns
-# that trigger and runs the named suite on its own, which keeps labels aimed
-# elsewhere, such as `e2e-tests` or Dependabot's `dependencies` and `javascript`,
-# from producing a second `All required checks pass` on the same commit.
+# Do not add `labeled` here. `tests-on-demand.yml` owns that trigger. A label
+# reaching this workflow reports a second `All required checks pass` on the same
+# commit, green while the real suite is still running.
 
 on:
   pull_request:
@@ -53,7 +47,7 @@ on:
         type: boolean
 
 concurrency:
-  # One run per PR at a time. A new commit replaces the one already going.
+  # One run per PR. A new commit replaces the one in progress.
   group: tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
@@ -273,17 +267,12 @@ jobs:
       - name: Remove all artifacts
         uses: ./.github/actions/remove-artifacts
 
-  # One check to read in place of the whole list. Green when nothing it waits on
-  # failed or was cancelled; a skipped job passes, because a suite gated off by
-  # the changed files is a decision rather than a problem. On a red run the step
-  # names which jobs are at fault, and their own checks hold the logs.
+  # The one check to read, and the one to require on protected branches. Red if
+  # any job below failed or was cancelled. A skipped job passes: skipping is a
+  # decision made from the changed files.
   #
-  # This is the check to require on protected branches. A job listed here blocks a
-  # merge when it fails; a job left out does not, so a new suite needs adding to
-  # the list to count.
-  #
-  # The housekeeping jobs stay out on purpose. Coverage, deployment cleanup and
-  # artifact removal say nothing about whether the code is sound.
+  # A job left out of `needs` cannot block a merge, so add new suites here.
+  # Coverage and cleanup are out on purpose.
   required-checks-passed:
     name: All required checks pass
     if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,20 +4,18 @@ name: ✅ Tests
 # files plus these labels: `run-all-tests`, `run-frontend-tests`,
 # `run-backend-tests`, `run-integration-tests`.
 #
-# Three cases:
+# A PR being opened, or a commit pushed to it, starts a run and replaces any run
+# already going. The changed files decide which suites it runs.
 #
-#   1. A PR is opened, or a commit is pushed to it. Any run already going is
-#      replaced.
-#   2. One of the four labels above is added, to widen what the PR runs.
-#   3. Any other label is added. Nothing runs. This case exists only so that
-#      labels aimed elsewhere, such as `e2e-tests` or Dependabot's own
-#      `dependencies` and `javascript`, cannot disturb case 1. See the
-#      concurrency note below.
+# The labels are read here so that one stays in effect for later pushes, but they
+# do not start a run: no label reaches this workflow. `tests-on-demand.yml` owns
+# that trigger and runs the named suite on its own, which keeps labels aimed
+# elsewhere, such as `e2e-tests` or Dependabot's `dependencies` and `javascript`,
+# from producing a second `All required checks pass` on the same commit.
 
 on:
-  # Cases 1, 2 and 3.
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:
@@ -55,32 +53,12 @@ on:
         type: boolean
 
 concurrency:
-  # One run per PR at a time. A new commit replaces the one already going, which
-  # is case 1.
-  #
-  # The `-noop-<run id>` on the end puts case 3 in a group of its own, where it
-  # cancels nothing. Without it, any label added to a PR would kill the run and
-  # start the whole suite again: the group is worked out before any job `if` is
-  # read, so skipping the jobs is too late. Dependabot adds `dependencies` and
-  # `javascript` twice each within two seconds of opening a PR, so without this
-  # every dependency PR loses the run that opening it started.
-  #
-  # The label list is repeated on the `changes` and `lint` jobs below. Changing
-  # one without the others breaks quietly.
-  group: >-
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{
-    github.event.action == 'labeled' &&
-    !contains(fromJSON('["run-all-tests","run-frontend-tests","run-backend-tests","run-integration-tests"]'), github.event.label.name)
-    && format('-noop-{0}', github.run_id) || '' }}
+  # One run per PR at a time. A new commit replaces the one already going.
+  group: tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Skipped in case 3, which is what makes that run do nothing. Every job after
-  # this one skips with it, through `needs`.
   changes:
-    if: >-
-      github.event.action != 'labeled' ||
-      contains(fromJSON('["run-all-tests","run-frontend-tests","run-backend-tests","run-integration-tests"]'), github.event.label.name)
     permissions:
       contents: read
       pull-requests: read
@@ -203,11 +181,6 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   lint:
-    # No `needs`, so it cannot inherit the skip from `changes` and repeats the
-    # same condition to stay out of case 3.
-    if: >-
-      github.event.action != 'labeled' ||
-      contains(fromJSON('["run-all-tests","run-frontend-tests","run-backend-tests","run-integration-tests"]'), github.event.label.name)
     uses: ./.github/workflows/lint.yml
     secrets: inherit
 
@@ -281,8 +254,7 @@ jobs:
   clean:
     uses: ./.github/workflows/clean-deployments.yml
     # `always()` runs this even when every test job skips, so it needs its own
-    # guard to stay out of case 3 and not delete deployments for a run that does
-    # no work.
+    # guard against deleting deployments for a run that did no work.
     if: ${{ always() && needs.changes.result != 'skipped' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork != true }}
     permissions:
       actions: write
@@ -300,3 +272,46 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - name: Remove all artifacts
         uses: ./.github/actions/remove-artifacts
+
+  # One check to read in place of the whole list. Green when nothing it waits on
+  # failed or was cancelled; a skipped job passes, because a suite gated off by
+  # the changed files is a decision rather than a problem. On a red run the step
+  # names which jobs are at fault, and their own checks hold the logs.
+  #
+  # This is the check to require on protected branches. A job listed here blocks a
+  # merge when it fails; a job left out does not, so a new suite needs adding to
+  # the list to count.
+  #
+  # The housekeeping jobs stay out on purpose. Coverage, deployment cleanup and
+  # artifact removal say nothing about whether the code is sound.
+  required-checks-passed:
+    name: All required checks pass
+    if: always()
+    needs:
+      - changes
+      - should-run
+      - lint
+      - type-check
+      - docker-build
+      - frontend-tests
+      - backend-tests
+      - integration-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the jobs this waits on
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failing=$(jq -r '
+            to_entries[]
+            | select(.value.result != "success" and .value.result != "skipped")
+            | "  \(.key): \(.value.result)"
+          ' <<< "$NEEDS_JSON")
+
+          if [ -n "$failing" ]; then
+            echo "These jobs did not pass:"
+            echo "$failing"
+            exit 1
+          fi
+
+          echo "Every job passed or was skipped."


### PR DESCRIPTION
# What

Two changes to the test workflows.

**One check to read.** `All required checks pass` waits on the suite jobs and goes red if any of them failed or was cancelled. A skipped job passes, since skipping is a decision made from the changed files. Today you read about thirty rows and work out for yourself which skips are normal.

**Labels run only the suite they name.** `run-frontend-tests` on a backend-only PR runs the frontend suite and nothing else, from the new `tests-on-demand.yml`. `tests.yml` no longer reacts to labels at all.

They go together. `tests.yml` runs the gate with `always()`, so a label reaching it would report a second `All required checks pass` on the same commit, green in seconds while the real suite is still running. Dependabot adds four labels to every PR it opens.

# Testing

Checked here, and on a throwaway PR shaped like a Dependabot one: `dependabot/**` branch, real `esbuild` patch bump under `redisinsight/api`, four labels within seconds.

- A backend-only bump skips the frontend suite, and the gate is green anyway
- One gate check per commit, after six label events
- `run-frontend-tests` runs the frontend suite only
- Dependabot's labels produce no gate check and cancel nothing
- A cancelled suite turns the gate red

# Follow-ups

- Nothing is enforced until `All required checks pass` is made a required check in branch protection.
- E2E sits outside the gate and runs on `dependabot/**`, so a green gate can hide a failed E2E run.

---

Refs #RI-8373

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR CI gating and label behavior; a misconfigured gate or branch protection could block merges or allow merges before suites finish until `All required checks pass` is required.
> 
> **Overview**
> Introduces a **single merge gate** in `tests.yml`: **`All required checks pass`** waits on the main suite jobs and fails if any of them failed or were cancelled; intentionally skipped suites still count as OK.
> 
> **Label-driven test runs** move out of `tests.yml` into new **`tests-on-demand.yml`**, which fires on `labeled` and runs only the matching suite (`run-frontend-tests`, `run-backend-tests`, `run-integration-tests`, or `run-all-tests`) via the existing reusable workflows. Irrelevant labels no-op without `always()`, and concurrency is per PR+label with **no cancel-in-progress** so label spam (e.g. Dependabot) does not cancel in-flight `tests.yml` runs or spawn duplicate green gates.
> 
> `tests.yml` now triggers only on **open/sync/reopen**, with simpler PR concurrency and no label/noop branching on `changes`/`lint`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bbe3f20609164bd93ec90bb23f82d557457697b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->