### PR TITLE
feat(agent-memory): add Redis Agent Memory API module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ storybook-static
 
 # TypeScript incremental build info
 *.tsbuildinfo
+
+# Playwright CLI scratch output
+.playwright-cli/

--- a/redisinsight/api/config/ormconfig.ts
+++ b/redisinsight/api/config/ormconfig.ts
@@ -19,6 +19,7 @@ import { FeaturesConfigEntity } from 'src/modules/feature/entities/features-conf
 import { CloudDatabaseDetailsEntity } from 'src/modules/cloud/database/entities/cloud-database-details.entity';
 import { CloudCapiKeyEntity } from 'src/modules/cloud/capi-key/entity/cloud-capi-key.entity';
 import { RdiEntity } from 'src/modules/rdi/entities/rdi.entity';
+import { AgentMemoryEndpointEntity } from 'src/modules/agent-memory/entities/agent-memory-endpoint.entity';
 import { AiQueryMessageEntity } from 'src/modules/ai/query/entities/ai-query.message.entity';
 import { CloudSessionEntity } from 'src/modules/cloud/session/entities/cloud.session.entity';
 import { DatabaseSettingsEntity } from 'src/modules/database-settings/entities/database-setting.entity';
@@ -54,6 +55,7 @@ const ormConfig = {
     CloudDatabaseDetailsEntity,
     CloudCapiKeyEntity,
     RdiEntity,
+    AgentMemoryEndpointEntity,
     AiQueryMessageEntity,
     CloudSessionEntity,
     DatabaseSettingsEntity,

--- a/redisinsight/api/migration/1779100000000-agent-memory-endpoint.ts
+++ b/redisinsight/api/migration/1779100000000-agent-memory-endpoint.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AgentMemoryEndpoint1779100000000 implements MigrationInterface {
+  name = 'AgentMemoryEndpoint1779100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "agent_memory_endpoint" (
+        "id" varchar PRIMARY KEY NOT NULL,
+        "name" varchar NOT NULL,
+        "url" varchar NOT NULL,
+        "backendType" varchar NOT NULL DEFAULT ('cloud'),
+        "storeId" varchar,
+        "apiKey" varchar,
+        "lastConnection" datetime,
+        "encryption" varchar
+      )`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "agent_memory_endpoint"`);
+  }
+}

--- a/redisinsight/api/migration/index.ts
+++ b/redisinsight/api/migration/index.ts
@@ -59,6 +59,7 @@ import { QueryLibrary1771500000000 } from './1771500000000-query-library';
 import { DatabaseIsProduction1778758000000 } from './1778758000000-database-isProduction';
 import { Environment1779000000000 } from './1779000000000-database-environment';
 import { DropDatabaseIsProduction1779000000001 } from './1779000000001-drop-database-isProduction';
