### PR TITLE
ci(e2e): pin NODE_ENV for the docker e2e container

### DIFF
--- a/.github/workflows/tests-e2e-playwright-docker.yml
+++ b/.github/workflows/tests-e2e-playwright-docker.yml
@@ -63,6 +63,20 @@ jobs:
         run: |
           docker image load -i ./release/docker/docker-linux-alpine.amd64.tar
 
+      # An empty NODE_ENV makes the app fall back to its development config and
+      # exit before it can write a log, which reads as a startup timeout further
+      # down. The compose file pins the value, so this only reports what the
+      # image itself carries.
+      - name: Report image NODE_ENV
+        run: |
+          node_env=$(docker image inspect redisinsight:amd64 \
+            --format '{{range .Config.Env}}{{println .}}{{end}}' \
+            | grep '^NODE_ENV=' || true)
+          echo "image carries ${node_env:-no NODE_ENV}"
+          if [ -z "$node_env" ] || [ "$node_env" = "NODE_ENV=" ]; then
+            echo "::warning::Image built without NODE_ENV; compose pins it to staging for this run"
+          fi
+
       - name: Start Redis test environment
         uses: ./.github/actions/redis-test-env-up
         with:

--- a/tests/e2e/docker.web.docker-compose.yml
+++ b/tests/e2e/docker.web.docker-compose.yml
@@ -20,6 +20,12 @@ services:
       RI_SERVER_TLS_CERT: $RI_SERVER_TLS_CERT
       RI_SERVER_TLS_KEY: $RI_SERVER_TLS_KEY
       RI_STDOUT_LOGGER: 'false'
+      # The image bakes in whatever NODE_ENV the build job could resolve, and a
+      # fork PR gets no environment variables, so that value is empty there. An
+      # empty NODE_ENV selects the development config, which ignores
+      # RI_APP_FOLDER_ABSOLUTE_PATH and puts the database somewhere the
+      # container cannot write. Pin it so the suite does not depend on the build.
+      NODE_ENV: staging
     volumes:
       - rihomedir:/data
       - tmp:/tmp


### PR DESCRIPTION
# What

The Docker E2E job fails on every fork PR, regardless of its contents. A fork PR runs without secrets or environment variables, so the docker build resolves `vars.ENV` to an empty string and bakes `NODE_ENV=` into the image. An empty value selects the development config, which ignores `RI_APP_FOLDER_ABSOLUTE_PATH` and points the SQLite database at the read-only app directory, so the container exits with `SQLITE_CANTOPEN` seconds after start and the startup gate reports it as a `/api/health` timeout.

This pins `NODE_ENV` in the E2E compose file, which makes the suite independent of what the build job could resolve and matches the value nightly runs already bake in. A new step reports what the image itself carries, so a repeat is visible from the log instead of needing a local reproduction.

Deliberately scoped to E2E files: no change to `pipeline-build-docker.yml` and no app code, so release and enterprise builds are untouched. A fork-built image still cannot boot on its own; the suite just no longer depends on it.

# Testing

Verified against the artifact of the failing run ([32239798982](https://github.com/redis/RedisInsight/actions/runs/32239798982)):

- That exact image, started through the patched compose file, serves `/api/health` with 200 after ~14s, container `status=running`, `NODE_ENV=staging` at runtime.
- The same image without the pin exits 1 with `SqliteError: unable to open database file` / `SQLITE_CANTOPEN`, matching CI.
- The new step's script passes `bash -n` and exits 0 even when `docker image inspect` fails, so it cannot fail the job.

The Docker E2E job on this PR exercises the unchanged (non-fork) path; #6409 exercises the fork path once this lands, since `pull_request` runs use workflow files from the merge ref.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E compose and CI diagnostics; no app, release, or Docker build pipeline changes.
> 
> **Overview**
> Fixes Docker Playwright E2E on **fork PRs**, where the built image can ship with an empty `NODE_ENV` and the app boots with development config—SQLite lands on a read-only path and startup fails as a `/api/health` timeout.
> 
> **`tests/e2e/docker.web.docker-compose.yml`** now sets **`NODE_ENV: staging`** at runtime so the suite no longer depends on whatever the build job baked in (aligned with nightly runs).
> 
> **`.github/workflows/tests-e2e-playwright-docker.yml`** adds a **Report image NODE_ENV** step that logs the image’s `NODE_ENV` and emits a workflow warning when it’s missing or empty, since compose already overrides it for the run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a86846ebee6461390d4f08c9b5dd2619d038d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->