### PR TITLE
fix(scripts): fail the TS baseline check when tsc crashes

### DIFF
--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -40,9 +40,9 @@
     "typeorm:migrate": "cross-env NODE_ENV=staging npm run typeorm -- migration:generate ./migration/migration",
     "typeorm:run": "npm run typeorm -- migration:run",
     "typeorm:run:stage": "cross-env NODE_ENV=staging npm run typeorm -- migration:run",
-    "type-check": "tsc --project tsconfig.check.json --noEmit --pretty false | tsc-output-parser | tsx ../../scripts/ts-error-check.ts compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/api'",
-    "tscheck": "tsc --project tsconfig.check.json --noEmit --pretty false | tsc-output-parser | tsx ../../scripts/ts-error-check.ts overwrite .tscheck.rec.json",
-    "tscheck:force": "tsc --project tsconfig.check.json --noEmit --pretty false | tsc-output-parser | tsx ../../scripts/ts-error-check.ts force_overwrite .tscheck.rec.json"
+    "type-check": "tsx ../../scripts/ts-error-check.ts compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/api' --project tsconfig.check.json",
+    "tscheck": "tsx ../../scripts/ts-error-check.ts overwrite .tscheck.rec.json --project tsconfig.check.json",
+    "tscheck:force": "tsx ../../scripts/ts-error-check.ts force_overwrite .tscheck.rec.json --project tsconfig.check.json"
   },
   "overrides": {
     "word-wrap": "1.2.4",

--- a/redisinsight/api/package.json
+++ b/redisinsight/api/package.json
@@ -40,9 +40,9 @@
     "typeorm:migrate": "cross-env NODE_ENV=staging npm run typeorm -- migration:generate ./migration/migration",
     "typeorm:run": "npm run typeorm -- migration:run",
     "typeorm:run:stage": "cross-env NODE_ENV=staging npm run typeorm -- migration:run",
-    "type-check": "tsx ../../scripts/ts-error-check.ts compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/api' --project tsconfig.check.json",
-    "tscheck": "tsx ../../scripts/ts-error-check.ts overwrite .tscheck.rec.json --project tsconfig.check.json",
-    "tscheck:force": "tsx ../../scripts/ts-error-check.ts force_overwrite .tscheck.rec.json --project tsconfig.check.json"
+    "type-check": "tsx ../../scripts/tsc-safe-run.ts --project tsconfig.check.json compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/api'",
+    "tscheck": "tsx ../../scripts/tsc-safe-run.ts --project tsconfig.check.json overwrite .tscheck.rec.json",
+    "tscheck:force": "tsx ../../scripts/tsc-safe-run.ts --project tsconfig.check.json force_overwrite .tscheck.rec.json"
   },
   "overrides": {
     "word-wrap": "1.2.4",

--- a/redisinsight/desktop/package.json
+++ b/redisinsight/desktop/package.json
@@ -7,8 +7,8 @@
     "build": "cross-env ELECTRON_DEV=true ELECTRON_ENABLE_LOGGING=true ELECTRON_DEBUG_LOGGING=true ELECTRON_ENABLE_STACK_DUMPING=true NODE_ENV=development vite build --config vite.main.config.ts",
     "build:preload": "cross-env ELECTRON_DEV=true ELECTRON_ENABLE_LOGGING=true ELECTRON_DEBUG_LOGGING=true ELECTRON_ENABLE_STACK_DUMPING=true NODE_ENV=development vite build --config vite.preload.config.ts",
     "build:renderer": "cross-env ELECTRON_DEV=true ELECTRON_ENABLE_LOGGING=true ELECTRON_DEBUG_LOGGING=true ELECTRON_ENABLE_STACK_DUMPING=true NODE_ENV=development vite build --config vite.renderer.config.ts",
-    "type-check": "tsx ../../scripts/ts-error-check.ts compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/desktop' --project tsconfig.json",
-    "tscheck": "tsx ../../scripts/ts-error-check.ts overwrite .tscheck.rec.json --project tsconfig.json",
-    "tscheck:force": "tsx ../../scripts/ts-error-check.ts force_overwrite .tscheck.rec.json --project tsconfig.json"
+    "type-check": "tsx ../../scripts/tsc-safe-run.ts --project tsconfig.json compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/desktop'",
+    "tscheck": "tsx ../../scripts/tsc-safe-run.ts --project tsconfig.json overwrite .tscheck.rec.json",
+    "tscheck:force": "tsx ../../scripts/tsc-safe-run.ts --project tsconfig.json force_overwrite .tscheck.rec.json"
   }
 }

