### PR TITLE
#6414 Fix Electron main process crash from webpack 5.109 import.meta

### DIFF
--- a/configs/stubs/sentryOrchestrionRegister.js
+++ b/configs/stubs/sentryOrchestrionRegister.js
@@ -1,0 +1,14 @@
+/**
+ * Stands in for @sentry/server-utils' orchestrion `register` module in the
+ * Electron main bundle.
+ *
+ * That module calls `createRequire(import.meta.url)`. The main bundle is
+ * CommonJS (`output.library.type: 'umd'`), where `import.meta` is a
+ * SyntaxError, so evaluating it kills the main process before any window
+ * opens. Diagnostics-channel injection hooks Node's own module loader and
+ * cannot work on bundled code in any case, so a no-op is the honest shape.
+ *
+ * Keep the export name in sync with the real module: the
+ * `orchestrion/index.js` barrel re-exports it by name.
+ */
+export function registerDiagnosticsChannelInjection() {}

--- a/configs/stubs/sentryOrchestrionRegister.ts
+++ b/configs/stubs/sentryOrchestrionRegister.ts
@@ -11,4 +11,4 @@
  * Keep the export name in sync with the real module: the
  * `orchestrion/index.js` barrel re-exports it by name.
  */
-export function registerDiagnosticsChannelInjection() {}
+export function registerDiagnosticsChannelInjection(): void {}

--- a/configs/webpack.config.base.ts
+++ b/configs/webpack.config.base.ts
@@ -58,7 +58,7 @@ const configuration: webpack.Configuration = {
     // See the stub for why this module cannot be bundled as-is.
     new webpack.NormalModuleReplacementPlugin(
       /@sentry[/\\]server-utils[/\\]build[/\\]esm[/\\]orchestrion[/\\]runtime[/\\]register\.js$/,
-      resolve(__dirname, 'stubs/sentryOrchestrionRegister.js'),
+      resolve(__dirname, 'stubs/sentryOrchestrionRegister.ts'),
     ),
 
     new webpack.IgnorePlugin({

--- a/configs/webpack.config.base.ts
+++ b/configs/webpack.config.base.ts
@@ -55,6 +55,12 @@ const configuration: webpack.Configuration = {
       NODE_ENV: 'production',
     }),
 
+    // See the stub for why this module cannot be bundled as-is.
+    new webpack.NormalModuleReplacementPlugin(
+      /@sentry[/\\]server-utils[/\\]build[/\\]esm[/\\]orchestrion[/\\]runtime[/\\]register\.js$/,
+      resolve(__dirname, 'stubs/sentryOrchestrionRegister.js'),
+    ),
+
     new webpack.IgnorePlugin({
       checkResource(resource) {
         const lazyImports = [


### PR DESCRIPTION
# What

webpack 5.109 leaves `import.meta` untransformed in part of `@sentry/server-utils`'
orchestrion `register` module. The Electron main bundle is CommonJS
(`output.library.type: 'umd'`), where `import.meta` is a SyntaxError, so the main
process dies during bootstrap and no window ever opens.

Replaces that one module with a same-shape no-op via
`NormalModuleReplacementPlugin`. Diagnostics-channel injection hooks Node's own
module loader and cannot work on bundled code either way, so nothing functional is
lost.

Two notes on the approach:

- The existing `IgnorePlugin` could not be reused: its `checkResource` only ignores
  resources whose `require.resolve` throws, and this module resolves fine.
- Replacement rather than removal, because `@sentry/electron` imports the binding
  eagerly. Dropping it would trade the SyntaxError for a missing-export error.

This is a no-op on `main` as it stands (webpack 5.104.1 transforms `import.meta`
correctly). It exists to unblock the webpack bump in #6414.

# Testing

Reproduced against the real `@sentry/server-utils@10.67.0` in a minimal
`target: electron-main` + `library.type: umd` build:

| webpack | fix | `import.meta` left in bundle | Result |
| --- | --- | --- | --- |
| 5.104.1 | no | 0 | runs |
| 5.109.2 | no | 4 | SyntaxError |
| 5.109.2 | yes | 0 | runs |

The failure was first isolated by bisecting #6414's 18 bumps down to `webpack`
(reverting it alone turned the Electron suite from 0/300 to 294 passed), then
root-caused by extracting `dist/main/main.js` from both AppImages and executing
them.

Full Electron E2E against webpack 5.109.2 with this fix is running on
`ric/6414/fix-sentry-orchestrion-importmeta`:
https://github.com/redis/RedisInsight/actions/runs/32476558702

E2E does not run by default on non-dependabot branches, so add the `e2e-tests`
label to exercise the Electron suite here.

Worth reporting upstream to webpack: `import.meta.url` is transformed in a bare
assignment but not inside a call argument in the same module.

---

Refs #6414

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only module stub; no runtime auth/data changes. Sentry diagnostics-channel injection is a no-op in the Electron main bundle, which it already could not do on bundled code.
> 
> **Overview**
> Prevents the Electron main process from dying at bootstrap when webpack 5.109 leaves `import.meta` untransformed in `@sentry/server-utils` orchestrion `register`.
> 
> Webpack now replaces that module with a same-shape no-op (`registerDiagnosticsChannelInjection`). Diagnostics-channel injection cannot work on bundled code anyway, so Sentry still loads without a missing-export error. This unblocks bumping webpack in #6414.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07869a702aeb39c48621fc2536bf146774e94e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->