+import { AgentMemoryEndpoint1779100000000 } from './1779100000000-agent-memory-endpoint';
 import { DatabaseConnectionFamily1784000000000 } from './1784000000000-database-connection-family';
 
 export default [
@@ -123,5 +124,6 @@ export default [
   DatabaseIsProduction1778758000000,
   Environment1779000000000,
   DropDatabaseIsProduction1779000000001,
+  AgentMemoryEndpoint1779100000000,
   DatabaseConnectionFamily1784000000000,
 ];

--- a/redisinsight/api/package-lock.json
+++ b/redisinsight/api/package-lock.json
@@ -20,6 +20,7 @@
         "@nestjs/typeorm": "^11.0.3",
         "@nestjs/websockets": "^11.1.29",
         "@okta/okta-auth-js": "^7.14.5",
+        "@redis-iris/agent-memory": "^0.2.0",
         "@segment/analytics-node": "^2.3.0",
         "@supercharge/promise-pool": "^3.3.0",
         "@types/json-bigint": "^1.0.4",
@@ -4410,6 +4411,14 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@redis-iris/agent-memory": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@redis-iris/agent-memory/-/agent-memory-0.2.0.tgz",
+      "integrity": "sha512-/3fwtHtehrU4hVwcauJoJiSNa0dOCvuvdmilqtgqRHkOL+iM7x73wd8pC3NaGoRGR6cD++kjjafP70BIU3jrPA==",
+      "dependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@redis/bloom": {
@@ -15275,6 +15284,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "stubs/cpu-features": {

--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -89,6 +89,7 @@
     "@nestjs/typeorm": "^11.0.3",
     "@nestjs/websockets": "^11.1.29",
     "@okta/okta-auth-js": "^7.14.5",
+    "@redis-iris/agent-memory": "^0.2.0",
     "@segment/analytics-node": "^2.3.0",
     "@supercharge/promise-pool": "^3.3.0",
     "@types/json-bigint": "^1.0.4",

--- a/redisinsight/api/src/app.module.ts
+++ b/redisinsight/api/src/app.module.ts
@@ -24,6 +24,7 @@ import { CustomTutorialModule } from 'src/modules/custom-tutorial/custom-tutoria
 import { CloudModule } from 'src/modules/cloud/cloud.module';
 import { AzureModule } from 'src/modules/azure/azure.module';
 import { RdiModule } from 'src/modules/rdi/rdi.module';
+import { AgentMemoryModule } from 'src/modules/agent-memory/agent-memory.module';
 import { AiChatModule } from 'src/modules/ai/chat/ai-chat.module';
 import { AiQueryModule } from 'src/modules/ai/query/ai-query.module';
 import { InitModule } from 'src/modules/init/init.module';
@@ -78,6 +79,7 @@ const STATICS_CONFIG = config.get('statics') as Config['statics'];
     AiChatModule,
     AiQueryModule.register(),
     RdiModule.register(),
+    AgentMemoryModule.register(),
     StaticsManagementModule.register({
       initDefaults: STATICS_CONFIG.initDefaults,
       autoUpdate: STATICS_CONFIG.autoUpdate,

--- a/redisinsight/api/src/modules/agent-memory/agent-memory-data.controller.ts
+++ b/redisinsight/api/src/modules/agent-memory/agent-memory-data.controller.ts
@@ -1,0 +1,143 @@
+import {
+  Body,
+  ClassSerializerInterceptor,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseInterceptors,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { AgentMemoryClientMetadata } from 'src/modules/agent-memory/models';
+import { AgentMemoryDataService } from 'src/modules/agent-memory/agent-memory-data.service';
+import {
+  AgentMemoryConfiguration,
+  DiscoveryFiltersResponse,
+  LongTermMemorySearchResponse,
+  WorkingMemoryResponse,
+} from 'src/modules/agent-memory/agent-memory.types';
+import { ApiEndpoint } from 'src/decorators/api-endpoint.decorator';
+import {
+  AddSessionEventDto,
+  DeleteLongTermMemoriesDto,
+  SearchLongTermMemoryDto,
+} from 'src/modules/agent-memory/dto';
+import { RequestAgentMemoryClientMetadata } from 'src/modules/agent-memory/decorators';
+
+@ApiTags('Agent Memory')
+@UsePipes(new ValidationPipe({ transform: true }))
+@UseInterceptors(ClassSerializerInterceptor)
+@Controller('agent-memory/:id')
+export class AgentMemoryDataController {
+  constructor(private readonly service: AgentMemoryDataService) {}
+
+  @Get('/sessions')
+  @ApiEndpoint({
+    description: 'List session ids on the connected agent memory endpoint',
+    responses: [{ status: 200 }],
+  })
+  async listSessions(
+    @RequestAgentMemoryClientMetadata() metadata: AgentMemoryClientMetadata,
+    @Query('userId') userId?: string,
+  ): Promise<string[]> {
+    return this.service.listSessions(metadata, { userId });
+  }
+
+  @Get('/working-memory/:sessionId')
+  @ApiEndpoint({
+    description: 'Get working memory (message log + summary) for a session',
+    responses: [{ status: 200 }],
+  })
+  async getWorkingMemory(
+    @RequestAgentMemoryClientMetadata() metadata: AgentMemoryClientMetadata,
+    @Param('sessionId') sessionId: string,
+    @Query('userId') userId?: string,
+  ): Promise<WorkingMemoryResponse> {
+    return this.service.getWorkingMemory(metadata, sessionId, {
+      userId,
+    });
+  }
+
+  @Delete('/working-memory/:sessionId')
+  @ApiEndpoint({
+    description: 'Clear working memory for a session',
+    responses: [{ status: 200 }],
+  })
+  async deleteWorkingMemory(
+    @RequestAgentMemoryClientMetadata() metadata: AgentMemoryClientMetadata,
+    @Param('sessionId') sessionId: string,
+    @Query('userId') userId?: string,
+  ): Promise<void> {
+    return this.service.deleteWorkingMemory(metadata, sessionId, {
+      userId,
+    });
+  }
+
+  @Post('/working-memory/:sessionId/messages')
+  @ApiEndpoint({
+    description:
+      "Append a message to a session's working memory (creates the session when the id is new)",
+    statusCode: 201,
+    responses: [{ status: 201 }],
+  })
+  async appendMessage(
+    @RequestAgentMemoryClientMetadata() metadata: AgentMemoryClientMetadata,
+    @Param('sessionId') sessionId: string,
+    @Body() dto: AddSessionEventDto,
+    @Query('userId') userId?: string,
+  ): Promise<void> {
+    return this.service.appendMessage(metadata, sessionId, { userId }, dto);
+  }
+
+  @Post('/long-term-memory/search')
+  @ApiEndpoint({
+    description: 'Search long-term memories (hybrid vector + keyword)',
+    statusCode: 200,
+    responses: [{ status: 200 }],
+  })
+  async searchLongTermMemory(
+    @RequestAgentMemoryClientMetadata() metadata: AgentMemoryClientMetadata,
+    @Body() dto: SearchLongTermMemoryDto,
+  ): Promise<LongTermMemorySearchResponse> {
+    return this.service.searchLongTermMemory(metadata, dto);
+  }
+
+  @Delete('/long-term-memory')
+  @ApiEndpoint({
+    description: 'Delete long-term memories by ids',
+    responses: [{ status: 200 }],
+  })
+  async deleteLongTermMemories(
+    @RequestAgentMemoryClientMetadata() metadata: AgentMemoryClientMetadata,
+    @Body() dto: DeleteLongTermMemoriesDto,
+  ): Promise<void> {
+    return this.service.deleteLongTermMemories(metadata, dto.ids);
+  }
+
+  @Get('/discovery')
+  @ApiEndpoint({
+    description: 'Discover distinct user ids present in long-term memory',
+    responses: [{ status: 200 }],
+  })
+  async discoverFilters(
+    @RequestAgentMemoryClientMetadata() metadata: AgentMemoryClientMetadata,
+  ): Promise<DiscoveryFiltersResponse> {
+    return this.service.discoverFilters(metadata);
+  }
+
+  @Get('/config')
+  @ApiEndpoint({
+    description: 'Get the store configuration (general settings + memory TTLs)',
+    responses: [{ status: 200 }],
+  })
+  async getConfiguration(
+    @RequestAgentMemoryClientMetadata() metadata: AgentMemoryClientMetadata,
+  ): Promise<AgentMemoryConfiguration> {
+    return this.service.getConfiguration(metadata);
+  }
+}

--- a/redisinsight/api/src/modules/agent-memory/agent-memory-data.service.ts
+++ b/redisinsight/api/src/modules/agent-memory/agent-memory-data.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@nestjs/common';
+
+import { AgentMemoryClientMetadata } from 'src/modules/agent-memory/models';
+import { AgentMemoryClientProvider } from 'src/modules/agent-memory/providers/agent-memory.client.provider';
+import {
+  AgentMemoryConfiguration,
+  AgentMemoryNewMessage,
+  AgentMemoryScopeFilter,
+  DiscoveryFiltersResponse,
+  LongTermMemorySearchResponse,
+  WorkingMemoryResponse,
+} from 'src/modules/agent-memory/agent-memory.types';
+import { SearchLongTermMemoryDto } from 'src/modules/agent-memory/dto';
+
+/**
+ * Proxies inspector data reads/writes to the connected agent memory
+ * backend. All methods resolve a pooled client for the requesting session
+ * first, so the endpoint's credentials never leave the backend.
+ */
+@Injectable()
+export class AgentMemoryDataService {
+  constructor(private readonly clientProvider: AgentMemoryClientProvider) {}
+
+  async listSessions(
+    metadata: AgentMemoryClientMetadata,
+    filter: AgentMemoryScopeFilter,
+  ): Promise<string[]> {
+    const client = await this.clientProvider.getOrCreate(metadata);
+    return client.listSessions(filter);
+  }
+
+  async getWorkingMemory(
+    metadata: AgentMemoryClientMetadata,
+    sessionId: string,
+    filter: AgentMemoryScopeFilter,
+  ): Promise<WorkingMemoryResponse> {
+    const client = await this.clientProvider.getOrCreate(metadata);
+    return client.getWorkingMemory(sessionId, filter);
+  }
+
+  async deleteWorkingMemory(
+    metadata: AgentMemoryClientMetadata,
+    sessionId: string,
+    filter: AgentMemoryScopeFilter,
+  ): Promise<void> {
+    const client = await this.clientProvider.getOrCreate(metadata);
+    return client.deleteWorkingMemory(sessionId, filter);
+  }
+
+  async appendMessage(
+    metadata: AgentMemoryClientMetadata,
+    sessionId: string,
+    filter: AgentMemoryScopeFilter,
+    message: AgentMemoryNewMessage,
+  ): Promise<void> {
+    const client = await this.clientProvider.getOrCreate(metadata);
+    return client.appendMessage(sessionId, filter, message);
+  }
+
+  async searchLongTermMemory(
+    metadata: AgentMemoryClientMetadata,
+    dto: SearchLongTermMemoryDto,
+  ): Promise<LongTermMemorySearchResponse> {
+    const client = await this.clientProvider.getOrCreate(metadata);
+    return client.searchLongTermMemory(dto);
+  }
+
+  async deleteLongTermMemories(
+    metadata: AgentMemoryClientMetadata,
+    ids: string[],
+  ): Promise<void> {
+    const client = await this.clientProvider.getOrCreate(metadata);
+    return client.deleteLongTermMemories(ids);
+  }
+
+  async discoverFilters(
+    metadata: AgentMemoryClientMetadata,
+  ): Promise<DiscoveryFiltersResponse> {
+    const client = await this.clientProvider.getOrCreate(metadata);
+    return client.discoverFilters();
+  }
+
+  async getConfiguration(
+    metadata: AgentMemoryClientMetadata,
+  ): Promise<AgentMemoryConfiguration> {
+    const client = await this.clientProvider.getOrCreate(metadata);
+    return client.getConfiguration();
+  }
+}

--- a/redisinsight/api/src/modules/agent-memory/agent-memory.controller.ts
+++ b/redisinsight/api/src/modules/agent-memory/agent-memory.controller.ts
@@ -1,0 +1,117 @@
+import {
+  Body,
+  ClassSerializerInterceptor,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseInterceptors,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import {
+  AgentMemoryClientMetadata,
+  AgentMemoryEndpoint,
+} from 'src/modules/agent-memory/models';
+import { AgentMemoryService } from 'src/modules/agent-memory/agent-memory.service';
+import { ApiEndpoint } from 'src/decorators/api-endpoint.decorator';
+import {
+  CreateAgentMemoryEndpointDto,
+  DeleteAgentMemoryEndpointsDto,
+  UpdateAgentMemoryEndpointDto,
+} from 'src/modules/agent-memory/dto';
+import { RequestAgentMemoryClientMetadata } from 'src/modules/agent-memory/decorators';
+import { RequestSessionMetadata } from 'src/common/decorators';
+import { SessionMetadata } from 'src/common/models';
+
+@ApiTags('Agent Memory')
+// The input transform needs the 'security' group so the group-guarded
+// apiKey field survives into the DTO. Responses are serialized by the
+// interceptor WITHOUT groups, so apiKey still never leaves the backend.
+@UsePipes(
+  new ValidationPipe({
+    transform: true,
+    transformOptions: { groups: ['security'] },
+  }),
+)
+@UseInterceptors(ClassSerializerInterceptor)
+@Controller('agent-memory')
+export class AgentMemoryController {
+  constructor(private readonly service: AgentMemoryService) {}
+
+  @Get()
+  @ApiEndpoint({
+    description: 'Get agent memory endpoints list',
+    responses: [{ status: 200, isArray: true, type: AgentMemoryEndpoint }],
+  })
+  async list(): Promise<AgentMemoryEndpoint[]> {
+    return this.service.list();
+  }
+
+  @Get('/:id')
+  @ApiEndpoint({
+    description: 'Get agent memory endpoint by id',
+    responses: [{ status: 200, type: AgentMemoryEndpoint }],
+  })
+  async get(@Param('id') id: string): Promise<AgentMemoryEndpoint> {
+    return this.service.get(id);
+  }
+
+  @Post()
+  @ApiEndpoint({
+    description: 'Create agent memory endpoint',
+    statusCode: 201,
+    responses: [{ status: 201, type: AgentMemoryEndpoint }],
+  })
+  async create(
+    @RequestSessionMetadata() sessionMetadata: SessionMetadata,
+    @Body() dto: CreateAgentMemoryEndpointDto,
+  ): Promise<AgentMemoryEndpoint> {
+    return this.service.create(sessionMetadata, dto);
+  }
+
+  @Patch('/:id')
+  @ApiEndpoint({
+    description: 'Update agent memory endpoint',
+    responses: [{ status: 200, type: AgentMemoryEndpoint }],
+  })
+  async update(
+    @RequestAgentMemoryClientMetadata() metadata: AgentMemoryClientMetadata,
+    @Body() dto: UpdateAgentMemoryEndpointDto,
+  ): Promise<AgentMemoryEndpoint> {
+    return this.service.update(metadata, dto);
+  }
+
+  @Delete()
+  @ApiEndpoint({
+    description: 'Delete agent memory endpoints',
+    responses: [{ status: 200 }],
+  })
+  async delete(
+    @Body() dto: DeleteAgentMemoryEndpointsDto,
+    @RequestSessionMetadata() sessionMetadata: SessionMetadata,
+  ): Promise<void> {
+    return this.service.delete(sessionMetadata, dto.ids);
+  }
+
+  @Get(':id/connect')
+  @ApiEndpoint({
+    description: 'Verify the agent memory endpoint is reachable',
+    statusCode: 200,
+    responses: [
+      {
+        status: 200,
+        description: 'Successfully connected to the agent memory endpoint',
+      },
+    ],
+  })
+  async connect(
+    @RequestAgentMemoryClientMetadata() metadata: AgentMemoryClientMetadata,
+  ) {
+    return this.service.connect(metadata);
+  }
+}

--- a/redisinsight/api/src/modules/agent-memory/agent-memory.module.ts
+++ b/redisinsight/api/src/modules/agent-memory/agent-memory.module.ts
@@ -1,0 +1,33 @@
+import { Module, Type } from '@nestjs/common';
+import { AgentMemoryController } from 'src/modules/agent-memory/agent-memory.controller';
+import { AgentMemoryDataController } from 'src/modules/agent-memory/agent-memory-data.controller';
+import { AgentMemoryService } from 'src/modules/agent-memory/agent-memory.service';
+import { AgentMemoryDataService } from 'src/modules/agent-memory/agent-memory-data.service';
+import { AgentMemoryEndpointRepository } from 'src/modules/agent-memory/repository/agent-memory-endpoint.repository';
+import { LocalAgentMemoryEndpointRepository } from 'src/modules/agent-memory/repository/local.agent-memory-endpoint.repository';
+import { AgentMemoryClientProvider } from 'src/modules/agent-memory/providers/agent-memory.client.provider';
+import { AgentMemoryClientStorage } from 'src/modules/agent-memory/providers/agent-memory.client.storage';
+import { AgentMemoryClientFactory } from 'src/modules/agent-memory/providers/agent-memory.client.factory';
+
+@Module({})
+export class AgentMemoryModule {
+  static register(
+    endpointRepository: Type<AgentMemoryEndpointRepository> = LocalAgentMemoryEndpointRepository,
+  ) {
+    return {
+      module: AgentMemoryModule,
+      controllers: [AgentMemoryController, AgentMemoryDataController],
+      providers: [
+        AgentMemoryService,
+        AgentMemoryDataService,
+        AgentMemoryClientProvider,
+        AgentMemoryClientStorage,
+        AgentMemoryClientFactory,
+        {
+          provide: AgentMemoryEndpointRepository,
+          useClass: endpointRepository,
+        },
+      ],
+    };
+  }
+}

--- a/redisinsight/api/src/modules/agent-memory/agent-memory.service.ts
+++ b/redisinsight/api/src/modules/agent-memory/agent-memory.service.ts
@@ -1,0 +1,156 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import { isUndefined, omitBy } from 'lodash';
+
+import {
+  CreateAgentMemoryEndpointDto,
+  UpdateAgentMemoryEndpointDto,
+} from 'src/modules/agent-memory/dto';
+import {
+  AgentMemoryClientMetadata,
+  AgentMemoryEndpoint,
+} from 'src/modules/agent-memory/models';
+import { AgentMemoryEndpointRepository } from 'src/modules/agent-memory/repository/agent-memory-endpoint.repository';
+import { AgentMemoryClientProvider } from 'src/modules/agent-memory/providers/agent-memory.client.provider';
+import { AgentMemoryClientFactory } from 'src/modules/agent-memory/providers/agent-memory.client.factory';
+import { classToClass } from 'src/utils';
+import { SessionMetadata } from 'src/common/models';
+import { deepMerge } from 'src/common/utils';
+import { wrapAgentMemoryError } from 'src/modules/agent-memory/exceptions';
+
+@Injectable()
+export class AgentMemoryService {
+  private logger = new Logger('AgentMemoryService');
+
+  static connectionFields: string[] = [
+    'url',
+    'backendType',
+    'storeId',
+    'apiKey',
+  ];
+
+  constructor(
+    private readonly repository: AgentMemoryEndpointRepository,
+    private readonly clientProvider: AgentMemoryClientProvider,
+    private readonly clientFactory: AgentMemoryClientFactory,
+  ) {}
+
+  static isConnectionAffected(dto: UpdateAgentMemoryEndpointDto) {
+    return Object.keys(omitBy(dto, isUndefined)).some((field) =>
+      this.connectionFields.includes(field),
+    );
+  }
+
+  async list(): Promise<AgentMemoryEndpoint[]> {
+    return this.repository.list();
+  }
+
+  async get(id: string): Promise<AgentMemoryEndpoint> {
+    const endpoint = await this.repository.get(id);
+
+    if (!endpoint) {
+      throw new NotFoundException(
+        `Agent memory endpoint with id ${id} was not found`,
+      );
+    }
+
+    return endpoint;
+  }
+
+  async create(
+    sessionMetadata: SessionMetadata,
+    dto: CreateAgentMemoryEndpointDto,
+  ): Promise<AgentMemoryEndpoint> {
+    const model = classToClass(AgentMemoryEndpoint, dto);
+    model.lastConnection = new Date();
+
+    const metadata: AgentMemoryClientMetadata = {
+      sessionMetadata,
+      id: uuidv4(),
+    };
+
+    try {
+      // Validate connectivity before persisting
+      await this.clientFactory.createClient(metadata, model);
+    } catch (error) {
+      this.logger.error(
+        'Failed to create agent memory endpoint',
+        sessionMetadata,
+      );
+
+      throw wrapAgentMemoryError(error);
+    }
+
+    this.logger.debug(
+      'Succeed to create agent memory endpoint',
+      sessionMetadata,
+    );
+    return this.repository.create(model);
+  }
+
+  async update(
+    metadata: AgentMemoryClientMetadata,
+    dto: UpdateAgentMemoryEndpointDto,
+  ): Promise<AgentMemoryEndpoint> {
+    const oldEndpoint = await this.get(metadata.id);
+    const newEndpoint = await deepMerge(oldEndpoint, dto);
+
+    try {
+      if (AgentMemoryService.isConnectionAffected(dto)) {
+        await this.clientFactory.createClient(metadata, newEndpoint);
+        await this.clientProvider.deleteManyByEndpointId(metadata.id);
+      }
+
+      return await this.repository.update(metadata.id, newEndpoint);
+    } catch (error) {
+      this.logger.error(
+        `Failed to update agent memory endpoint ${metadata.id}`,
+        error,
+        metadata,
+      );
+      throw wrapAgentMemoryError(error);
+    }
+  }
+
+  async delete(sessionMetadata: SessionMetadata, ids: string[]): Promise<void> {
+    try {
+      await this.repository.delete(ids);
+      await Promise.all(
+        ids.map(async (id) => {
+          await this.clientProvider.deleteManyByEndpointId(id);
+        }),
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to delete endpoint(s): ${ids}`,
+        error,
+        sessionMetadata,
+      );
+      throw new InternalServerErrorException();
+    }
+  }
+
+  /** Verify the endpoint is reachable and its credentials are valid. */
+  async connect(metadata: AgentMemoryClientMetadata) {
+    try {
+      await this.clientProvider.getOrCreate(metadata);
+
+      this.logger.debug(
+        `Succeed to connect to agent memory endpoint ${metadata.id}`,
+        metadata,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to connect to agent memory endpoint ${metadata.id}`,
+        error,
+        metadata,
+      );
+      throw wrapAgentMemoryError(error);
+    }
+  }
+}

--- a/redisinsight/api/src/modules/agent-memory/agent-memory.types.ts
+++ b/redisinsight/api/src/modules/agent-memory/agent-memory.types.ts
@@ -1,0 +1,71 @@
+/**
+ * Normalized (camelCase) shapes returned to the UI. The backend client
+ * translates the Redis Agent Memory service's responses into these shapes
+ * so the UI reads one consistent contract.
+ */
+
+export interface AgentMemoryMessage {
+  id?: string;
+  role: string;
+  content: string;
+  createdAt?: string;
+}
+
+export interface AgentMemorySummary {
+  text: string;
+  updatedAt?: string;
+  summarizedEvents?: number;
+}
+
+export interface WorkingMemoryResponse {
+  sessionId: string;
+  userId?: string;
+  namespace?: string;
+  messages: AgentMemoryMessage[];
+  /** Compacted summary of older session history, maintained by the
+   * backend summarization workflow. Absent until the first cycle runs. */
+  summary?: AgentMemorySummary;
+  createdAt?: string;
+}
+
+export interface LongTermMemoryRecord {
+  id: string;
+  text: string;
+  memoryType?: string;
+  userId?: string;
+  sessionId?: string;
+  namespace?: string;
+  topics: string[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface LongTermMemorySearchResponse {
+  memories: LongTermMemoryRecord[];
+  total: number;
+}
+
+export interface DiscoveryFiltersResponse {
+  users: string[];
+  namespaces: string[];
+}
+
+export interface AgentMemoryNewMessage {
+  role: string;
+  content: string;
+}
+
+export interface AgentMemoryScopeFilter {
+  userId?: string;
+}
+
+/**
+ * Store configuration as shown in the Redis Cloud console (General
+ * Settings). Fields the backend doesn't expose stay undefined.
+ */
+export interface AgentMemoryConfiguration {
+  serviceName?: string;
+  storeId?: string;
+  database?: string;
+  endpoint?: string;
+}

--- a/redisinsight/api/src/modules/agent-memory/client/agent-memory.client.ts
+++ b/redisinsight/api/src/modules/agent-memory/client/agent-memory.client.ts
@@ -1,0 +1,116 @@
+import axios, { AxiosInstance, CreateAxiosDefaults } from 'axios';
+
+import {
+  AgentMemoryClientMetadata,
+  AgentMemoryEndpoint,
+} from 'src/modules/agent-memory/models';
+import {
+  wrapAgentMemoryError,
+  wrapSdkError,
+} from 'src/modules/agent-memory/exceptions';
+import {
+  AgentMemoryNewMessage,
+  AgentMemoryConfiguration,
+  AgentMemoryScopeFilter,
+  DiscoveryFiltersResponse,
+  LongTermMemorySearchResponse,
+  WorkingMemoryResponse,
+} from 'src/modules/agent-memory/agent-memory.types';
+import { SearchLongTermMemoryDto } from 'src/modules/agent-memory/dto';
+import { AGENT_MEMORY_IDLE_THRESHOLD } from 'src/modules/agent-memory/constants';
+
+export abstract class AgentMemoryClient {
+  public readonly id: string;
+
+  public lastUsed: number = Date.now();
+
+  protected constructor(
+    public readonly metadata: AgentMemoryClientMetadata,
+    protected readonly endpoint: AgentMemoryEndpoint,
+  ) {
+    this.id = AgentMemoryClient.generateId(this.metadata);
+  }
+
+  public isIdle(): boolean {
+    return Date.now() - this.lastUsed > AGENT_MEMORY_IDLE_THRESHOLD;
+  }
+
+  /**
+   * Build the axios instance with a response interceptor that maps
+   * transport errors to sanitized HTTP exceptions, so individual client
+   * methods don't need per-call try/catch wrappers (methods that want a
+   * fallback instead can still catch the wrapped error).
+   */
+  protected createApi(config: CreateAxiosDefaults): AxiosInstance {
+    const api = axios.create(config);
+    api.interceptors.response.use(undefined, (error) =>
+      Promise.reject(wrapAgentMemoryError(error)),
+    );
+    return api;
+  }
+
+  /** Run an SDK request, mapping its errors like the axios interceptor */
+  protected async sdkCall<T>(request: () => Promise<T>): Promise<T> {
+    try {
+      return await request();
+    } catch (error) {
+      throw wrapSdkError(error);
+    }
+  }
+
+  public setLastUsed(): void {
+    this.lastUsed = Date.now();
+  }
+
+  /** Verify the endpoint is reachable and credentials are valid */
+  abstract connect(): Promise<void>;
+
+  /** Re-validate auth before a pooled client is reused */
+  abstract ensureAuth(): Promise<void>;
+
+  abstract listSessions(filter: AgentMemoryScopeFilter): Promise<string[]>;
+
+  abstract getWorkingMemory(
+    sessionId: string,
+    filter: AgentMemoryScopeFilter,
+  ): Promise<WorkingMemoryResponse>;
+
+  abstract deleteWorkingMemory(
+    sessionId: string,
+    filter: AgentMemoryScopeFilter,
+  ): Promise<void>;
+
+  /** Append one message to a session's working memory (creates the
+   * session when the id is new) */
+  abstract appendMessage(
+    sessionId: string,
+    filter: AgentMemoryScopeFilter,
+    message: AgentMemoryNewMessage,
+  ): Promise<void>;
+
+  abstract searchLongTermMemory(
+    dto: SearchLongTermMemoryDto,
+  ): Promise<LongTermMemorySearchResponse>;
+
+  abstract deleteLongTermMemories(ids: string[]): Promise<void>;
+
+  /** Derive distinct user ids by scanning long-term memory */
+  abstract discoverFilters(): Promise<DiscoveryFiltersResponse>;
+
+  /** Store configuration (general settings + memory TTLs) */
+  abstract getConfiguration(): Promise<AgentMemoryConfiguration>;
+
+  static generateId(cm: AgentMemoryClientMetadata): string {
+    const empty = '(nil)';
+    const separator = '_';
+
+    const uId = [
+      cm.sessionMetadata?.userId || empty,
+      cm.sessionMetadata?.accountId || empty,
+      cm.sessionMetadata?.sessionId || empty,
+      cm.sessionMetadata?.uniqueId || empty,
+    ].join(separator);
+
+    return [cm.id, uId].join(separator);
+  }
+}

--- a/redisinsight/api/src/modules/agent-memory/client/cloud.agent-memory.client.ts
+++ b/redisinsight/api/src/modules/agent-memory/client/cloud.agent-memory.client.ts
@@ -1,0 +1,245 @@
+import { BadRequestException } from '@nestjs/common';
+import { AxiosInstance } from 'axios';
+import { AgentMemory as IrisAgentMemoryClient } from '@redis-iris/agent-memory';
+
+type IrisSearchRequest = NonNullable<
+  Parameters<IrisAgentMemoryClient['searchLongTermMemory']>[0]
+>;
+type IrisFilter = NonNullable<IrisSearchRequest['filter']>;
+type IrisMessageRole = Parameters<
+  IrisAgentMemoryClient['addSessionEvent']
+>[0]['role'];
+
+import {
+  AgentMemoryClientMetadata,
+  AgentMemoryEndpoint,
+} from 'src/modules/agent-memory/models';
+import {
+  AgentMemoryConfiguration,
+  AgentMemoryNewMessage,
+  AgentMemoryScopeFilter,
+  DiscoveryFiltersResponse,
+  LongTermMemorySearchResponse,
+  WorkingMemoryResponse,
+} from 'src/modules/agent-memory/agent-memory.types';
+import { SearchLongTermMemoryDto } from 'src/modules/agent-memory/dto';
+import {
+  AGENT_MEMORY_TIMEOUT,
+  CLOUD_EVENT_ROLES,
+  LONG_TERM_MEMORY_SEARCH_LIMIT,
+  SESSIONS_LIST_LIMIT,
+} from 'src/modules/agent-memory/constants';
+import { AgentMemoryClient } from 'src/modules/agent-memory/client/agent-memory.client';
+import {
+  fromCloudMemory,
+  fromCloudSessionMemory,
+} from 'src/modules/agent-memory/client/transformers';
+
+/**
+ * Client for the Redis Cloud agent memory service (Iris / Context Engine).
+ *
+ * Endpoints live under /v1/stores/{storeId}/... and require a bearer API
+ * key. Responses are camelCase with cloud-specific field names and are
+ * normalized to the shared shapes before leaving this class. Transport
+ * errors are mapped to sanitized HTTP exceptions by the base-class
+ * response interceptor.
+ *
+ * The cloud search endpoint rejects requests with neither `text` nor
+ * `filter`; a single-space text is used as a benign match-all sentinel.
+ */
+const MATCH_ALL_TEXT = ' ';
+
+export class CloudAgentMemoryClient extends AgentMemoryClient {
+  protected readonly api: AxiosInstance;
+
+  /** Official Iris data-plane SDK - used for everything except the store
+   * details lookup, which is outside its surface. */
+  private readonly sdk: IrisAgentMemoryClient;
+
+  constructor(
+    metadata: AgentMemoryClientMetadata,
+    endpoint: AgentMemoryEndpoint,
+  ) {
+    super(metadata, endpoint);
+
+    if (!endpoint.storeId || !endpoint.apiKey) {
+      throw new BadRequestException(
+        'Store ID and API key are required for the Redis Cloud backend',
+      );
+    }
+
+    const baseUrl = endpoint.url.replace(/\/+$/, '');
+
+    this.api = this.createApi({
+      baseURL: `${baseUrl}/v1/stores/${encodeURIComponent(endpoint.storeId)}`,
+      timeout: AGENT_MEMORY_TIMEOUT,
+      headers: {
+        Authorization: `Bearer ${endpoint.apiKey}`,
+        Accept: 'application/json',
+      },
+    });
+
+    this.sdk = new IrisAgentMemoryClient({
+      serverURL: baseUrl,
+      storeId: endpoint.storeId,
+      apiKey: endpoint.apiKey,
+      timeoutMs: AGENT_MEMORY_TIMEOUT,
+    });
+  }
+
+  async connect(): Promise<void> {
+    // A cheap authenticated list call verifies host + credentials +
+    // store id in one shot. The service requires either an owner filter
+    // or includeAll=true on listings.
+    await this.sdkCall(() =>
+      this.sdk.listSessions(1, undefined, undefined, true),
+    );
+  }
+
+  async ensureAuth(): Promise<void> {
+    // Static bearer token - nothing to refresh.
+  }
+
+  async listSessions(filter: AgentMemoryScopeFilter): Promise<string[]> {
+    // The service requires either an owner filter or includeAll=true
+    const data = await this.sdkCall(() =>
+      this.sdk.listSessions(
+        SESSIONS_LIST_LIMIT,
+        undefined,
+        filter.userId || undefined,
+        filter.userId ? undefined : true,
+      ),
+    );
+    return (data?.items ?? []).filter((id): id is string => Boolean(id));
+  }
+
+  async getWorkingMemory(
+    sessionId: string,
+    _filter: AgentMemoryScopeFilter,
+  ): Promise<WorkingMemoryResponse> {
+    const data = await this.sdkCall(() => this.sdk.getSessionMemory(sessionId));
+    return fromCloudSessionMemory(data ?? {});
+  }
+
+  async deleteWorkingMemory(
+    sessionId: string,
+    _filter: AgentMemoryScopeFilter,
+  ): Promise<void> {
+    await this.sdkCall(() => this.sdk.deleteSessionMemory(sessionId));
+  }
+
+  /**
+   * The service has a first-class append endpoint. Roles are limited to
+   * USER/ASSISTANT/SYSTEM per its spec ('tool' has no equivalent).
+   */
+  async appendMessage(
+    sessionId: string,
+    filter: AgentMemoryScopeFilter,
+    message: AgentMemoryNewMessage,
+  ): Promise<void> {
+    const role = message.role.toUpperCase();
+    if (!(CLOUD_EVENT_ROLES as readonly string[]).includes(role)) {
+      throw new BadRequestException(
+        `Role "${message.role}" is not supported by the Redis Cloud backend`,
+      );
+    }
+    await this.sdkCall(() =>
+      this.sdk.addSessionEvent({
+        sessionId,
+        actorId: filter.userId || 'redisinsight',
+        role: role as IrisMessageRole,
+        content: [{ text: message.content }],
+        createdAt: new Date(),
+      }),
+    );
+  }
+
+  async searchLongTermMemory(
+    dto: SearchLongTermMemoryDto,
+  ): Promise<LongTermMemorySearchResponse> {
+    const filter: IrisFilter = {};
+    const userIds = dto.userIds ?? [];
+    if (userIds.length === 1) filter.ownerId = { eq: userIds[0] };
+    else if (userIds.length > 1) filter.ownerId = { in: userIds };
+    else if (dto.userId) filter.ownerId = { eq: dto.userId };
+    const sessionIds = dto.sessionIds ?? [];
+    if (sessionIds.length === 1) filter.sessionId = { eq: sessionIds[0] };
+    else if (sessionIds.length > 1) filter.sessionId = { in: sessionIds };
+    const memoryTypes = dto.memoryTypes ?? [];
+    if (memoryTypes.length === 1) filter.memoryType = { eq: memoryTypes[0] };
+    else if (memoryTypes.length > 1) filter.memoryType = { in: memoryTypes };
+    const namespaces = dto.namespaces ?? [];
+    if (namespaces.length === 1) filter.namespace = { eq: namespaces[0] };
+    else if (namespaces.length > 1) filter.namespace = { in: namespaces };
+    if (dto.topics?.length) filter.topics = { in: dto.topics };
+
+    const hasFilter = Object.keys(filter).length > 0;
+    let text: string | undefined;
+    if (dto.text?.trim()) {
+      text = dto.text;
+    } else if (!hasFilter) {
+      text = MATCH_ALL_TEXT;
+    }
+
+    const data = await this.sdkCall(() =>
+      this.sdk.searchLongTermMemory({
+        text,
+        similarityThreshold: dto.similarityThreshold,
+        limit: LONG_TERM_MEMORY_SEARCH_LIMIT,
+        filter: hasFilter ? filter : undefined,
+        // AND across filter keys so scoping (ownerId, sessionId) and
+        // narrowing (topics) compose. Within each {in: [...]} list the
+        // values stay OR'd.
+        filterOp: hasFilter ? 'all' : undefined,
+      }),
+    );
+    const items = (data?.items ?? []).map(fromCloudMemory);
+    return { memories: items, total: items.length };
+  }
+
+  async deleteLongTermMemories(ids: string[]): Promise<void> {
+    await this.sdkCall(() =>
+      this.sdk.bulkDeleteLongTermMemories({ memoryIds: ids }),
+    );
+  }
+
+  async discoverFilters(): Promise<DiscoveryFiltersResponse> {
+    const data = await this.sdkCall(() =>
+      this.sdk.searchLongTermMemory({ text: MATCH_ALL_TEXT }),
+    );
+    const items = data?.items ?? [];
+    const users = [
+      ...new Set(
+        items.map((m) => m.ownerId).filter((id): id is string => Boolean(id)),
+      ),
+    ];
+    const namespaces = [
+      ...new Set(
+        items.map((m) => m.namespace).filter((ns): ns is string => Boolean(ns)),
+      ),
+    ];
+    return { users, namespaces };
+  }
+
+  /**
+   * Fetch the store details (as shown on cloud.redis.io). Field names are
+   * mapped defensively - missing fields fall back to the connection
+   * details RedisInsight manages itself.
+   */
+  async getConfiguration(): Promise<AgentMemoryConfiguration> {
+    let store: Record<string, any> = {};
+    try {
+      const { data } = await this.api.get('');
+      store = data ?? {};
+    } catch {
+      // store details endpoint unavailable - fall back to local knowledge
+    }
+
+    return {
+      serviceName: store.name ?? store.serviceName ?? this.endpoint.name,
+      storeId: store.id ?? this.endpoint.storeId,
+      database: store.databaseName ?? store.database ?? store.databaseId,
+      endpoint: store.endpoint ?? store.publicEndpoint ?? this.endpoint.url,
+    };
+  }
+}

--- a/redisinsight/api/src/modules/agent-memory/client/transformers.spec.ts
+++ b/redisinsight/api/src/modules/agent-memory/client/transformers.spec.ts
@@ -1,0 +1,62 @@
+import {
+  fromCloudEvent,
+  fromCloudMemory,
+  fromCloudSessionMemory,
+} from 'src/modules/agent-memory/client/transformers';
+
+describe('agent memory transformers', () => {
+  describe('fromCloudEvent', () => {
+    it('should flatten content and lowercase the role', () => {
+      expect(
+        fromCloudEvent({
+          eventId: 'e-1',
+          role: 'ASSISTANT',
+          content: [{ text: 'hello' }],
+          createdAt: '2026-01-01T00:00:00Z',
+        }),
+      ).toEqual({
+        id: 'e-1',
+        role: 'assistant',
+        content: 'hello',
+        createdAt: '2026-01-01T00:00:00Z',
+      });
+    });
+  });
+
+  describe('fromCloudSessionMemory', () => {
+    it('should map ownerId to userId and events to messages', () => {
+      const result = fromCloudSessionMemory({
+        sessionId: 's-1',
+        ownerId: 'u-1',
+        events: [{ eventId: 'e-1', role: 'USER', content: [{ text: 'hi' }] }],
+      });
+
+      expect(result.sessionId).toEqual('s-1');
+      expect(result.userId).toEqual('u-1');
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].content).toEqual('hi');
+    });
+  });
+
+  describe('fromCloudMemory', () => {
+    it('should map cloud fields to the normalized record shape', () => {
+      const result = fromCloudMemory({
+        id: 'mem-1',
+        text: 'likes redis',
+        memoryType: 'semantic',
+        ownerId: 'u-1',
+        sessionId: 's-1',
+        topics: ['databases'],
+        createdAt: '2026-01-01T00:00:00Z',
+      });
+
+      expect(result).toMatchObject({
+        id: 'mem-1',
+        memoryType: 'semantic',
+        userId: 'u-1',
+        sessionId: 's-1',
+        topics: ['databases'],
+      });
+    });
+  });
+});

--- a/redisinsight/api/src/modules/agent-memory/client/transformers.ts
+++ b/redisinsight/api/src/modules/agent-memory/client/transformers.ts
@@ -1,0 +1,62 @@
+import {
+  AgentMemoryMessage,
+  LongTermMemoryRecord,
+  WorkingMemoryResponse,
+} from 'src/modules/agent-memory/agent-memory.types';
+
+// The memory server may tag a memory with the same topic more than once -
+// dedupe so consumers can key UI elements on the values.
+const uniqueStrings = (values: unknown): string[] => [
+  ...new Set(Array.isArray(values) ? values : []),
+];
+
+/**
+ * Redis Agent Memory (camelCase) -> normalized camelCase shapes.
+ */
+
+export const fromCloudEvent = (
+  event: Record<string, any>,
+): AgentMemoryMessage => ({
+  id: event?.eventId,
+  role: (event?.role ?? 'user').toLowerCase(),
+  content: event?.content?.[0]?.text ?? '',
+  createdAt: event?.createdAt,
+});
+
+export const fromCloudSessionMemory = (
+  data: Record<string, any>,
+): WorkingMemoryResponse => ({
+  sessionId: data?.sessionId,
+  userId: data?.ownerId ?? undefined,
+  namespace: data?.namespace ?? undefined,
+  messages: (data?.events ?? []).map(fromCloudEvent),
+  summary:
+    typeof data?.summary?.text === 'string' && data.summary.text
+      ? {
+          text: data.summary.text,
+          updatedAt: data.summary.updatedAt ?? undefined,
+          summarizedEvents: data.summary.summarizedEvents ?? undefined,
+        }
+      : undefined,
+  // The session record carries no created_at - approximate from the
+  // earliest event.
+  createdAt:
+    (data?.events ?? [])
+      .map((event: Record<string, any>) => event?.createdAt)
+      .filter(Boolean)
+      .sort()[0] ?? undefined,
+});
+
+export const fromCloudMemory = (
+  memory: Record<string, any>,
+): LongTermMemoryRecord => ({
+  id: memory?.id,
+  text: memory?.text ?? '',
+  memoryType: memory?.memoryType,
+  userId: memory?.ownerId ?? undefined,
+  sessionId: memory?.sessionId ?? undefined,
+  namespace: memory?.namespace ?? undefined,
+  topics: uniqueStrings(memory?.topics),
+  createdAt: memory?.createdAt,
+  updatedAt: memory?.updatedAt,
+});

--- a/redisinsight/api/src/modules/agent-memory/constants/index.ts
+++ b/redisinsight/api/src/modules/agent-memory/constants/index.ts
@@ -1,0 +1,18 @@
+export const AGENT_MEMORY_TIMEOUT = 30_000; // 30 sec
+export const AGENT_MEMORY_IDLE_THRESHOLD = 10 * 60 * 1000; // 10 min
+export const AGENT_MEMORY_SYNC_INTERVAL = 5 * 60 * 1000; // 5 min
+// lastConnection is display-only (the endpoints table) - throttle its
+// persistence so auto-refresh traffic doesn't write SQLite every request.
+export const LAST_CONNECTION_UPDATE_INTERVAL = 60 * 1000; // 1 min
+
+export const SESSIONS_LIST_LIMIT = 50;
+
+// The Cloud service accepts only these event roles.
+export const CLOUD_EVENT_ROLES = ['USER', 'ASSISTANT', 'SYSTEM'] as const;
+
+export const LONG_TERM_MEMORY_SEARCH_LIMIT = 50;
+
+export const AGENT_MEMORY_ERROR_MESSAGES = {
+  INVALID_ENDPOINT_ID: 'Invalid agent memory endpoint id.',
+  UNSUPPORTED_BACKEND: 'Unsupported agent memory backend type.',
+} as const;

--- a/redisinsight/api/src/modules/agent-memory/decorators/index.ts
+++ b/redisinsight/api/src/modules/agent-memory/decorators/index.ts
@@ -1,0 +1,1 @@
+export * from './request.agent-memory.client.metadata.decorator';

--- a/redisinsight/api/src/modules/agent-memory/decorators/request.agent-memory.client.metadata.decorator.ts
+++ b/redisinsight/api/src/modules/agent-memory/decorators/request.agent-memory.client.metadata.decorator.ts
@@ -1,0 +1,47 @@
+import {
+  BadRequestException,
+  createParamDecorator,
+  ExecutionContext,
+} from '@nestjs/common';
+import { sessionMetadataFromRequest } from 'src/common/decorators';
+import { plainToInstance } from 'class-transformer';
+import { AgentMemoryClientMetadata } from 'src/modules/agent-memory/models';
+import { Validator } from 'class-validator';
+import { ApiParam } from '@nestjs/swagger';
+
+const validator = new Validator();
+
+export const RequestAgentMemoryClientMetadata = createParamDecorator(
+  (_: unknown, ctx: ExecutionContext) => {
+    const req = ctx.switchToHttp().getRequest();
+
+    const metadata = plainToInstance(AgentMemoryClientMetadata, {
+      id: req.params?.['id'],
+      sessionMetadata: sessionMetadataFromRequest(req),
+    });
+
+    const errors = validator.validateSync(metadata, {
+      whitelist: false, // allow additional fields if needed for flexibility
+    });
+
+    if (errors?.length) {
+      throw new BadRequestException(
+        Object.values(errors[0].constraints ?? { error: 'Bad request' }),
+      );
+    }
+
+    return metadata;
+  },
+  [
+    (target: object, key: string | symbol | undefined) => {
+      if (key === undefined) return;
+      const descriptor = Object.getOwnPropertyDescriptor(target, key);
+      if (!descriptor) return;
+      ApiParam({
+        name: 'id',
+        schema: { type: 'string' },
+        required: true,
+      })(target, key, descriptor);
+    },
+  ],
+);

--- a/redisinsight/api/src/modules/agent-memory/dto/add.session-event.dto.ts
+++ b/redisinsight/api/src/modules/agent-memory/dto/add.session-event.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+
+const SESSION_EVENT_ROLES = ['user', 'assistant', 'system'] as const;
+
+export class AddSessionEventDto {
+  @ApiProperty({
+    description: 'Message role',
+    enum: SESSION_EVENT_ROLES,
+  })
+  @Expose()
+  @IsIn(SESSION_EVENT_ROLES)
+  role: string;
+
+  @ApiProperty({
+    description: 'Message content',
+    type: String,
+  })
+  @Expose()
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+}

--- a/redisinsight/api/src/modules/agent-memory/dto/create.agent-memory-endpoint.dto.ts
+++ b/redisinsight/api/src/modules/agent-memory/dto/create.agent-memory-endpoint.dto.ts
@@ -1,0 +1,7 @@
+import { OmitType } from '@nestjs/swagger';
+import { AgentMemoryEndpoint } from 'src/modules/agent-memory/models';
+
+export class CreateAgentMemoryEndpointDto extends OmitType(
+  AgentMemoryEndpoint,
+  ['id', 'lastConnection'] as const,
+) {}

--- a/redisinsight/api/src/modules/agent-memory/dto/delete.agent-memory-endpoints.dto.ts
+++ b/redisinsight/api/src/modules/agent-memory/dto/delete.agent-memory-endpoints.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { ArrayNotEmpty, IsArray, IsString } from 'class-validator';
+
+export class DeleteAgentMemoryEndpointsDto {
+  @ApiProperty({
+    description: 'Ids of agent memory endpoints to delete',
+    type: String,
+    isArray: true,
+  })
+  @Expose()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  ids: string[];
+}

--- a/redisinsight/api/src/modules/agent-memory/dto/delete.long-term-memories.dto.ts
+++ b/redisinsight/api/src/modules/agent-memory/dto/delete.long-term-memories.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { ArrayNotEmpty, IsArray, IsString } from 'class-validator';
+
+export class DeleteLongTermMemoriesDto {
+  @ApiProperty({
+    description: 'Ids of long-term memories to delete',
+    type: String,
+    isArray: true,
+  })
+  @Expose()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  ids: string[];
+}

--- a/redisinsight/api/src/modules/agent-memory/dto/index.ts
+++ b/redisinsight/api/src/modules/agent-memory/dto/index.ts
@@ -1,0 +1,6 @@
+export * from './create.agent-memory-endpoint.dto';
+export * from './update.agent-memory-endpoint.dto';
+export * from './delete.agent-memory-endpoints.dto';
+export * from './add.session-event.dto';
+export * from './search.long-term-memory.dto';
+export * from './delete.long-term-memories.dto';

--- a/redisinsight/api/src/modules/agent-memory/dto/search.long-term-memory.dto.ts
+++ b/redisinsight/api/src/modules/agent-memory/dto/search.long-term-memory.dto.ts
@@ -1,0 +1,98 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import {
+  IsArray,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class SearchLongTermMemoryDto {
+  @ApiPropertyOptional({
+    description: 'Text to search for (hybrid vector + keyword search)',
+    type: String,
+  })
+  @IsOptional()
+  @Expose()
+  @IsString()
+  text?: string;
+
+  @ApiPropertyOptional({
+    description: 'Scope results to a user id',
+    type: String,
+  })
+  @IsOptional()
+  @Expose()
+  @IsString()
+  userId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter to memories of any of these users (overrides userId)',
+    type: String,
+    isArray: true,
+  })
+  @IsOptional()
+  @Expose()
+  @IsArray()
+  @IsString({ each: true })
+  userIds?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Filter to memories in any of these namespaces',
+    type: String,
+    isArray: true,
+  })
+  @IsOptional()
+  @Expose()
+  @IsArray()
+  @IsString({ each: true })
+  namespaces?: string[];
+
+  @ApiPropertyOptional({
+    description:
+      'Scope results to memories extracted from any of these sessions',
+    type: String,
+    isArray: true,
+  })
+  @IsOptional()
+  @Expose()
+  @IsArray()
+  @IsString({ each: true })
+  sessionIds?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Filter to memories of any of these types',
+    type: String,
+    isArray: true,
+  })
+  @IsOptional()
+  @Expose()
+  @IsArray()
+  @IsString({ each: true })
+  memoryTypes?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Filter to memories tagged with any of these topics',
+    type: String,
+    isArray: true,
+  })
+  @IsOptional()
+  @Expose()
+  @IsArray()
+  @IsString({ each: true })
+  topics?: string[];
+
+  @ApiPropertyOptional({
+    description:
+      'Minimum normalized cosine similarity for vector results (0-1)',
+    type: Number,
+  })
+  @IsOptional()
+  @Expose()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  similarityThreshold?: number;
+}