--- a/redisinsight/desktop/package.json
+++ b/redisinsight/desktop/package.json
@@ -7,8 +7,8 @@
     "build": "cross-env ELECTRON_DEV=true ELECTRON_ENABLE_LOGGING=true ELECTRON_DEBUG_LOGGING=true ELECTRON_ENABLE_STACK_DUMPING=true NODE_ENV=development vite build --config vite.main.config.ts",
     "build:preload": "cross-env ELECTRON_DEV=true ELECTRON_ENABLE_LOGGING=true ELECTRON_DEBUG_LOGGING=true ELECTRON_ENABLE_STACK_DUMPING=true NODE_ENV=development vite build --config vite.preload.config.ts",
     "build:renderer": "cross-env ELECTRON_DEV=true ELECTRON_ENABLE_LOGGING=true ELECTRON_DEBUG_LOGGING=true ELECTRON_ENABLE_STACK_DUMPING=true NODE_ENV=development vite build --config vite.renderer.config.ts",
-    "type-check": "tsc --project tsconfig.json --noEmit --pretty false | tsc-output-parser | tsx ../../scripts/ts-error-check.ts compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/desktop'",
-    "tscheck": "tsc --project tsconfig.json --noEmit --pretty false | tsc-output-parser | tsx ../../scripts/ts-error-check.ts overwrite .tscheck.rec.json",
-    "tscheck:force": "tsc --project tsconfig.json --noEmit --pretty false | tsc-output-parser | tsx ../../scripts/ts-error-check.ts force_overwrite .tscheck.rec.json"
+    "type-check": "tsx ../../scripts/ts-error-check.ts compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/desktop' --project tsconfig.json",
+    "tscheck": "tsx ../../scripts/ts-error-check.ts overwrite .tscheck.rec.json --project tsconfig.json",
+    "tscheck:force": "tsx ../../scripts/ts-error-check.ts force_overwrite .tscheck.rec.json --project tsconfig.json"
   }
 }

--- a/redisinsight/ui/package.json
+++ b/redisinsight/ui/package.json
@@ -13,9 +13,9 @@
     "dev": "vite dev",
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build",
     "stats": "NODE_OPTIONS=--max_old_space_size=8192 npx vite-bundle-visualizer --open -o ./dist-stats.html --sourcemap",
