### PR TITLE
#6440 Ignore quicktype-core minors until the API moves to TypeScript 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -220,6 +220,11 @@ updates:
       - dependency-name: 'redis-parser'
         update-types:
           ['version-update:semver-patch', 'version-update:semver-minor']
+      # From 23.2 the shipped .d.ts uses `const` type parameters, which need
+      # TypeScript 5. The api compiles on 4.9, so a minor breaks type-check,
+      # the Linux build and the Docker build.
+      - dependency-name: 'quicktype-core'
+        update-types: ['version-update:semver-minor']
 
     groups:
       # `group-by` raises one pull request per dependency spanning both


### PR DESCRIPTION
# What

Stops dependabot proposing `quicktype-core` minors for `redisinsight/api`.

From 23.2 the shipped `.d.ts` declares `const` type parameters, which need
TypeScript 5. The api compiles on 4.9, and these are parse errors rather than
type errors, so the existing `skipLibCheck: true` does not hide them. The bump
fails the tsc baselines, `nest build` (so both the Linux and Docker builds) and
the Chromium E2E.

Scoped deliberately:

- Patches within 23.0.x stay allowed, so only the minor is held back.
- The rule names its update types, so security updates still come through.

The runtime API is unchanged (`quicktype`, `InputData`,
`jsonInputForTargetLanguage` and `lang: 'schema'` all behave the same on
23.3.25), so this is purely a compiler-version hold. The bump becomes takeable
as it stands once the api moves to TypeScript 5, at which point this rule should
be removed rather than left to calcify.

# Testing

`.github/dependabot.yml` parses, and the new rule resolves into the
`/redisinsight` + `/redisinsight/api` entry alongside the existing holds:

```
ignore names: ['*', 'typescript', 'typeorm', 'ioredis-mock', 'redis',
               'ioredis', 'redis-parser', 'quicktype-core']
```

Config-only, so no suite exercises it: `.github/dependabot.yml` matches no
pattern in the `infra` paths filter in `tests.yml`, and dependabot reads the
file from the default branch, so the rule only takes effect after this merges.

Verify after merge by commenting `@dependabot recreate` on #6440 and checking
the regenerated PR drops `quicktype-core` and keeps the other five updates.

---

Refs #6440

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Dependabot; no application or runtime behavior changes.
> 
> **Overview**
> Adds a Dependabot **ignore** rule on the shared `/redisinsight` + `/redisinsight/api` npm entry so **`quicktype-core` semver-minor** bumps are not proposed automatically.
> 
> From **23.2**, that package’s shipped `.d.ts` uses `const` type parameters, which **TypeScript 4.9** (what the API still uses) cannot parse—even with `skipLibCheck`—so those minors break type-check, `nest build`, and related CI. **Patch** updates within the current line stay allowed; naming only `semver-minor` on the rule leaves **security** updates unaffected. Remove this hold after the API upgrades to TypeScript 5.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4525cc022993f7f0f8390cc49db2c7567ae4b26e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->