--- a/redisinsight/api/src/modules/agent-memory/dto/update.agent-memory-endpoint.dto.ts
+++ b/redisinsight/api/src/modules/agent-memory/dto/update.agent-memory-endpoint.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAgentMemoryEndpointDto } from 'src/modules/agent-memory/dto/create.agent-memory-endpoint.dto';
+
+export class UpdateAgentMemoryEndpointDto extends PartialType(
+  CreateAgentMemoryEndpointDto,
+) {}

--- a/redisinsight/api/src/modules/agent-memory/entities/agent-memory-endpoint.entity.ts
+++ b/redisinsight/api/src/modules/agent-memory/entities/agent-memory-endpoint.entity.ts
@@ -1,0 +1,36 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Expose } from 'class-transformer';
+
+@Entity('agent_memory_endpoint')
+export class AgentMemoryEndpointEntity {
+  @Expose()
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Expose()
+  @Column({ nullable: false })
+  name: string;
+
+  @Expose()
+  @Column({ nullable: false })
+  url: string;
+
+  @Expose()
+  @Column({ nullable: false, default: 'cloud' })
+  backendType: string;
+
+  @Expose()
+  @Column({ nullable: true })
+  storeId: string;
+
+  @Expose({ groups: ['security'] })
+  @Column({ nullable: true })
+  apiKey: string;
+
+  @Expose()
+  @Column({ type: 'datetime', nullable: true })
+  lastConnection: Date;
+
+  @Column({ nullable: true })
+  encryption: string;
+}

