### PR TITLE
feat(agent-memory): Memory details pane with inline edit

### DIFF
--- a/redisinsight/api/src/modules/agent-memory/agent-memory-data.controller.ts
+++ b/redisinsight/api/src/modules/agent-memory/agent-memory-data.controller.ts
@@ -5,6 +5,7 @@ import {
   Delete,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   UseInterceptors,
@@ -18,6 +19,7 @@ import { AgentMemoryDataService } from 'src/modules/agent-memory/agent-memory-da
 import {
   AgentMemoryConfiguration,
   DiscoveryFiltersResponse,
+  LongTermMemoryRecord,
   LongTermMemorySearchResponse,
   WorkingMemoryResponse,
 } from 'src/modules/agent-memory/agent-memory.types';
@@ -26,6 +28,7 @@ import {
   AddSessionEventDto,
   DeleteLongTermMemoriesDto,
   SearchLongTermMemoryDto,
+  UpdateLongTermMemoryDto,
 } from 'src/modules/agent-memory/dto';
 import { RequestAgentMemoryClientMetadata } from 'src/modules/agent-memory/decorators';
 
@@ -105,6 +108,19 @@ export class AgentMemoryDataController {
     @Body() dto: SearchLongTermMemoryDto,
   ): Promise<LongTermMemorySearchResponse> {
     return this.service.searchLongTermMemory(metadata, dto);
+  }
+
+  @Patch('/long-term-memory/:memoryId')
+  @ApiEndpoint({
+    description: 'Update a long-term memory record',
+    responses: [{ status: 200 }],
+  })
+  async updateLongTermMemory(
+    @RequestAgentMemoryClientMetadata() metadata: AgentMemoryClientMetadata,
+    @Param('memoryId') memoryId: string,
+    @Body() dto: UpdateLongTermMemoryDto,
+  ): Promise<LongTermMemoryRecord> {
+    return this.service.updateLongTermMemory(metadata, memoryId, dto);
   }
 
   @Delete('/long-term-memory')

--- a/redisinsight/api/src/modules/agent-memory/agent-memory-data.service.ts
+++ b/redisinsight/api/src/modules/agent-memory/agent-memory-data.service.ts
@@ -7,10 +7,14 @@ import {
   AgentMemoryNewMessage,
   AgentMemoryScopeFilter,
   DiscoveryFiltersResponse,
+  LongTermMemoryRecord,
   LongTermMemorySearchResponse,
   WorkingMemoryResponse,
 } from 'src/modules/agent-memory/agent-memory.types';
-import { SearchLongTermMemoryDto } from 'src/modules/agent-memory/dto';
+import {
+  SearchLongTermMemoryDto,
+  UpdateLongTermMemoryDto,
+} from 'src/modules/agent-memory/dto';
 
 /**
  * Proxies inspector data reads/writes to the connected agent memory
@@ -63,6 +67,15 @@ export class AgentMemoryDataService {
   ): Promise<LongTermMemorySearchResponse> {
     const client = await this.clientProvider.getOrCreate(metadata);
     return client.searchLongTermMemory(dto);
+  }
+
+  async updateLongTermMemory(
+    metadata: AgentMemoryClientMetadata,
+    memoryId: string,
+    dto: UpdateLongTermMemoryDto,
+  ): Promise<LongTermMemoryRecord> {
+    const client = await this.clientProvider.getOrCreate(metadata);
+    return client.updateLongTermMemory(memoryId, dto);
   }
 
   async deleteLongTermMemories(

--- a/redisinsight/api/src/modules/agent-memory/client/agent-memory.client.ts
+++ b/redisinsight/api/src/modules/agent-memory/client/agent-memory.client.ts
@@ -13,10 +13,14 @@ import {
   AgentMemoryConfiguration,
   AgentMemoryScopeFilter,
   DiscoveryFiltersResponse,
+  LongTermMemoryRecord,
   LongTermMemorySearchResponse,
   WorkingMemoryResponse,
 } from 'src/modules/agent-memory/agent-memory.types';
-import { SearchLongTermMemoryDto } from 'src/modules/agent-memory/dto';
+import {
+  SearchLongTermMemoryDto,
+  UpdateLongTermMemoryDto,
+} from 'src/modules/agent-memory/dto';
 import { AGENT_MEMORY_IDLE_THRESHOLD } from 'src/modules/agent-memory/constants';
 
 export abstract class AgentMemoryClient {
@@ -91,6 +95,12 @@ export abstract class AgentMemoryClient {
   abstract searchLongTermMemory(
     dto: SearchLongTermMemoryDto,
   ): Promise<LongTermMemorySearchResponse>;
+
+  /** Apply a partial update to one long-term memory record */
+  abstract updateLongTermMemory(
+    memoryId: string,
+    update: UpdateLongTermMemoryDto,
+  ): Promise<LongTermMemoryRecord>;
 
   abstract deleteLongTermMemories(ids: string[]): Promise<void>;
 

--- a/redisinsight/api/src/modules/agent-memory/client/cloud.agent-memory.client.ts
+++ b/redisinsight/api/src/modules/agent-memory/client/cloud.agent-memory.client.ts
@@ -6,6 +6,9 @@ type IrisSearchRequest = NonNullable<
   Parameters<IrisAgentMemoryClient['searchLongTermMemory']>[0]
 >;
 type IrisFilter = NonNullable<IrisSearchRequest['filter']>;
+type IrisUpdateRequest = NonNullable<
+  Parameters<IrisAgentMemoryClient['updateLongTermMemory']>[1]
+>;
 type IrisMessageRole = Parameters<
   IrisAgentMemoryClient['addSessionEvent']
 >[0]['role'];
@@ -19,10 +22,14 @@ import {
   AgentMemoryNewMessage,
   AgentMemoryScopeFilter,
   DiscoveryFiltersResponse,
+  LongTermMemoryRecord,
   LongTermMemorySearchResponse,
   WorkingMemoryResponse,
 } from 'src/modules/agent-memory/agent-memory.types';
-import { SearchLongTermMemoryDto } from 'src/modules/agent-memory/dto';
+import {
+  SearchLongTermMemoryDto,
+  UpdateLongTermMemoryDto,
+} from 'src/modules/agent-memory/dto';
 import {
   AGENT_MEMORY_TIMEOUT,
   CLOUD_EVENT_ROLES,
@@ -195,6 +202,25 @@ export class CloudAgentMemoryClient extends AgentMemoryClient {
     );
     const items = (data?.items ?? []).map(fromCloudMemory);
     return { memories: items, total: items.length };
+  }
+
+  async updateLongTermMemory(
+    memoryId: string,
+    update: UpdateLongTermMemoryDto,
+  ): Promise<LongTermMemoryRecord> {
+    const body: IrisUpdateRequest = {};
+    if (update.text !== undefined) body.text = update.text;
+    if (update.memoryType !== undefined) body.memoryType = update.memoryType;
+    if (update.topics !== undefined) body.topics = update.topics;
+    if (update.namespace !== undefined) body.namespace = update.namespace;
+    // The normalized record exposes ownerId as userId.
+    if (update.userId !== undefined) body.ownerId = update.userId;
+    if (update.sessionId !== undefined) body.sessionId = update.sessionId;
+
+    const data = await this.sdkCall(() =>
+      this.sdk.updateLongTermMemory(memoryId, body),
+    );
+    return fromCloudMemory(data);
   }
 
   async deleteLongTermMemories(ids: string[]): Promise<void> {

--- a/redisinsight/api/src/modules/agent-memory/dto/index.ts
+++ b/redisinsight/api/src/modules/agent-memory/dto/index.ts
@@ -3,4 +3,5 @@ export * from './update.agent-memory-endpoint.dto';
 export * from './delete.agent-memory-endpoints.dto';
 export * from './add.session-event.dto';
 export * from './search.long-term-memory.dto';
+export * from './update.long-term-memory.dto';
 export * from './delete.long-term-memories.dto';

--- a/redisinsight/api/src/modules/agent-memory/dto/update.long-term-memory.dto.ts
+++ b/redisinsight/api/src/modules/agent-memory/dto/update.long-term-memory.dto.ts
@@ -1,0 +1,64 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsOptional,
+  IsString,
+  Length,
+} from 'class-validator';
+
+export class UpdateLongTermMemoryDto {
+  @ApiPropertyOptional({ description: 'Updated memory text', type: String })
+  @IsOptional()
+  @Expose()
+  @IsString()
+  @Length(1, 50000)
+  text?: string;
+
+  @ApiPropertyOptional({ description: 'Updated memory type', type: String })
+  @IsOptional()
+  @Expose()
+  @IsString()
+  memoryType?: string;
+
+  @ApiPropertyOptional({
+    description: 'Updated topic tags',
+    type: String,
+    isArray: true,
+  })
+  @IsOptional()
+  @Expose()
+  @IsArray()
+  @ArrayMaxSize(50)
+  @IsString({ each: true })
+  @Length(1, 100, { each: true })
+  topics?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Updated namespace (empty string clears it)',
+    type: String,
+  })
+  @IsOptional()
+  @Expose()
+  @IsString()
+  @Length(0, 64)
+  namespace?: string;
+
+  @ApiPropertyOptional({ description: 'Updated owner (user) id', type: String })
+  @IsOptional()
+  @Expose()
+  @IsString()
+  @Length(1, 64)
+  userId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Updated session id (empty string clears it)',
+    type: String,
+  })
+  @IsOptional()
+  @Expose()
+  @IsString()
+  @Length(0, 64)
+  sessionId?: string;
+}

