### PR TITLE
#6414 Fix Electron main bundle build broken by TypeScript Sentry stub

### DIFF
--- a/configs/stubs/sentryOrchestrionRegister.js
+++ b/configs/stubs/sentryOrchestrionRegister.js
@@ -10,5 +10,10 @@
  *
  * Keep the export name in sync with the real module: the
  * `orchestrion/index.js` barrel re-exports it by name.
+ *
+ * This file has to stay plain JavaScript. `NormalModuleReplacementPlugin`
+ * swaps the resource only after webpack has picked loaders for the module it
+ * replaces, and that module sits in `node_modules`, so it gets none. Any
+ * TypeScript syntax here reaches the JS parser and fails to build.
  */
-export function registerDiagnosticsChannelInjection(): void {}
+export function registerDiagnosticsChannelInjection() {}

--- a/configs/webpack.config.base.ts
+++ b/configs/webpack.config.base.ts
@@ -58,7 +58,7 @@ const configuration: webpack.Configuration = {
     // See the stub for why this module cannot be bundled as-is.
     new webpack.NormalModuleReplacementPlugin(
       /@sentry[/\\]server-utils[/\\]build[/\\]esm[/\\]orchestrion[/\\]runtime[/\\]register\.js$/,
-      resolve(__dirname, 'stubs/sentryOrchestrionRegister.ts'),
+      resolve(__dirname, 'stubs/sentryOrchestrionRegister.js'),
     ),
 
     new webpack.IgnorePlugin({


### PR DESCRIPTION
# What

The Sentry orchestrion stub is swapped into the Electron main bundle by `NormalModuleReplacementPlugin`. That plugin replaces the resource in its `afterResolve` hook, by which point webpack has already selected loaders for the module being replaced - and that module lives in `node_modules`, so it gets none. The stub is therefore always handed to the plain JS parser, and the `: void` annotation on it fails to build:

```
ERROR in ./node_modules/@sentry/server-utils/build/esm/orchestrion/runtime/register.js 14:53
Module parse failed: Unexpected token (14:53)
> export function registerDiagnosticsChannelInjection(): void {}
```

This reverts the stub to plain JavaScript and adds a comment explaining why it has to stay that way. The annotation was added for type coverage, but `configs/tsconfig.json` sets no `allowJs`, so a `.js` stub is not type-checked anyway - and a zero-arg no-op has nothing worth checking.

Every desktop build (Linux, macOS, Windows) and the E2E Playwright v2 workflow are currently failing on `main` because of this.

# Testing

`npm run build:main:stage` fails on `main` and passes here. Verified the emitted bundle contains the no-op (`function registerDiagnosticsChannelInjection() {}`) and that the only remaining `import.meta` occurrences are inside comments, so the original main-process crash stays fixed.

`npm run type-check` reports no new errors against the baselines; `configs/tsconfig.json` is clean. Both changed files are outside ESLint's scope.

# Note

No PR-triggered workflow compiles the Electron main bundle today - `build.yml` is `workflow_call` only, and `tests-e2e-playwright-v2.yml` skips regular PRs. That is why this merged green and only showed up on dependabot branches and the nightly run. Worth a follow-up to close that gap.

---

Refs #6414

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-config-only change to a no-op webpack stub; no runtime behavior or security-sensitive code is altered.
> 
> **Overview**
> Fixes the Electron main bundle build, which was failing because the Sentry orchestrion stub used TypeScript syntax (`: void`) that webpack never transpiles.
> 
> `NormalModuleReplacementPlugin` swaps the resource after loaders are chosen for the original `node_modules` module, so the stub is parsed as plain JS. The stub is now `.js` with a no-op `registerDiagnosticsChannelInjection`, and webpack points at that file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d58fb5fa99964be85537d1abb62699a803a0708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->