-    "type-check": "tsx ../../scripts/ts-error-check.ts compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/ui' --project tsconfig.json",
-    "tscheck": "tsx ../../scripts/ts-error-check.ts overwrite .tscheck.rec.json --project tsconfig.json",
-    "tscheck:force": "tsx ../../scripts/ts-error-check.ts force_overwrite .tscheck.rec.json --project tsconfig.json"
+    "type-check": "tsx ../../scripts/tsc-safe-run.ts --project tsconfig.json compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/ui'",
+    "tscheck": "tsx ../../scripts/tsc-safe-run.ts --project tsconfig.json overwrite .tscheck.rec.json",
+    "tscheck:force": "tsx ../../scripts/tsc-safe-run.ts --project tsconfig.json force_overwrite .tscheck.rec.json"
   },
   "overrides": {
     "form-data": "^4.0.4"

--- a/redisinsight/ui/package.json
+++ b/redisinsight/ui/package.json
@@ -13,9 +13,9 @@
     "dev": "vite dev",
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build",
     "stats": "NODE_OPTIONS=--max_old_space_size=8192 npx vite-bundle-visualizer --open -o ./dist-stats.html --sourcemap",
-    "type-check": "tsc --project tsconfig.json --noEmit --pretty false | tsc-output-parser | tsx ../../scripts/ts-error-check.ts compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/ui'",
-    "tscheck": "tsc --project tsconfig.json --noEmit --pretty false | tsc-output-parser | tsx ../../scripts/ts-error-check.ts overwrite .tscheck.rec.json",
-    "tscheck:force": "tsc --project tsconfig.json --noEmit --pretty false | tsc-output-parser | tsx ../../scripts/ts-error-check.ts force_overwrite .tscheck.rec.json"
+    "type-check": "tsx ../../scripts/ts-error-check.ts compare .tscheck.rec.json 'npm run tscheck --prefix redisinsight/ui' --project tsconfig.json",
+    "tscheck": "tsx ../../scripts/ts-error-check.ts overwrite .tscheck.rec.json --project tsconfig.json",
+    "tscheck:force": "tsx ../../scripts/ts-error-check.ts force_overwrite .tscheck.rec.json --project tsconfig.json"
   },
   "overrides": {
     "form-data": "^4.0.4"

--- a/scripts/ts-error-check.ts
+++ b/scripts/ts-error-check.ts
@@ -1,9 +1,6 @@
 import { diff } from 'deep-object-diff'
 import stringify from 'json-stable-stringify'
-import { parse } from '@aivenio/tsc-output-parser'
-import { spawnSync } from 'child_process'
 import fs from 'fs'
-import { createRequire } from 'module'
 import path from 'path'
 
 const OVERWRITE = 'overwrite'
@@ -36,18 +33,9 @@ interface ErrorInfo {
   >
 }
 
-const argv = process.argv.slice(2)
-const projectFlagIndex = argv.indexOf('--project')
-const projectArg =
-  projectFlagIndex === -1 ? undefined : argv[projectFlagIndex + 1]
-const positionalArgs =
-  projectFlagIndex === -1
-    ? argv
-    : [...argv.slice(0, projectFlagIndex), ...argv.slice(projectFlagIndex + 2)]
-
-const command = positionalArgs[0]
-const recFileArg = positionalArgs[1]
-const updateHintArg = positionalArgs[2]
+const command = process.argv[2]
+const recFileArg = process.argv[3]
+const updateHintArg = process.argv[4]
 
 if (
   !SUPPORTED_COMMANDS.includes(command as (typeof SUPPORTED_COMMANDS)[number])
@@ -65,90 +53,10 @@ if (!recFileArg) {
   )
 }
 
-if (!projectArg) {
-  throw new Error('Pass the tsconfig to check as `--project <file>`')
-}
-
 const REC_FILE_PATH = path.resolve(process.cwd(), recFileArg)
 const UPDATE_HINT = updateHintArg || `update the baseline at ${recFileArg}`
 
-// tsc exits 0 when it finds nothing and 1 or 2 when it reports diagnostics.
-// Any other status means it died before listing them - 134 for an
-// out-of-memory abort - and its empty output must never be read as a clean
-// run, which would silently erase the baseline.
-const TSC_FINISHED_STATUSES = new Set([0, 1, 2])
-
-function refuseRun(reason: string, stderr: string): never {
-  console.error('_'.repeat(80))
-  console.error(`✗ tsc ${reason}.`)
-
-  if (/heap out of memory|Allocation failed/.test(stderr)) {
-    console.error('')
-    console.error('It ran out of memory. Give it a bigger heap and retry:')
-    console.error('')
-    console.error('   NODE_OPTIONS=--max-old-space-size=8192 <command>')
-  }
-
-  console.error('')
-  console.error(`The baseline at ${recFileArg} is left untouched.`)
-  console.error('_'.repeat(80))
-
-  throw new Error(
-    `tsc ${reason}, so its output says nothing about the real error count`,
-  )
-}
-
-function runTsc(project: string): {
-  stdout: string
-  stderr: string
-  status: number
-} {
-  // Resolve tsc the way the shell would from this package, since the api
-  // pins its own typescript.
-  const requireFromCwd = createRequire(path.join(process.cwd(), 'noop.js'))
-  const { status, signal, stdout, stderr, error } = spawnSync(
-    process.execPath,
-    [
-      requireFromCwd.resolve('typescript/bin/tsc'),
-      '--project',
-      project,
-      '--noEmit',
-      '--pretty',
-      'false',
-    ],
-    { encoding: 'utf-8', maxBuffer: 1 << 28 },
-  )
-
-  if (error) {
-    throw new Error(`Could not start tsc: ${error.message}`)
-  }
-
-  if (stderr) {
-    console.error(stderr)
-  }
-
-  if (signal || status === null || !TSC_FINISHED_STATUSES.has(status)) {
-    const cause = signal ? `was killed by ${signal}` : `exited with ${status}`
-
-    refuseRun(`${cause} before reporting any diagnostics`, stderr)
-  }
-
-  return { stdout, stderr, status }
-}
-
-const tscRun = runTsc(projectArg)
-const tsErrorsAsJson: TsError[] = parse(tscRun.stdout) as TsError[]
-
-// A non-zero status means tsc had something to report, so an empty result
-// means it crashed before listing anything rather than finding nothing. An
-// uncaught compiler exception looks exactly like this: status 1, a stack
-// trace on stderr, and no diagnostics at all.
-if (tscRun.status !== 0 && !tsErrorsAsJson.length) {
-  refuseRun(
-    `exited with ${tscRun.status} without reporting a single diagnostic`,
-    tscRun.stderr,
-  )
-}
+const tsErrorsAsJson: TsError[] = JSON.parse(fs.readFileSync(0, 'utf-8'))
 
 function getNewSnapshot() {
   let totalErrorCount = 0

--- a/scripts/ts-error-check.ts
+++ b/scripts/ts-error-check.ts
@@ -1,6 +1,9 @@
 import { diff } from 'deep-object-diff'
 import stringify from 'json-stable-stringify'
+import { parse } from '@aivenio/tsc-output-parser'
+import { spawnSync } from 'child_process'
 import fs from 'fs'
+import { createRequire } from 'module'
 import path from 'path'
 
 const OVERWRITE = 'overwrite'
@@ -33,9 +36,18 @@ interface ErrorInfo {
   >
 }
 
-const command = process.argv[2]
-const recFileArg = process.argv[3]
-const updateHintArg = process.argv[4]
+const argv = process.argv.slice(2)
+const projectFlagIndex = argv.indexOf('--project')
+const projectArg =
+  projectFlagIndex === -1 ? undefined : argv[projectFlagIndex + 1]
+const positionalArgs =
+  projectFlagIndex === -1
+    ? argv
+    : [...argv.slice(0, projectFlagIndex), ...argv.slice(projectFlagIndex + 2)]
+
+const command = positionalArgs[0]
+const recFileArg = positionalArgs[1]
+const updateHintArg = positionalArgs[2]
 
 if (
   !SUPPORTED_COMMANDS.includes(command as (typeof SUPPORTED_COMMANDS)[number])
@@ -53,10 +65,70 @@ if (!recFileArg) {
   )
 }
 
+if (!projectArg) {
+  throw new Error('Pass the tsconfig to check as `--project <file>`')
+}
+
 const REC_FILE_PATH = path.resolve(process.cwd(), recFileArg)
 const UPDATE_HINT = updateHintArg || `update the baseline at ${recFileArg}`
 
-const tsErrorsAsJson: TsError[] = JSON.parse(fs.readFileSync(0, 'utf-8'))
+// tsc exits 0 when it finds nothing and 1 or 2 when it reports diagnostics.
+// Any other status means it died before listing them - 134 for an
+// out-of-memory abort - and its empty output must never be read as a clean
+// run, which would silently erase the baseline.
+const TSC_FINISHED_STATUSES = new Set([0, 1, 2])
+
+function runTsc(project: string): string {
+  // Resolve tsc the way the shell would from this package, since the api
+  // pins its own typescript.
+  const requireFromCwd = createRequire(path.join(process.cwd(), 'noop.js'))
+  const { status, signal, stdout, stderr, error } = spawnSync(
+    process.execPath,
+    [
+      requireFromCwd.resolve('typescript/bin/tsc'),
+      '--project',
+      project,
+      '--noEmit',
+      '--pretty',
+      'false',
+    ],
+    { encoding: 'utf-8', maxBuffer: 1 << 28 },
+  )
+
+  if (error) {
+    throw new Error(`Could not start tsc: ${error.message}`)
+  }
+
+  if (stderr) {
+    console.error(stderr)
+  }
+
+  if (signal || status === null || !TSC_FINISHED_STATUSES.has(status)) {
+    const cause = signal ? `was killed by ${signal}` : `exited with ${status}`
+
+    console.error('_'.repeat(80))
+    console.error(`✗ tsc ${cause} before reporting any diagnostics.`)
+
+    if (/heap out of memory|Allocation failed/.test(stderr)) {
+      console.error('')
+      console.error('It ran out of memory. Give it a bigger heap and retry:')
+      console.error('')
+      console.error('   NODE_OPTIONS=--max-old-space-size=8192 <command>')
+    }
+
+    console.error('')
+    console.error(`The baseline at ${recFileArg} is left untouched.`)
+    console.error('_'.repeat(80))
+
+    throw new Error(
+      `tsc ${cause}, so its output says nothing about the real error count`,
+    )
+  }
+
+  return stdout
+}
+
+const tsErrorsAsJson: TsError[] = parse(runTsc(projectArg)) as TsError[]
 
 function getNewSnapshot() {
   let totalErrorCount = 0

--- a/scripts/ts-error-check.ts
+++ b/scripts/ts-error-check.ts
@@ -78,7 +78,31 @@ const UPDATE_HINT = updateHintArg || `update the baseline at ${recFileArg}`
 // run, which would silently erase the baseline.
 const TSC_FINISHED_STATUSES = new Set([0, 1, 2])
 
-function runTsc(project: string): string {
+function refuseRun(reason: string, stderr: string): never {
+  console.error('_'.repeat(80))
+  console.error(`✗ tsc ${reason}.`)
+
+  if (/heap out of memory|Allocation failed/.test(stderr)) {
+    console.error('')
+    console.error('It ran out of memory. Give it a bigger heap and retry:')
+    console.error('')
+    console.error('   NODE_OPTIONS=--max-old-space-size=8192 <command>')
+  }
+
+  console.error('')
+  console.error(`The baseline at ${recFileArg} is left untouched.`)
+  console.error('_'.repeat(80))
+
+  throw new Error(
+    `tsc ${reason}, so its output says nothing about the real error count`,
+  )
+}
+
+function runTsc(project: string): {
+  stdout: string
+  stderr: string
+  status: number
+} {
   // Resolve tsc the way the shell would from this package, since the api
   // pins its own typescript.
   const requireFromCwd = createRequire(path.join(process.cwd(), 'noop.js'))
@@ -106,29 +130,25 @@ function runTsc(project: string): string {
   if (signal || status === null || !TSC_FINISHED_STATUSES.has(status)) {
     const cause = signal ? `was killed by ${signal}` : `exited with ${status}`
 
-    console.error('_'.repeat(80))
-    console.error(`✗ tsc ${cause} before reporting any diagnostics.`)
-
-    if (/heap out of memory|Allocation failed/.test(stderr)) {
-      console.error('')
-      console.error('It ran out of memory. Give it a bigger heap and retry:')
-      console.error('')
-      console.error('   NODE_OPTIONS=--max-old-space-size=8192 <command>')
-    }
-
-    console.error('')
-    console.error(`The baseline at ${recFileArg} is left untouched.`)
-    console.error('_'.repeat(80))
-
-    throw new Error(
-      `tsc ${cause}, so its output says nothing about the real error count`,
-    )
+    refuseRun(`${cause} before reporting any diagnostics`, stderr)
   }
 
-  return stdout
+  return { stdout, stderr, status }
 }
 
-const tsErrorsAsJson: TsError[] = parse(runTsc(projectArg)) as TsError[]
+const tscRun = runTsc(projectArg)
+const tsErrorsAsJson: TsError[] = parse(tscRun.stdout) as TsError[]
+
+// A non-zero status means tsc had something to report, so an empty result
+// means it crashed before listing anything rather than finding nothing. An
+// uncaught compiler exception looks exactly like this: status 1, a stack
+// trace on stderr, and no diagnostics at all.
+if (tscRun.status !== 0 && !tsErrorsAsJson.length) {
+  refuseRun(
+    `exited with ${tscRun.status} without reporting a single diagnostic`,
+    tscRun.stderr,
+  )
+}
 
 function getNewSnapshot() {
   let totalErrorCount = 0

--- a/scripts/tsc-safe-run.ts
+++ b/scripts/tsc-safe-run.ts
@@ -1,0 +1,114 @@
+import { parse } from '@aivenio/tsc-output-parser'
+import { spawnSync } from 'child_process'
+import { createRequire } from 'module'
+import path from 'path'
+
+// tsc exits 0 when it finds nothing and 1 or 2 when it reports diagnostics.
+// Any other status means it died before listing them - 134 for an
+// out-of-memory abort - and its empty output must never be read as a clean
+// run, which would silently erase the baseline in ts-error-check.ts.
+const TSC_FINISHED_STATUSES = new Set([0, 1, 2])
+
+const argv = process.argv.slice(2)
+const projectFlagIndex = argv.indexOf('--project')
+const projectArg =
+  projectFlagIndex === -1 ? undefined : argv[projectFlagIndex + 1]
+
+if (!projectArg) {
+  throw new Error('Pass the tsconfig to check as `--project <file>`')
+}
+
+// Everything except --project is forwarded to ts-error-check.ts untouched.
+const checkArgs = [
+  ...argv.slice(0, projectFlagIndex),
+  ...argv.slice(projectFlagIndex + 2),
+]
+
+function refuseRun(reason: string, stderr: string): never {
+  console.error('_'.repeat(80))
+  console.error(`✗ tsc ${reason}.`)
+
+  if (/heap out of memory|Allocation failed/.test(stderr)) {
+    console.error('')
+    console.error('It ran out of memory. Give it a bigger heap and retry:')
+    console.error('')
+    console.error('   NODE_OPTIONS=--max-old-space-size=8192 <command>')
+  }
+
+  console.error('')
+  console.error('The baseline was left untouched.')
+  console.error('_'.repeat(80))
+
+  throw new Error(
+    `tsc ${reason}, so its output says nothing about the real error count`,
+  )
+}
+
+// Resolve tsc the way the shell would from this package, since the api pins
+// its own typescript.
+const requireFromCwd = createRequire(path.join(process.cwd(), 'noop.js'))
+const tsc = spawnSync(
+  process.execPath,
+  [
+    requireFromCwd.resolve('typescript/bin/tsc'),
+    '--project',
+    projectArg,
+    '--noEmit',
+    '--pretty',
+    'false',
+  ],
+  { encoding: 'utf-8', maxBuffer: 1 << 28 },
+)
+
+if (tsc.error) {
+  throw new Error(`Could not start tsc: ${tsc.error.message}`)
+}
+
+if (tsc.stderr) {
+  console.error(tsc.stderr)
+}
+
+if (
+  tsc.signal ||
+  tsc.status === null ||
+  !TSC_FINISHED_STATUSES.has(tsc.status)
+) {
+  const cause = tsc.signal
+    ? `was killed by ${tsc.signal}`
+    : `exited with ${tsc.status}`
+
+  refuseRun(`${cause} before reporting any diagnostics`, tsc.stderr)
+}
+
+const tsErrors = parse(tsc.stdout) as unknown[]
+
+// A non-zero status means tsc had something to report, so an empty result
+// means it crashed before listing anything rather than finding nothing. An
+// uncaught compiler exception looks exactly like this: status 1, a stack
+// trace on stderr, and no diagnostics at all.
+if (tsc.status !== 0 && !tsErrors.length) {
+  refuseRun(
+    `exited with ${tsc.status} without reporting a single diagnostic`,
+    tsc.stderr,
+  )
+}
+
+// Hand the parsed diagnostics to ts-error-check.ts on stdin, exactly the way
+// the old `tsc | tsc-output-parser | tsx ts-error-check.ts` shell pipe did.
+// That script is untouched - it still only knows how to compare/overwrite a
+// baseline against TsError[] JSON read from stdin.
+const check = spawnSync(
+  'tsx',
+  [path.join(__dirname, 'ts-error-check.ts'), ...checkArgs],
+  {
+    input: JSON.stringify(tsErrors),
+    stdio: ['pipe', 'inherit', 'inherit'],
+    encoding: 'utf-8',
+  },
+)
+
+if (check.error) {
+  throw new Error(`Could not start ts-error-check.ts: ${check.error.message}`)
+}
+
+process.exit(check.status ?? 1)

--- a/scripts/tsc-safe-run.ts
+++ b/scripts/tsc-safe-run.ts
@@ -98,8 +98,12 @@ if (tsc.status !== 0 && !tsErrors.length) {
 // That script is untouched - it still only knows how to compare/overwrite a
 // baseline against TsError[] JSON read from stdin.
 const check = spawnSync(
-  'tsx',
-  [path.join(__dirname, 'ts-error-check.ts'), ...checkArgs],
+  process.execPath,
+  [
+    requireFromCwd.resolve('tsx/cli'),
+    path.join(__dirname, 'ts-error-check.ts'),
+    ...checkArgs,
+  ],
   {
     input: JSON.stringify(tsErrors),
     stdio: ['pipe', 'inherit', 'inherit'],


### PR DESCRIPTION
# What

The baseline check piped tsc's output through parsers, so tsc's exit status was discarded. When tsc crashes (OOM, exit 134), the pipe yields empty output, which was read as "zero errors" - silently wiping the baseline.

`tsc-safe-run.ts` now runs tsc directly and checks its exit status/signal. On a crash it refuses to touch the baseline and reports the failure, without calling `ts-error-check.ts`. On a clean run it forwards the parsed diagnostics to `ts-error-check.ts` over stdin, same as the old pipe did. `ts-error-check.ts` itself is unchanged, so it stays easy to sync with the copy kept in another repo.

No heap flag added - this only makes failures visible instead of silent. CI's `NODE_OPTIONS` for the UI step still applies, since the spawned tsc inherits the environment.

# Testing

Happy path unchanged: `type-check`/`tscheck` report the same counts and exit 0.

Forced OOM (`NODE_OPTIONS=--max-old-space-size=512 npm run type-check --prefix redisinsight/ui`):
- Before: reported "fixed 1287 errors", wiped the baseline, exit 0.
- After: `✗ tsc was killed by SIGABRT`, baseline untouched, non-zero exit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect local/CI TypeScript baseline tooling; runtime app behavior is unchanged and the fix reduces risk of silently corrupting error baselines.
> 
> **Overview**
> The TypeScript baseline workflow no longer shells out to `tsc | tsc-output-parser | ts-error-check.ts`, which dropped **tsc’s exit code** and could treat a crash (e.g. OOM / SIGABRT) as **zero errors** and wipe `.tscheck.rec.json`.
> 
> A new **`scripts/tsc-safe-run.ts`** runs `tsc` with `spawnSync`, treats only exit codes **0/1/2** as a completed compile, and **refuses to call `ts-error-check.ts`** when `tsc` is killed, exits abnormally, or exits non‑zero with no parsed diagnostics—leaving the baseline untouched and surfacing OOM hints. On success it parses stdout and feeds the same JSON to **`ts-error-check.ts` on stdin** (that script is unchanged).
> 
> **`type-check` / `tscheck` / `tscheck:force`** in **`redisinsight/api`**, **`desktop`**, and **`ui`** now invoke `tsx ../../scripts/tsc-safe-run.ts --project …` with the same compare/overwrite arguments as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 353c8efc84cf9ca7b264bc5df5d30520c67ceab3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->