--- a/redisinsight/api/src/modules/agent-memory/exceptions/agent-memory.error.handler.spec.ts
+++ b/redisinsight/api/src/modules/agent-memory/exceptions/agent-memory.error.handler.spec.ts
@@ -1,0 +1,89 @@
+import { AxiosError } from 'axios';
+import {
+  BadRequestException,
+  ForbiddenException,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+
+import {
+  parseErrorMessage,
+  wrapAgentMemoryError,
+} from 'src/modules/agent-memory/exceptions/agent-memory.error.handler';
+
+const axiosErrorWith = (status: number, data: unknown): AxiosError<any> =>
+  ({
+    message: 'Request failed',
+    response: { status, data },
+  }) as AxiosError<any>;
+
+describe('agent memory error handler', () => {
+  describe('parseErrorMessage', () => {
+    it('should return plain string bodies as-is', () => {
+      expect(parseErrorMessage(axiosErrorWith(403, 'blocked'))).toEqual(
+        'blocked',
+      );
+    });
+
+    it('should read FastAPI-style string detail', () => {
+      expect(
+        parseErrorMessage(axiosErrorWith(400, { detail: 'bad filter' })),
+      ).toEqual('bad filter');
+    });
+
+    it('should read nested detail message', () => {
+      expect(
+        parseErrorMessage(
+          axiosErrorWith(422, { detail: { message: 'invalid group' } }),
+        ),
+      ).toEqual('invalid group');
+    });
+
+    it('should read problem-details style title', () => {
+      expect(
+        parseErrorMessage(axiosErrorWith(401, { title: 'Unauthorized' })),
+      ).toEqual('Unauthorized');
+    });
+
+    it('should fall back to the axios error message', () => {
+      expect(parseErrorMessage(axiosErrorWith(500, {}))).toEqual(
+        'Request failed',
+      );
+    });
+  });
+
+  describe('wrapAgentMemoryError', () => {
+    it.each([
+      [400, BadRequestException],
+      [401, UnauthorizedException],
+      [403, ForbiddenException],
+      [404, NotFoundException],
+      [422, UnprocessableEntityException],
+      [500, InternalServerErrorException],
+    ])('should map status %d', (status, exceptionType) => {
+      const wrapped = wrapAgentMemoryError(
+        axiosErrorWith(status, { detail: 'oops' }),
+      );
+
+      expect(wrapped).toBeInstanceOf(exceptionType);
+    });
+
+    it('should map missing response to internal server error', () => {
+      const wrapped = wrapAgentMemoryError({
+        message: 'connect ECONNREFUSED',
+      } as AxiosError<any>);
+
+      expect(wrapped).toBeInstanceOf(InternalServerErrorException);
+    });
+
+    it('should pass through existing HttpExceptions', () => {
+      const original = new NotFoundException('missing');
+
+      expect(wrapAgentMemoryError(original as unknown as AxiosError)).toBe(
+        original,
+      );
+    });
+  });
+});

--- a/redisinsight/api/src/modules/agent-memory/exceptions/agent-memory.error.handler.ts
+++ b/redisinsight/api/src/modules/agent-memory/exceptions/agent-memory.error.handler.ts
@@ -1,0 +1,107 @@
+import { AxiosError } from 'axios';
+import {
+  BadRequestException,
+  ForbiddenException,
+  HttpException,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+
+/**
+ * Extract a human-readable message from an agent memory service error
+ * response. The Cloud service returns problem-details-style bodies
+ * ({ title, detail }); a WAF/CDN in front of it may return plain text.
+ */
+export const parseErrorMessage = (error: AxiosError<any>): string => {
+  const data = error.response?.data;
+  if (typeof data === 'string') {
+    return data;
+  }
+
+  const detail = data?.detail ?? data?.title ?? data?.message;
+  if (!detail) return error.message;
+
+  if (typeof detail === 'string') return detail;
+
+  return detail.message || detail.msg || error.message;
+};
+
+const exceptionForStatus = (
+  status: number | undefined,
+  message: string,
+): HttpException => {
+  switch (status) {
+    case 400:
+      return new BadRequestException(message);
+    case 401:
+      return new UnauthorizedException(message);
+    case 403:
+      return new ForbiddenException(message);
+    case 404:
+      return new NotFoundException(message);
+    case 422:
+      return new UnprocessableEntityException(message);
+    default:
+      return new InternalServerErrorException(message);
+  }
+};
+
+export const wrapAgentMemoryError = (error: AxiosError<any>): HttpException => {
+  if (error instanceof HttpException) {
+    return error;
+  }
+
+  return exceptionForStatus(error.response?.status, parseErrorMessage(error));
+};
+
+/**
+ * Map SDK-thrown errors (@redis-iris/agent-memory) to the same sanitized
+ * HTTP exceptions the axios interceptor produces. The SDK carries a
+ * statusCode on its server-error classes; everything else (connection,
+ * timeout, validation) falls through by name.
+ */
+const parseErrorBody = (body?: string): string | undefined => {
+  if (!body) return undefined;
+  try {
+    const parsed = JSON.parse(body);
+    const detail = parsed?.detail ?? parsed?.title ?? parsed?.message;
+    if (typeof detail === 'string') return detail;
+    return detail?.message || detail?.msg;
+  } catch {
+    return body.length <= 200 ? body : undefined;
+  }
+};
+
+export const wrapSdkError = (error: unknown): HttpException => {
+  if (error instanceof HttpException) {
+    return error;
+  }
+
+  const err = error as {
+    name?: string;
+    message?: string;
+    statusCode?: number;
+    body?: string;
+  };
+  // Speakeasy errors serialize the whole HTTP exchange into `message`
+  // (including request$/response$ internals) - extract the human text
+  // from the raw body instead, like parseErrorMessage does for axios.
+  const message =
+    parseErrorBody(err?.body) ||
+    (err?.body ? 'Agent memory request failed' : err?.message) ||
+    'Agent memory request failed';
+
+  if (typeof err?.statusCode === 'number') {
+    return exceptionForStatus(err.statusCode, message);
+  }
+
+  switch (err?.name) {
+    case 'SDKValidationError':
+    case 'ResponseValidationError':
+      return new BadRequestException(message);
+    default:
+      return new InternalServerErrorException(message);
+  }
+};

--- a/redisinsight/api/src/modules/agent-memory/exceptions/index.ts
+++ b/redisinsight/api/src/modules/agent-memory/exceptions/index.ts
@@ -1,0 +1,1 @@
+export * from './agent-memory.error.handler';

--- a/redisinsight/api/src/modules/agent-memory/models/agent-memory-endpoint.ts
+++ b/redisinsight/api/src/modules/agent-memory/models/agent-memory-endpoint.ts
@@ -1,0 +1,79 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+export enum AgentMemoryBackendType {
+  Cloud = 'cloud',
+}
+
+export class AgentMemoryEndpoint {
+  @ApiProperty({
+    description: 'Agent memory endpoint id.',
+    type: String,
+  })
+  @Expose()
+  id: string;
+
+  @ApiProperty({
+    description: 'A name to associate with the agent memory endpoint',
+    type: String,
+  })
+  @Expose()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(500)
+  name: string;
+
+  @ApiProperty({
+    description: 'Base url of the Redis Agent Memory endpoint',
+    example: 'https://agent-memory.redis.io',
+    type: String,
+  })
+  @Expose()
+  @IsNotEmpty()
+  @IsString()
+  url: string;
+
+  @ApiProperty({
+    description: 'Type of the agent memory backend',
+    enum: AgentMemoryBackendType,
+    default: AgentMemoryBackendType.Cloud,
+  })
+  @Expose()
+  @IsEnum(AgentMemoryBackendType)
+  @IsNotEmpty()
+  backendType: AgentMemoryBackendType = AgentMemoryBackendType.Cloud;
+
+  @ApiPropertyOptional({
+    description: 'Store id (Redis Cloud agent memory only)',
+    type: String,
+  })
+  @IsOptional()
+  @Expose()
+  @IsString()
+  storeId?: string;
+
+  @ApiPropertyOptional({
+    description: 'API key (bearer token), if the server requires auth',
+    type: String,
+  })
+  @IsOptional()
+  @Expose({ groups: ['security'] })
+  @IsString()
+  apiKey?: string;
+
+  @ApiPropertyOptional({
+    description: 'Time of the last connection to the agent memory endpoint.',
+    type: String,
+    format: 'date-time',
+    example: '2021-01-06T12:44:39.000Z',
+  })
+  @Expose()
+  lastConnection?: Date;
+}

--- a/redisinsight/api/src/modules/agent-memory/models/agent-memory.client.metadata.ts
+++ b/redisinsight/api/src/modules/agent-memory/models/agent-memory.client.metadata.ts
@@ -1,0 +1,13 @@
+import { SessionMetadata } from 'src/common/models/session';
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class AgentMemoryClientMetadata {
+  @IsNotEmpty()
+  @Type(() => SessionMetadata)
+  sessionMetadata: SessionMetadata;
+
+  @IsNotEmpty()
+  @IsString()
+  id: string;
+}

--- a/redisinsight/api/src/modules/agent-memory/models/index.ts
+++ b/redisinsight/api/src/modules/agent-memory/models/index.ts
@@ -1,0 +1,2 @@
+export * from './agent-memory-endpoint';
+export * from './agent-memory.client.metadata';

--- a/redisinsight/api/src/modules/agent-memory/providers/agent-memory.client.factory.ts
+++ b/redisinsight/api/src/modules/agent-memory/providers/agent-memory.client.factory.ts
@@ -1,0 +1,30 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+import {
+  AgentMemoryBackendType,
+  AgentMemoryClientMetadata,
+  AgentMemoryEndpoint,
+} from 'src/modules/agent-memory/models';
+import { AgentMemoryClient } from 'src/modules/agent-memory/client/agent-memory.client';
+import { CloudAgentMemoryClient } from 'src/modules/agent-memory/client/cloud.agent-memory.client';
+import { AGENT_MEMORY_ERROR_MESSAGES } from 'src/modules/agent-memory/constants';
+
+@Injectable()
+export class AgentMemoryClientFactory {
+  async createClient(
+    metadata: AgentMemoryClientMetadata,
+    endpoint: AgentMemoryEndpoint,
+  ): Promise<AgentMemoryClient> {
+    // Redis Agent Memory is the only supported backend.
+    if (endpoint.backendType !== AgentMemoryBackendType.Cloud) {
+      throw new BadRequestException(
+        AGENT_MEMORY_ERROR_MESSAGES.UNSUPPORTED_BACKEND,
+      );
+    }
+
+    const client = new CloudAgentMemoryClient(metadata, endpoint);
+    await client.connect();
+
+    return client;
+  }
+}

--- a/redisinsight/api/src/modules/agent-memory/providers/agent-memory.client.provider.ts
+++ b/redisinsight/api/src/modules/agent-memory/providers/agent-memory.client.provider.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+
+import { AgentMemoryClient } from 'src/modules/agent-memory/client/agent-memory.client';
+import { AgentMemoryClientMetadata } from 'src/modules/agent-memory/models';
+import { AgentMemoryClientStorage } from 'src/modules/agent-memory/providers/agent-memory.client.storage';
+import { AgentMemoryClientFactory } from 'src/modules/agent-memory/providers/agent-memory.client.factory';
+import { AgentMemoryEndpointRepository } from 'src/modules/agent-memory/repository/agent-memory-endpoint.repository';
+import {
+  AGENT_MEMORY_ERROR_MESSAGES,
+  LAST_CONNECTION_UPDATE_INTERVAL,
+} from 'src/modules/agent-memory/constants';
+
+@Injectable()
+export class AgentMemoryClientProvider {
+  private logger: Logger = new Logger('AgentMemoryClientProvider');
+
+  /** Endpoint id -> when lastConnection was last persisted */
+  private readonly lastConnectionWrites: Map<string, number> = new Map();
+
+  constructor(
+    private readonly repository: AgentMemoryEndpointRepository,
+    private readonly clientStorage: AgentMemoryClientStorage,
+    private readonly clientFactory: AgentMemoryClientFactory,
+  ) {}
+
+  async getOrCreate(
+    metadata: AgentMemoryClientMetadata,
+  ): Promise<AgentMemoryClient> {
+    let client = await this.clientStorage.getByMetadata(metadata);
+    if (client) {
+      await client.ensureAuth();
+      this.updateLastConnection(metadata);
+      return client;
+    }
+
+    client = await this.create(metadata);
+
+    return this.clientStorage.set(client);
+  }
+
+  async create(
+    metadata: AgentMemoryClientMetadata,
+  ): Promise<AgentMemoryClient> {
+    const endpoint = await this.repository.get(metadata.id);
+
+    if (!endpoint) {
+      this.logger.error(
+        `Agent memory endpoint with ${metadata.id} was not found`,
+        metadata,
+      );
+      throw new NotFoundException(
+        AGENT_MEMORY_ERROR_MESSAGES.INVALID_ENDPOINT_ID,
+      );
+    }
+    const client = await this.clientFactory.createClient(metadata, endpoint);
+    if (client) {
+      this.updateLastConnection(metadata);
+    }
+    return client;
+  }
+
+  async deleteManyByEndpointId(id: string): Promise<number> {
+    this.lastConnectionWrites.delete(id);
+    return this.clientStorage.deleteManyByEndpointId(id);
+  }
+
+  /**
+   * Persist lastConnection at most once per LAST_CONNECTION_UPDATE_INTERVAL
+   * per endpoint - getOrCreate runs on every data request (auto-refresh can
+   * make that frequent) and each write is a full decrypt/encrypt SQLite cycle.
+   */
+  private async updateLastConnection(
+    metadata: AgentMemoryClientMetadata,
+  ): Promise<void> {
+    const lastWrite = this.lastConnectionWrites.get(metadata.id) ?? 0;
+    if (Date.now() - lastWrite < LAST_CONNECTION_UPDATE_INTERVAL) {
+      return;
+    }
+    this.lastConnectionWrites.set(metadata.id, Date.now());
+
+    try {
+      await this.repository.update(metadata.id, {
+        lastConnection: new Date(),
+      });
+    } catch (e) {
+      // ignore the error
+    }
+  }
+}

--- a/redisinsight/api/src/modules/agent-memory/providers/agent-memory.client.storage.ts
+++ b/redisinsight/api/src/modules/agent-memory/providers/agent-memory.client.storage.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+
+import { PooledClientStorage } from 'src/modules/agent-memory/providers/pooled-client.storage';
+import { AgentMemoryClient } from 'src/modules/agent-memory/client/agent-memory.client';
+import { AgentMemoryClientMetadata } from 'src/modules/agent-memory/models';
+import { AGENT_MEMORY_SYNC_INTERVAL } from 'src/modules/agent-memory/constants';
+
+@Injectable()
+export class AgentMemoryClientStorage extends PooledClientStorage<
+  AgentMemoryClient,
+  AgentMemoryClientMetadata
+> {
+  constructor() {
+    super(AgentMemoryClientStorage.name, AGENT_MEMORY_SYNC_INTERVAL);
+  }
+
+  protected generateId(metadata: AgentMemoryClientMetadata): string {
+    return AgentMemoryClient.generateId(metadata);
+  }
+
+  async deleteManyByEndpointId(id: string): Promise<number> {
+    return this.deleteManyByMetadataId(id);
+  }
+}

--- a/redisinsight/api/src/modules/agent-memory/providers/pooled-client.storage.ts
+++ b/redisinsight/api/src/modules/agent-memory/providers/pooled-client.storage.ts
@@ -1,0 +1,136 @@
+import { BadRequestException, Logger, OnModuleDestroy } from '@nestjs/common';
+import { sum } from 'lodash';
+
+import { SessionMetadata } from 'src/common/models';
+
+export const INCOMPLETE_CLIENT_METADATA_MESSAGE =
+  'Client metadata missed required properties';
+
+export interface PooledClientMetadata {
+  id: string;
+  sessionMetadata?: SessionMetadata;
+}
+
+/** What the pool needs from a client: identity plus idle bookkeeping. */
+export interface PooledClient {
+  id: string;
+  metadata: PooledClientMetadata;
+  isIdle(): boolean;
+  setLastUsed(): void;
+}
+
+/**
+ * In-memory pool of per-user API clients with a periodic idle sweep.
+ * Shared by the feature modules that keep authenticated HTTP clients
+ * alive between requests (RDI, Agent Memory); subclasses only provide
+ * the pool-key derivation for their metadata type.
+ */
+export abstract class PooledClientStorage<
+  TClient extends PooledClient,
+  TMetadata extends PooledClientMetadata,
+> implements OnModuleDestroy
+{
+  protected readonly logger: Logger;
+
+  private readonly clients: Map<string, TClient> = new Map();
+
+  private readonly syncInterval: NodeJS.Timeout;
+
+  protected constructor(loggerContext: string, syncIntervalMs: number) {
+    this.logger = new Logger(loggerContext);
+    this.syncInterval = setInterval(
+      this.syncClients.bind(this),
+      syncIntervalMs,
+    );
+  }
+
+  /** Build the pool key for the given client metadata */
+  protected abstract generateId(metadata: TMetadata): string;
+
+  onModuleDestroy() {
+    clearInterval(this.syncInterval);
+  }
+
+  /**
+   * Removes all clients with exceeded idle threshold
+   * @private
+   */
+  private syncClients(): void {
+    this.clients.forEach((client) => {
+      if (client.isIdle()) {
+        this.clients.delete(client.id);
+      }
+    });
+  }
+
+  async get(id: string): Promise<TClient | undefined> {
+    const client = this.clients.get(id);
+    if (client) {
+      client.setLastUsed();
+    }
+
+    return client;
+  }
+
+  async getByMetadata(metadata: TMetadata): Promise<TClient | undefined> {
+    this.validateMetadata(metadata);
+    return this.get(this.generateId(metadata));
+  }
+
+  async delete(id: string): Promise<number> {
+    const client = this.clients.get(id);
+
+    if (client) {
+      this.clients.delete(id);
+      return 1;
+    }
+
+    return 0;
+  }
+
+  /**
+   * Finds clients created for the endpoint/instance with the given
+   * metadata id and returns their pool keys.
+   */
+  protected findClientsByMetadataId(id: string): string[] {
+    return [...this.clients.values()]
+      .filter((client) => client.metadata.id === id)
+      .map((client) => client.id);
+  }
+
+  /**
+   * Removes all clients created for the endpoint/instance with the given
+   * metadata id and returns the number of removed clients.
+   */
+  protected async deleteManyByMetadataId(id: string): Promise<number> {
+    const toRemove = this.findClientsByMetadataId(id);
+
+    this.logger.debug(`Trying to remove ${toRemove.length} clients`);
+
+    return sum(await Promise.all(toRemove.map(this.delete.bind(this))));
+  }
+
+  /**
+   * Saves client into the clients pool. When a client with such "id"
+   * exists it is replaced with the new one.
+   */
+  async set(client: TClient): Promise<TClient> {
+    if (!client.id) {
+      throw new BadRequestException(INCOMPLETE_CLIENT_METADATA_MESSAGE);
+    }
+    this.validateMetadata(client.metadata);
+    this.clients.set(client.id, client);
+    return client;
+  }
+
+  private validateMetadata(metadata: PooledClientMetadata): void {
+    if (
+      !metadata?.id ||
+      !metadata.sessionMetadata?.sessionId ||
+      !metadata.sessionMetadata?.accountId ||
+      !metadata.sessionMetadata.userId
+    ) {
+      throw new BadRequestException(INCOMPLETE_CLIENT_METADATA_MESSAGE);
+    }
+  }
+}

--- a/redisinsight/api/src/modules/agent-memory/repository/agent-memory-endpoint.repository.ts
+++ b/redisinsight/api/src/modules/agent-memory/repository/agent-memory-endpoint.repository.ts
@@ -1,0 +1,34 @@
+import { AgentMemoryEndpoint } from 'src/modules/agent-memory/models';
+
+export abstract class AgentMemoryEndpointRepository {
+  /**
+   * List of agent memory endpoints (never includes apiKey)
+   */
+  abstract list(): Promise<AgentMemoryEndpoint[]>;
+
+  /**
+   * Get endpoint connection details by id
+   */
+  abstract get(
+    id: string,
+    ignoreEncryptionErrors?: boolean,
+  ): Promise<AgentMemoryEndpoint | null>;
+
+  /**
+   * Create endpoint connection
+   */
+  abstract create(endpoint: AgentMemoryEndpoint): Promise<AgentMemoryEndpoint>;
+
+  /**
+   * Update endpoint connection config
+   */
+  abstract update(
+    id: string,
+    endpoint: Partial<AgentMemoryEndpoint>,
+  ): Promise<AgentMemoryEndpoint>;
+
+  /**
+   * Delete endpoints by ids
+   */
+  abstract delete(ids: string[]): Promise<void>;
+}

--- a/redisinsight/api/src/modules/agent-memory/repository/local.agent-memory-endpoint.repository.ts
+++ b/redisinsight/api/src/modules/agent-memory/repository/local.agent-memory-endpoint.repository.ts
@@ -1,0 +1,117 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { EncryptionService } from 'src/modules/encryption/encryption.service';
+import { ModelEncryptor } from 'src/modules/encryption/model.encryptor';
+import { AgentMemoryEndpointEntity } from 'src/modules/agent-memory/entities/agent-memory-endpoint.entity';
+import { AgentMemoryEndpoint } from 'src/modules/agent-memory/models';
+import { AgentMemoryEndpointRepository } from 'src/modules/agent-memory/repository/agent-memory-endpoint.repository';
+import { classToClass } from 'src/utils';
+
+@Injectable()
+export class LocalAgentMemoryEndpointRepository extends AgentMemoryEndpointRepository {
+  private readonly modelEncryptor: ModelEncryptor;
+
+  constructor(
+    @InjectRepository(AgentMemoryEndpointEntity)
+    private readonly repository: Repository<AgentMemoryEndpointEntity>,
+    private readonly encryptionService: EncryptionService,
+  ) {
+    super();
+    this.modelEncryptor = new ModelEncryptor(this.encryptionService, [
+      'apiKey',
+    ]);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async get(
+    id: string,
+    ignoreEncryptionErrors: boolean = false,
+  ): Promise<AgentMemoryEndpoint | null> {
+    const entity = await this.repository.findOneBy({ id });
+
+    if (!entity) {
+      return null;
+    }
+
+    return classToClass(
+      AgentMemoryEndpoint,
+      await this.modelEncryptor.decryptEntity(entity, ignoreEncryptionErrors),
+    );
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async list(): Promise<AgentMemoryEndpoint[]> {
+    const entities = await this.repository
+      .createQueryBuilder('e')
+      .select([
+        'e.id',
+        'e.name',
+        'e.url',
+        'e.backendType',
+        'e.storeId',
+        'e.lastConnection',
+      ])
+      .getMany();
+    return entities.map((entity) => classToClass(AgentMemoryEndpoint, entity));
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async create(
+    endpoint: AgentMemoryEndpoint,
+  ): Promise<AgentMemoryEndpoint> {
+    const entity = classToClass(AgentMemoryEndpointEntity, endpoint);
+
+    return classToClass(
+      AgentMemoryEndpoint,
+      await this.modelEncryptor.decryptEntity(
+        await this.repository.save(
+          await this.modelEncryptor.encryptEntity(entity),
+        ),
+      ),
+    );
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async update(
+    id: string,
+    endpoint: Partial<AgentMemoryEndpoint>,
+  ): Promise<AgentMemoryEndpoint> {
+    const existingEntity = await this.repository.findOneBy({ id });
+    if (!existingEntity) {
+      throw new Error(`Agent memory endpoint ${id} was not found`);
+    }
+    const oldEntity = await this.modelEncryptor.decryptEntity(
+      existingEntity,
+      true,
+    );
+    const newEntity = classToClass(AgentMemoryEndpointEntity, endpoint);
+
+    const encrypted = await this.modelEncryptor.encryptEntity(
+      this.repository.merge(oldEntity, newEntity),
+    );
+
+    return classToClass(
+      AgentMemoryEndpoint,
+      await this.modelEncryptor.decryptEntity(
+        await this.repository.save(encrypted),
+      ),
+    );
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async delete(ids: string[]): Promise<void> {
+    await this.repository.delete(ids);
+  }
+}


### PR DESCRIPTION
Add a NestJS module that connects RedisInsight to Redis Agent Memory (RAM) stores through the @redis-iris/agent-memory SDK (0.2.0).

Endpoints:
- CRUD for endpoint connections, credentials encrypted at rest
- Verify reachability and credentials on connect
- backendType discriminator fixed to Cloud, leaving room for other transports without a schema migration

Working memory:
- Read a session's message log, running summary, and namespace
- Add events (creating the session if needed)
- Clear a session

Long-term memory:
- Semantic + keyword search with a similarity-threshold control, filtered by owner, namespace, session, memory type, and topics
- Delete records
- Discover the distinct owners and namespaces present in a store

Store configuration:
- Read the store's general settings and memory TTLs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New persistence of encrypted API keys plus proxy APIs that read, append, and delete session and long-term memory on Redis Cloud. Credential handling, encryption, and destructive data operations are security-sensitive.
> 
> **Overview**
> Adds a backend **Agent Memory** module so RedisInsight can connect to Redis Cloud RAM stores and inspect or mutate working and long-term memory.
> 
> **Connections:** CRUD under `/agent-memory` with a SQLite `agent_memory_endpoint` table. `apiKey` is encrypted at rest, omitted from list/get responses, and never returned to the client. Create/update/connect validate reachability via the `@redis-iris/agent-memory` SDK. Clients are pooled per session and idle-swept.
> 
> **Data APIs** (`/agent-memory/:id`): list sessions; get/append/clear working memory; hybrid long-term search (filters + similarity threshold); bulk delete memories; discover owners/namespaces; fetch store config. Cloud responses are normalized to a shared camelCase contract. `backendType` is Cloud-only for now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b2749b0584f51c491dc8af6346dbdd856b28164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->