--- a/redisinsight/ui/src/pages/agent-memory/workspace/AgentMemoryWorkspacePage.tsx
+++ b/redisinsight/ui/src/pages/agent-memory/workspace/AgentMemoryWorkspacePage.tsx
@@ -42,6 +42,7 @@ import FilterPills from './components/filter-pills/FilterPills'
 import WorkingMemoryPanel from './components/working-memory-panel/WorkingMemoryPanel'
 import LongTermOverviewPanel from './components/long-term-overview-panel/LongTermOverviewPanel'
 import LongTermMemoryPanel from './components/long-term-memory-panel/LongTermMemoryPanel'
+import LongTermMemoryDetails from './components/long-term-memory-details/LongTermMemoryDetails'
 import LongTermMemoryToolbar from './components/long-term-memory-toolbar/LongTermMemoryToolbar'
 import ConfigurationPanel from './components/configuration-panel/ConfigurationPanel'
 import * as S from './AgentMemoryWorkspacePage.styles'
@@ -309,9 +310,25 @@ const AgentMemoryWorkspacePage = () => {
       {isLtmTab && (
         <S.PanesArea>
           <S.PanesContainer direction="horizontal">
-            <ResizablePanel id="agent-memory-records-panel" defaultSize={100}>
+            <ResizablePanel
+              id="agent-memory-records-panel"
+              defaultSize={longTermMemory.selectedRecordId ? 55 : 100}
+              minSize={PANEL_MIN_SIZE}
+            >
               <LongTermMemoryPanel endpointId={endpointId} />
             </ResizablePanel>
+            {!!longTermMemory.selectedRecordId && (
+              <>
+                <ResizablePanelHandle />
+                <ResizablePanel
+                  id="agent-memory-record-detail-panel"
+                  defaultSize={45}
+                  minSize={PANEL_MIN_SIZE}
+                >
+                  <LongTermMemoryDetails endpointId={endpointId} />
+                </ResizablePanel>
+              </>
+            )}
           </S.PanesContainer>
         </S.PanesArea>
       )}

--- a/redisinsight/ui/src/pages/agent-memory/workspace/components/long-term-memory-details/LongTermMemoryDetails.spec.tsx
+++ b/redisinsight/ui/src/pages/agent-memory/workspace/components/long-term-memory-details/LongTermMemoryDetails.spec.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { cloneDeep } from 'lodash'
+import { faker } from '@faker-js/faker'
+
+import type { RootState } from 'uiSrc/slices/store'
+import { LongTermMemoryRecord } from 'uiSrc/slices/interfaces/agentMemory'
+import {
+  cleanup,
+  fireEvent,
+  initialStateDefault,
+  mockStore,
+  render,
+  screen,
+} from 'uiSrc/utils/test-utils'
+
+import { updateLongTermMemoryAction } from 'uiSrc/slices/agentMemory/workspace'
+import LongTermMemoryDetails, {
+  LongTermMemoryDetailsProps,
+} from './LongTermMemoryDetails'
+
+jest.mock('uiSrc/slices/agentMemory/workspace', () => ({
+  ...jest.requireActual('uiSrc/slices/agentMemory/workspace'),
+  updateLongTermMemoryAction: jest.fn(() => ({ type: 'UPDATE_LTM' })),
+  deleteLongTermMemoryAction: jest.fn(() => ({ type: 'DELETE_LTM' })),
+}))
+
+const mockRecord: LongTermMemoryRecord = {
+  id: 'memory-1',
+  text: 'user prefers redis',
+  memoryType: 'semantic',
+  userId: 'user-1',
+  sessionId: 'session-1',
+  namespace: 'demo',
+  topics: ['databases', 'preferences'],
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-02T00:00:00.000Z',
+}
+
+interface StateOverrides {
+  record?: LongTermMemoryRecord | null
+}
+
+const createStore = ({ record = mockRecord }: StateOverrides = {}) => {
+  const state = cloneDeep(initialStateDefault) as RootState
+  state.agentMemory.workspace.longTermMemory.data = record ? [record] : []
+  state.agentMemory.workspace.longTermMemory.selectedRecordId =
+    record?.id ?? null
+  return mockStore(state)
+}
+
+describe('LongTermMemoryDetails', () => {
+  const defaultProps: LongTermMemoryDetailsProps = {
+    endpointId: faker.string.uuid(),
+  }
+
+  const renderComponent = (stateOverrides: StateOverrides = {}) => {
+    const store = createStore(stateOverrides)
+    return {
+      store,
+      ...render(<LongTermMemoryDetails {...defaultProps} />, { store }),
+    }
+  }
+
+  beforeEach(() => {
+    cleanup()
+    jest.clearAllMocks()
+  })
+
+  it('should render every field of the selected record', () => {
+    renderComponent()
+
+    expect(screen.getByTestId('ltm-details-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('ltm-field-text')).toHaveTextContent(
+      'user prefers redis',
+    )
+    expect(screen.getByTestId('ltm-field-memoryType')).toHaveTextContent(
+      'semantic',
+    )
+    expect(screen.getByTestId('ltm-field-topics')).toHaveTextContent(
+      'databases, preferences',
+    )
+    expect(screen.getByTestId('ltm-field-userId')).toHaveTextContent('user-1')
+    expect(screen.getByTestId('ltm-field-sessionId')).toHaveTextContent(
+      'session-1',
+    )
+    expect(screen.getByTestId('ltm-field-namespace')).toHaveTextContent('demo')
+  })
+
+  it('should show the empty state when no record is selected', () => {
+    renderComponent({ record: null })
+
+    expect(screen.getByTestId('ltm-details-empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('ltm-field-text')).toBeNull()
+  })
+
+  it('should edit the text field via a textarea and dispatch an update', () => {
+    renderComponent()
+
+    expect(screen.queryByTestId('ltm-text-editor')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('ltm-text-edit'))
+
+    const textarea = screen.getByTestId('ltm-text-editor')
+    fireEvent.change(textarea, { target: { value: 'user loves redis' } })
+    fireEvent.click(screen.getByTestId('ltm-text-apply'))
+
+    expect(updateLongTermMemoryAction).toHaveBeenCalledWith(
+      defaultProps.endpointId,
+      'memory-1',
+      { text: 'user loves redis' },
+      expect.any(Function),
+    )
+  })
+
+  it('should clear the selection when the close button is clicked', () => {
+    const { store } = renderComponent()
+
+    fireEvent.click(screen.getByTestId('ltm-details-close'))
+
+    expect(store.getActions()).toEqual(
+      expect.arrayContaining([
+        { type: 'agentMemoryWorkspace/setSelectedRecord', payload: null },
+      ]),
+    )
+  })
+})

--- a/redisinsight/ui/src/pages/agent-memory/workspace/components/long-term-memory-details/LongTermMemoryDetails.styles.ts
+++ b/redisinsight/ui/src/pages/agent-memory/workspace/components/long-term-memory-details/LongTermMemoryDetails.styles.ts
@@ -1,0 +1,123 @@
+import { HTMLAttributes } from 'react'
+import styled from 'styled-components'
+
+import { Col, Row } from 'uiSrc/components/base/layout/flex'
+import { TextArea } from 'uiSrc/components/base/inputs'
+
+import { fontMono, palette } from '../../AgentMemoryWorkspacePage.styles'
+
+/* A description list of the record's fields: label (dt) on the left, value
+ * (dd) on the right. Grid columns keep the two aligned; the label column is a
+ * fixed width and the value column takes the rest. */
+export const Fields = styled.dl<HTMLAttributes<HTMLDListElement>>`
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  margin: 0;
+  padding: ${({ theme }) => theme.core.space.space150}
+    ${({ theme }) => theme.core.space.space200};
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  align-content: start;
+  font-size: 1.25rem;
+
+  /* The shared inline editor centers its value in a fixed 42px row; drop that
+   * so the value and its hover edit button start at the top of the row,
+   * level with the label. */
+  [class*='contentWrapper'] {
+    align-items: flex-start;
+    min-height: 0;
+  }
+`
+
+export const FieldLabel = styled.dt<HTMLAttributes<HTMLElement>>`
+  padding: ${({ theme }) => theme.core.space.space100} 0;
+  border-bottom: 1px solid ${palette.border};
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: ${palette.textSecondary};
+`
+
+export const FieldValue = styled.dd<HTMLAttributes<HTMLElement>>`
+  margin: 0;
+  padding: ${({ theme }) => theme.core.space.space100} 0;
+  padding-left: ${({ theme }) => theme.core.space.space200};
+  border-bottom: 1px solid ${palette.border};
+  min-width: 0;
+  color: ${palette.text};
+  word-break: break-word;
+  white-space: pre-wrap;
+`
+
+/* Read-only text with a hover-revealed edit pencil, matching the inline
+ * editors used by the other fields. */
+export const TextReadonly = styled(Row)`
+  .ltm-inline-edit {
+    flex-shrink: 0;
+    opacity: 0;
+  }
+  &:hover .ltm-inline-edit {
+    opacity: 1;
+  }
+`
+
+/* Editing row: textarea at the field width with the controls beside it, laid
+ * out like the read-only row. styled(TextArea) styles the wrapper TextArea
+ * renders around the <textarea>, so growing it (not the inner element) is what
+ * makes the editor fill the width. */
+export const TextEditRow = styled(Row)`
+  button {
+    flex-shrink: 0;
+  }
+`
+
+export const TextEditorArea = styled(TextArea)`
+  flex: 1;
+  min-width: 0;
+`
+
+export const ReadOnlyValue = styled.span<HTMLAttributes<HTMLSpanElement>>`
+  font-family: ${fontMono};
+  color: ${palette.textSecondary};
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.core.space.space050};
+`
+
+export const Placeholder = styled.span<HTMLAttributes<HTMLSpanElement>>`
+  color: ${palette.textMuted};
+  font-style: italic;
+`
+
+export const RecordId = styled.span<HTMLAttributes<HTMLSpanElement>>`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.core.space.space050};
+  font-family: ${fontMono};
+  font-size: ${({ theme }) => theme.core.font.fontSize.s12};
+  color: ${palette.textSecondary};
+`
+
+export const HeaderRight = styled.div<HTMLAttributes<HTMLDivElement>>`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.core.space.space050};
+`
+
+export const EmptyState = styled(Col)`
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: ${({ theme }) => theme.core.space.space300};
+  color: ${palette.textMuted};
+  font-style: italic;
+  text-align: center;
+`
+
+export {
+  Pane,
+  PaneHeaderBlock,
+  PaneHeader,
+  PaneTitle,
+} from '../../AgentMemoryWorkspacePage.styles'

--- a/redisinsight/ui/src/pages/agent-memory/workspace/components/long-term-memory-details/LongTermMemoryDetails.tsx
+++ b/redisinsight/ui/src/pages/agent-memory/workspace/components/long-term-memory-details/LongTermMemoryDetails.tsx
@@ -1,0 +1,263 @@
+import React, { useState } from 'react'
+
+import { useAppSelector } from 'uiSrc/slices/hooks'
+import { dispatch } from 'uiSrc/slices/store'
+import { CopyButton } from 'uiSrc/components/copy-button'
+import { IconButton } from 'uiSrc/components/base/forms/buttons'
+import {
+  CancelSlimIcon,
+  CheckThinIcon,
+  EditIcon,
+} from 'uiSrc/components/base/icons'
+import PopoverDelete from 'uiSrc/pages/browser/components/popover-delete/PopoverDelete'
+import { EditableInput } from 'uiSrc/pages/browser/modules/key-details/shared'
+import {
+  agentMemorySelectedRecordSelector,
+  deleteLongTermMemoryAction,
+  setSelectedRecord,
+  updateLongTermMemoryAction,
+} from 'uiSrc/slices/agentMemory/workspace'
+import {
+  AgentMemoryRecordUpdate,
+  DEFAULT_MEMORY_TYPE,
+} from 'uiSrc/slices/interfaces/agentMemory'
+
+import { formatDateTime, relativeTime } from '../../utils/format'
+import TimestampWithRelative from '../timestamp-with-relative/TimestampWithRelative'
+import * as S from './LongTermMemoryDetails.styles'
+
+export interface LongTermMemoryDetailsProps {
+  endpointId: string
+}
+
+const DELETE_SUFFIX = '_ltm_detail'
+
+/**
+ * Right-hand detail pane for the selected long-term memory record. Shows
+ * every field; text/type/topics/namespace/owner/session are editable
+ * inline (mirrors the Browser key-details editing), created/updated and id
+ * are read-only.
+ */
+const LongTermMemoryDetails = ({ endpointId }: LongTermMemoryDetailsProps) => {
+  const record = useAppSelector(agentMemorySelectedRecordSelector)
+  const [editingField, setEditingField] = useState<string | null>(null)
+  const [textDraft, setTextDraft] = useState('')
+  const [deleting, setDeleting] = useState('')
+
+  if (!record) {
+    return (
+      <S.Pane data-testid="ltm-details-panel">
+        <S.EmptyState data-testid="ltm-details-empty">
+          Select a memory record to see its details.
+        </S.EmptyState>
+      </S.Pane>
+    )
+  }
+
+  const applyUpdate = (patch: AgentMemoryRecordUpdate) =>
+    dispatch(
+      updateLongTermMemoryAction(endpointId, record.id, patch, () =>
+        setEditingField(null),
+      ),
+    )
+
+  const renderEditable = (
+    field: string,
+    label: string,
+    value: string,
+    toPatch: (next: string) => AgentMemoryRecordUpdate,
+    placeholder: string,
+  ) => (
+    <>
+      <S.FieldLabel>{label}</S.FieldLabel>
+      <S.FieldValue>
+        <EditableInput
+          field={field}
+          initialValue={value}
+          placeholder={placeholder}
+          isEditing={editingField === field}
+          onEdit={(editing) => setEditingField(editing ? field : null)}
+          onDecline={() => setEditingField(null)}
+          onApply={(next) => applyUpdate(toPatch(next))}
+          testIdPrefix={`ltm-${field}`}
+        >
+          {value ? (
+            <span data-testid={`ltm-field-${field}`}>{value}</span>
+          ) : (
+            <S.Placeholder data-testid={`ltm-field-${field}`}>
+              {placeholder}
+            </S.Placeholder>
+          )}
+        </EditableInput>
+      </S.FieldValue>
+    </>
+  )
+
+  // The other fields use the shared EditableInput; the multi-line text needs a
+  // textarea. EditableTextArea would give one, but it sizes itself through
+  // react-virtualized AutoSizer, which only works inside fixed-size table cells
+  // and collapses in this flow layout. So lay out a plain textarea with the
+  // edit controls beside it, mirroring the read-only row.
+  const renderText = () => (
+    <>
+      <S.FieldLabel>Text</S.FieldLabel>
+      <S.FieldValue>
+        {editingField === 'text' ? (
+          <S.TextEditRow align="start" gap="s">
+            <S.TextEditorArea
+              rows={4}
+              value={textDraft}
+              onChange={(value: string) => setTextDraft(value)}
+              data-testid="ltm-text-editor"
+            />
+            <IconButton
+              icon={CancelSlimIcon}
+              aria-label="Cancel editing text"
+              data-testid="ltm-text-decline"
+              onClick={() => setEditingField(null)}
+            />
+            <IconButton
+              icon={CheckThinIcon}
+              aria-label="Save text"
+              data-testid="ltm-text-apply"
+              onClick={() => applyUpdate({ text: textDraft })}
+            />
+          </S.TextEditRow>
+        ) : (
+          <S.TextReadonly align="start" gap="s">
+            {record.text ? (
+              <span data-testid="ltm-field-text">{record.text}</span>
+            ) : (
+              <S.Placeholder data-testid="ltm-field-text">
+                No text
+              </S.Placeholder>
+            )}
+            <IconButton
+              className="ltm-inline-edit"
+              icon={EditIcon}
+              aria-label="Edit text"
+              data-testid="ltm-text-edit"
+              onClick={() => {
+                setTextDraft(record.text)
+                setEditingField('text')
+              }}
+            />
+          </S.TextReadonly>
+        )}
+      </S.FieldValue>
+    </>
+  )
+
+  return (
+    <S.Pane data-testid="ltm-details-panel">
+      <S.PaneHeaderBlock>
+        <S.PaneHeader align="center" justify="between">
+          <S.PaneTitle align="center" gap="m">
+            <h2>Memory details</h2>
+            <S.RecordId>
+              <span data-testid="ltm-details-id">{record.id}</span>
+              <CopyButton
+                copy={record.id}
+                aria-label="Copy memory id"
+                data-testid="ltm-details-copy-id"
+              />
+            </S.RecordId>
+          </S.PaneTitle>
+          <S.HeaderRight>
+            <PopoverDelete
+              header="Memory"
+              text="will be permanently deleted from long-term memory."
+              item={record.id}
+              suffix={DELETE_SUFFIX}
+              deleting={deleting}
+              updateLoading={false}
+              closePopover={() => setDeleting('')}
+              showPopover={(item) => setDeleting(`${item}${DELETE_SUFFIX}`)}
+              testid="ltm-details-delete"
+              handleDeleteItem={() =>
+                dispatch(deleteLongTermMemoryAction(endpointId, record.id))
+              }
+            />
+            <IconButton
+              icon={CancelSlimIcon}
+              aria-label="Close record details"
+              data-testid="ltm-details-close"
+              onClick={() => dispatch(setSelectedRecord(null))}
+            />
+          </S.HeaderRight>
+        </S.PaneHeader>
+      </S.PaneHeaderBlock>
+
+      <S.Fields>
+        {renderText()}
+        {renderEditable(
+          'memoryType',
+          'Type',
+          record.memoryType ?? DEFAULT_MEMORY_TYPE,
+          (next) => ({ memoryType: next }),
+          DEFAULT_MEMORY_TYPE,
+        )}
+        {renderEditable(
+          'topics',
+          'Topics',
+          record.topics.join(', '),
+          (next) => ({
+            topics: next
+              .split(',')
+              .map((topic) => topic.trim())
+              .filter(Boolean),
+          }),
+          'No topics',
+        )}
+        {renderEditable(
+          'namespace',
+          'Namespace',
+          record.namespace ?? '',
+          (next) => ({ namespace: next.trim() }),
+          'No namespace',
+        )}
+        {renderEditable(
+          'userId',
+          'Owner (user)',
+          record.userId ?? '',
+          (next) => ({ userId: next.trim() }),
+          'No owner',
+        )}
+        {renderEditable(
+          'sessionId',
+          'Session ID',
+          record.sessionId ?? '',
+          (next) => ({ sessionId: next.trim() }),
+          'No session',
+        )}
+
+        <S.FieldLabel>Created</S.FieldLabel>
+        <S.FieldValue>
+          {record.createdAt ? (
+            <S.ReadOnlyValue>
+              <TimestampWithRelative
+                dateTime={record.createdAt}
+                content={`Created ${relativeTime(record.createdAt)}`}
+              />
+            </S.ReadOnlyValue>
+          ) : (
+            <S.Placeholder>—</S.Placeholder>
+          )}
+        </S.FieldValue>
+
+        <S.FieldLabel>Updated</S.FieldLabel>
+        <S.FieldValue>
+          {record.updatedAt ? (
+            <S.ReadOnlyValue data-testid="ltm-field-updatedAt">
+              {formatDateTime(record.updatedAt)}
+            </S.ReadOnlyValue>
+          ) : (
+            <S.Placeholder>—</S.Placeholder>
+          )}
+        </S.FieldValue>
+      </S.Fields>
+    </S.Pane>
+  )
+}
+
+export default LongTermMemoryDetails

--- a/redisinsight/ui/src/pages/agent-memory/workspace/components/long-term-memory-panel/LongTermMemoryPanel.styles.ts
+++ b/redisinsight/ui/src/pages/agent-memory/workspace/components/long-term-memory-panel/LongTermMemoryPanel.styles.ts
@@ -1,3 +1,31 @@
+import styled from 'styled-components'
+
+import { Card, ChipRow } from '../../AgentMemoryWorkspacePage.styles'
+
+/** A records-list card that opens the detail pane when clicked. Hover and
+ * selection both use the Browser's selected-row accent (--euiColorPrimary):
+ * a thin full border on hover, a 3px left accent when selected. */
+export const RecordCard = styled(Card)<{ $selected?: boolean }>`
+  cursor: pointer;
+  transition: border-color 120ms ease;
+
+  &:hover {
+    border-color: var(--euiColorPrimary);
+  }
+
+  ${({ $selected }) =>
+    $selected &&
+    `
+    border-left: 3px solid var(--euiColorPrimary);
+  `}
+
+  /* No session footer -> the topic chips are the last row; give them the
+   * breathing room the footer's session band otherwise provides. */
+  & > ${ChipRow}:last-child {
+    padding-bottom: ${({ theme }) => theme.core.space.space100};
+  }
+`
+
 export {
   Pane,
   PaneHeader,

--- a/redisinsight/ui/src/pages/agent-memory/workspace/components/long-term-memory-panel/LongTermMemoryPanel.tsx
+++ b/redisinsight/ui/src/pages/agent-memory/workspace/components/long-term-memory-panel/LongTermMemoryPanel.tsx
@@ -6,6 +6,7 @@ import { RiTooltip } from 'uiSrc/components'
 import {
   agentMemoryLongTermSelector,
   fetchLongTermMemoryAction,
+  setSelectedRecord,
   toggleSessionFilter,
   toggleTopicFilter,
 } from 'uiSrc/slices/agentMemory/workspace'
@@ -50,7 +51,10 @@ const TopicChips = ({ values, onPick }: TopicChipsProps) => {
               type="button"
               $kind="topic"
               data-testid={`topic-chip-${value}`}
-              onClick={() => onPick(value)}
+              onClick={(e) => {
+                e.stopPropagation()
+                onPick(value)
+              }}
             >
               {value}
             </S.Chip>
@@ -63,10 +67,21 @@ const TopicChips = ({ values, onPick }: TopicChipsProps) => {
 
 interface MemoryCardProps {
   memory: LongTermMemoryRecord
+  selected: boolean
+  onSelect: (id: string) => void
 }
 
-const MemoryCard = ({ memory }: MemoryCardProps) => (
-  <S.Card data-testid="long-term-memory-card">
+// Interactive controls inside the card open filters/copy, not the detail
+// pane, so they stop the card's select click.
+const stop = (event: React.MouseEvent) => event.stopPropagation()
+
+const MemoryCard = ({ memory, selected, onSelect }: MemoryCardProps) => (
+  <S.RecordCard
+    data-testid="long-term-memory-card"
+    data-selected={selected}
+    $selected={selected}
+    onClick={() => onSelect(memory.id)}
+  >
     <S.CardMeta>
       <S.TypeBadge $type={memory.memoryType ?? DEFAULT_MEMORY_TYPE}>
         {memory.memoryType ?? DEFAULT_MEMORY_TYPE}
@@ -84,7 +99,7 @@ const MemoryCard = ({ memory }: MemoryCardProps) => (
           }
         />
       )}
-      <S.CardId>
+      <S.CardId onClick={stop}>
         <HoverCopyButton
           copy={memory.id}
           label="Copy id"
@@ -102,7 +117,7 @@ const MemoryCard = ({ memory }: MemoryCardProps) => (
     />
     {!!memory.sessionId && (
       <S.CardFooter>
-        <S.CardMetaSession>
+        <S.CardMetaSession onClick={stop}>
           <S.VisuallyHidden>from session:</S.VisuallyHidden>
           <RiTooltip
             title="Session ID"
@@ -125,15 +140,14 @@ const MemoryCard = ({ memory }: MemoryCardProps) => (
         </S.CardMetaSession>
       </S.CardFooter>
     )}
-  </S.Card>
+  </S.RecordCard>
 )
 
 /** The long-term memory records list. Search + filters live in the
  * toolbar above the panel (LongTermMemoryToolbar). */
 const LongTermMemoryPanel = ({ endpointId }: LongTermMemoryPanelProps) => {
-  const { data, error, loading, lastRefreshTime } = useAppSelector(
-    agentMemoryLongTermSelector,
-  )
+  const { data, error, loading, lastRefreshTime, selectedRecordId } =
+    useAppSelector(agentMemoryLongTermSelector)
 
   return (
     <S.Pane data-testid="long-term-memory-panel">
@@ -160,7 +174,11 @@ const LongTermMemoryPanel = ({ endpointId }: LongTermMemoryPanelProps) => {
       <S.CardList>
         {data.map((memory) => (
           <li key={memory.id}>
-            <MemoryCard memory={memory} />
+            <MemoryCard
+              memory={memory}
+              selected={memory.id === selectedRecordId}
+              onSelect={(id) => dispatch(setSelectedRecord(id))}
+            />
           </li>
         ))}
         {!data.length && (

--- a/redisinsight/ui/src/slices/agentMemory/thunks/long-term-memory.ts
+++ b/redisinsight/ui/src/slices/agentMemory/thunks/long-term-memory.ts
@@ -10,11 +10,15 @@ import {
 
 import { AppDispatch, RootState } from '../../store'
 import { addErrorNotification } from '../../app/notifications'
-import { LongTermMemoryRecord } from '../../interfaces/agentMemory'
+import {
+  AgentMemoryRecordUpdate,
+  LongTermMemoryRecord,
+} from '../../interfaces/agentMemory'
 import {
   getLongTermMemory,
   getLongTermMemoryFailure,
   getLongTermMemorySuccess,
+  updateLongTermMemorySuccess,
 } from '../workspace'
 import { isStaleResponse } from './helpers'
 
@@ -94,6 +98,32 @@ export function fetchLongTermMemoryAction(endpointId: string) {
 /** Overview pane: scoped to the shared user + session pills. */
 export function fetchOverviewLongTermMemoryAction(endpointId: string) {
   return fetchLongTermMemory(endpointId, true)
+}
+
+/**
+ * Apply a partial update to one record. On success the updated record
+ * (returned by the server) replaces the one in the list in place.
+ */
+export function updateLongTermMemoryAction(
+  endpointId: string,
+  memoryId: string,
+  update: AgentMemoryRecordUpdate,
+  onSuccess?: () => void,
+) {
+  return async (dispatch: AppDispatch) => {
+    try {
+      const { data, status } = await apiService.patch<LongTermMemoryRecord>(
+        getAgentMemoryUrl(endpointId, ApiEndpoints.AGENT_MEMORY_LTM, memoryId),
+        update,
+      )
+      if (isStatusSuccessful(status)) {
+        dispatch(updateLongTermMemorySuccess(data))
+        onSuccess?.()
+      }
+    } catch (_err) {
+      dispatch(addErrorNotification(_err as AxiosError))
+    }
+  }
 }
 
 export function deleteLongTermMemoryAction(

--- a/redisinsight/ui/src/slices/agentMemory/workspace.ts
+++ b/redisinsight/ui/src/slices/agentMemory/workspace.ts
@@ -31,6 +31,7 @@ export const initialState: StateAgentMemoryWorkspace = {
     error: '',
     data: [],
     lastRefreshTime: null,
+    selectedRecordId: null,
     search: '',
     similarityThreshold: null,
     topics: [],
@@ -124,10 +125,33 @@ const inspectorSlice = createSlice({
       state.longTermMemory.error = ''
       state.longTermMemory.data = payload
       state.longTermMemory.lastRefreshTime = Date.now()
+      // Drop a selection that no longer exists (deleted or filtered out) so
+      // the detail pane can't point at a missing record.
+      if (
+        state.longTermMemory.selectedRecordId &&
+        !payload.some((m) => m.id === state.longTermMemory.selectedRecordId)
+      ) {
+        state.longTermMemory.selectedRecordId = null
+      }
     },
     getLongTermMemoryFailure: (state, { payload }: PayloadAction<string>) => {
       state.longTermMemory.loading = false
       state.longTermMemory.error = payload
+    },
+    setSelectedRecord: (
+      state,
+      { payload }: PayloadAction<Nullable<string>>,
+    ) => {
+      state.longTermMemory.selectedRecordId = payload
+    },
+    updateLongTermMemorySuccess: (
+      state,
+      { payload }: PayloadAction<LongTermMemoryRecord>,
+    ) => {
+      const index = state.longTermMemory.data.findIndex(
+        (m) => m.id === payload.id,
+      )
+      if (index !== -1) state.longTermMemory.data[index] = payload
     },
     setLongTermMemorySearch: (state, { payload }: PayloadAction<string>) => {
       state.longTermMemory.search = payload
@@ -211,6 +235,8 @@ export const {
   getLongTermMemory,
   getLongTermMemorySuccess,
   getLongTermMemoryFailure,
+  setSelectedRecord,
+  updateLongTermMemorySuccess,
   setLongTermMemorySearch,
   setSimilarityThreshold,
   toggleTopicFilter,
@@ -231,6 +257,10 @@ export const agentMemoryWorkingSelector = (state: RootState) =>
   state.agentMemory.workspace.workingMemory
 export const agentMemoryLongTermSelector = (state: RootState) =>
   state.agentMemory.workspace.longTermMemory
+export const agentMemorySelectedRecordSelector = (state: RootState) => {
+  const { data, selectedRecordId } = state.agentMemory.workspace.longTermMemory
+  return data.find((m) => m.id === selectedRecordId) ?? null
+}
 export const agentMemoryConfigurationSelector = (state: RootState) =>
   state.agentMemory.workspace.configuration
 
@@ -247,6 +277,7 @@ export {
 export {
   fetchLongTermMemoryAction,
   fetchOverviewLongTermMemoryAction,
+  updateLongTermMemoryAction,
   deleteLongTermMemoryAction,
 } from './thunks/long-term-memory'
 export { fetchConfigurationAction } from './thunks/configuration'

--- a/redisinsight/ui/src/slices/interfaces/agentMemory.ts
+++ b/redisinsight/ui/src/slices/interfaces/agentMemory.ts
@@ -50,6 +50,16 @@ export interface LongTermMemoryRecord {
   updatedAt?: string
 }
 
+/** Partial update payload for a long-term memory record (editable fields). */
+export interface AgentMemoryRecordUpdate {
+  text?: string
+  memoryType?: string
+  topics?: string[]
+  namespace?: string
+  userId?: string
+  sessionId?: string
+}
+
 export const DEFAULT_MEMORY_TYPE = 'semantic'
 
 export enum AgentMemoryWorkspaceTab {
@@ -111,6 +121,8 @@ export interface StateAgentMemoryWorkspace {
     error: string
     data: LongTermMemoryRecord[]
     lastRefreshTime: Nullable<number>
+    /** Record shown in the detail pane; null when the pane is closed. */
+    selectedRecordId: Nullable<string>
     search: string
     similarityThreshold: Nullable<number>
     topics: string[]

--- a/redisinsight/ui/src/slices/tests/agentMemory/workspace.spec.ts
+++ b/redisinsight/ui/src/slices/tests/agentMemory/workspace.spec.ts
@@ -9,6 +9,8 @@ import reducer, {
   getWorkingMemorySuccess,
   getWorkingMemoryFailure,
   getLongTermMemorySuccess,
+  setSelectedRecord,
+  updateLongTermMemorySuccess,
   setLongTermMemorySearch,
   toggleTopicFilter,
   toggleSessionFilter,
@@ -155,6 +157,37 @@ describe('agentMemory workspace slice', () => {
       )
 
       expect(nextState.longTermMemory.data).toEqual([mockMemory])
+    })
+  })
+
+  describe('record selection + update', () => {
+    it('should set and clear the selected record id', () => {
+      let state = reducer(initialState, setSelectedRecord('memory-1'))
+      expect(state.longTermMemory.selectedRecordId).toEqual('memory-1')
+
+      state = reducer(state, setSelectedRecord(null))
+      expect(state.longTermMemory.selectedRecordId).toBeNull()
+    })
+
+    it('should replace the updated record in place', () => {
+      const state = reducer(
+        initialState,
+        getLongTermMemorySuccess([mockMemory]),
+      )
+      const updated = { ...mockMemory, text: 'user loves redis' }
+
+      const nextState = reducer(state, updateLongTermMemorySuccess(updated))
+
+      expect(nextState.longTermMemory.data).toEqual([updated])
+    })
+
+    it('should drop a selection that is no longer in the fetched data', () => {
+      let state = reducer(initialState, getLongTermMemorySuccess([mockMemory]))
+      state = reducer(state, setSelectedRecord('memory-1'))
+
+      const nextState = reducer(state, getLongTermMemorySuccess([]))
+
+      expect(nextState.longTermMemory.selectedRecordId).toBeNull()
     })
   })
 


### PR DESCRIPTION
- add long-term memory record update endpoint
- Clicking a long-term memory record opens a detail pane on the right - a records | details resizable split, with selected record being highlighted.
- The pane shows every field and enables editing the fields supported by Redis Agent Memory update API

<img width="1512" height="982" alt="Redis Agent Memory - view / update a record" src="https://github.com/user-attachments/assets/e2dc289b-e494-476b-b264-909b353474dd" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a write path that mutates long-term memory records (text, owner, session, topics) via a new PATCH API. Scope is limited to the agent-memory inspector and existing session-bound clients.
> 
> **Overview**
> Lets users inspect and edit a long-term memory record from the explorer. Clicking a record opens a resizable details pane (list | details) with the selected card highlighted.
> 
> Adds `PATCH /agent-memory/:id/long-term-memory/:memoryId` with a validated partial DTO (text, type, topics, namespace, owner, session). The cloud client maps `userId` to SDK `ownerId` and returns the updated record, which replaces the list item in place.
> 
> The details pane supports inline edits (textarea for text, `EditableInput` for the rest), copy id, and delete. Selection is cleared when the record is filtered out or deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c43eeee9cd3c044719559ec0dfe15710157401b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->