### PR TITLE
RI-8394 Add a manual "Check for Updates" action for notify mode

### DIFF
--- a/redisinsight/desktop/src/lib/app/ipc.handlers.ts
+++ b/redisinsight/desktop/src/lib/app/ipc.handlers.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain, nativeTheme } from 'electron'
+import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
 import log from 'electron-log'
 import {
   electronStore,
@@ -8,6 +8,8 @@ import {
   startUpdateDownload,
   checkForUpdate,
   triggerManualUpdateCheck,
+  getTray,
+  MenuBuilder,
 } from 'desktopSrc/lib'
 import { wrapErrorMessageSensitiveData } from 'desktopSrc/utils'
 import {
@@ -60,6 +62,12 @@ export const initIPCHandlers = () => {
       }
 
       electronStore?.set(ElectronStorageItem.updateStrategy, strategy)
+
+      getTray()?.buildContextMenu()
+      const focusedWindow = BrowserWindow.getFocusedWindow()
+      if (focusedWindow) {
+        new MenuBuilder(focusedWindow).buildMenu()
+      }
 
       checkForUpdate(
         process.env.RI_MANUAL_UPGRADES_LINK || process.env.RI_UPGRADES_LINK,

--- a/redisinsight/desktop/src/lib/app/ipc.handlers.ts
+++ b/redisinsight/desktop/src/lib/app/ipc.handlers.ts
@@ -9,6 +9,7 @@ import {
   checkForUpdate,
   triggerManualUpdateCheck,
   getTray,
+  getTrayInstance,
   MenuBuilder,
 } from 'desktopSrc/lib'
 import { wrapErrorMessageSensitiveData } from 'desktopSrc/utils'
@@ -63,7 +64,9 @@ export const initIPCHandlers = () => {
 
       electronStore?.set(ElectronStorageItem.updateStrategy, strategy)
 
-      getTray()?.buildContextMenu()
+      if (!getTrayInstance()?.isDestroyed()) {
+        getTray()?.buildContextMenu()
+      }
       const focusedWindow = BrowserWindow.getFocusedWindow()
       if (focusedWindow) {
         new MenuBuilder(focusedWindow).buildMenu()

--- a/redisinsight/desktop/src/lib/app/ipc.handlers.ts
+++ b/redisinsight/desktop/src/lib/app/ipc.handlers.ts
@@ -7,6 +7,7 @@ import {
   getUpdateStrategy,
   startUpdateDownload,
   checkForUpdate,
+  triggerManualUpdateCheck,
 } from 'desktopSrc/lib'
 import { wrapErrorMessageSensitiveData } from 'desktopSrc/utils'
 import {
@@ -76,5 +77,9 @@ export const initIPCHandlers = () => {
 
   ipcMain.handle(IpcInvokeEvent.appUpdateDownload, (_event, version: string) =>
     startUpdateDownload(version),
+  )
+
+  ipcMain.handle(IpcInvokeEvent.checkForUpdate, () =>
+    triggerManualUpdateCheck(),
   )
 }

--- a/redisinsight/desktop/src/lib/menu/menu.ts
+++ b/redisinsight/desktop/src/lib/menu/menu.ts
@@ -13,13 +13,10 @@ import {
   WindowType,
   windowFactory,
   electronStore,
-  getUpdateStrategy,
+  shouldShowManualUpdateCheck,
   triggerManualUpdateCheck,
 } from 'desktopSrc/lib'
-import {
-  AppUpdateStrategy,
-  ElectronStorageItem,
-} from 'uiSrc/electron/constants'
+import { ElectronStorageItem } from 'uiSrc/electron/constants'
 
 interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
   selector?: string
@@ -71,7 +68,7 @@ export class MenuBuilder {
           label: `About ${app.name}`,
           selector: 'orderFrontStandardAboutPanel:',
         },
-        ...(getUpdateStrategy() === AppUpdateStrategy.notify
+        ...(shouldShowManualUpdateCheck()
           ? [
               {
                 label: 'Check for Updates…',
@@ -358,7 +355,7 @@ export class MenuBuilder {
               )
             },
           },
-          ...(getUpdateStrategy() === AppUpdateStrategy.notify
+          ...(shouldShowManualUpdateCheck()
             ? [
                 {
                   label: 'Check for Updates…',

--- a/redisinsight/desktop/src/lib/menu/menu.ts
+++ b/redisinsight/desktop/src/lib/menu/menu.ts
@@ -13,8 +13,13 @@ import {
   WindowType,
   windowFactory,
   electronStore,
+  getUpdateStrategy,
+  triggerManualUpdateCheck,
 } from 'desktopSrc/lib'
-import { ElectronStorageItem } from 'uiSrc/electron/constants'
+import {
+  AppUpdateStrategy,
+  ElectronStorageItem,
+} from 'uiSrc/electron/constants'
 
 interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
   selector?: string
@@ -66,6 +71,16 @@ export class MenuBuilder {
           label: `About ${app.name}`,
           selector: 'orderFrontStandardAboutPanel:',
         },
+        ...(getUpdateStrategy() === AppUpdateStrategy.notify
+          ? [
+              {
+                label: 'Check for Updates…',
+                click: () => {
+                  triggerManualUpdateCheck()
+                },
+              },
+            ]
+          : []),
         { type: 'separator' },
         {
           label: `Hide ${app.name}`,
@@ -343,6 +358,16 @@ export class MenuBuilder {
               )
             },
           },
+          ...(getUpdateStrategy() === AppUpdateStrategy.notify
+            ? [
+                {
+                  label: 'Check for Updates…',
+                  click: () => {
+                    triggerManualUpdateCheck()
+                  },
+                },
+              ]
+            : []),
           { type: 'separator' },
           {
             label: `About ${app.name}`,

--- a/redisinsight/desktop/src/lib/tray/tray.ts
+++ b/redisinsight/desktop/src/lib/tray/tray.ts
@@ -7,8 +7,13 @@ import {
   MenuItemConstructorOptions,
 } from 'electron'
 import path from 'path'
-import { getWindows } from 'desktopSrc/lib'
+import {
+  getWindows,
+  getUpdateStrategy,
+  triggerManualUpdateCheck,
+} from 'desktopSrc/lib'
 import { showOrCreateWindow } from 'desktopSrc/utils'
+import { AppUpdateStrategy } from 'uiSrc/electron/constants'
 // eslint-disable-next-line import/no-cycle
 import { setToQuiting } from './trayManager'
 
@@ -82,6 +87,16 @@ export class TrayBuilder {
           )
         },
       },
+      ...(getUpdateStrategy() === AppUpdateStrategy.notify
+        ? [
+            {
+              label: 'Check for Updates…',
+              click: () => {
+                triggerManualUpdateCheck()
+              },
+            },
+          ]
+        : []),
       { type: 'separator' },
       {
         label: 'Quit',

--- a/redisinsight/desktop/src/lib/tray/tray.ts
+++ b/redisinsight/desktop/src/lib/tray/tray.ts
@@ -9,11 +9,10 @@ import {
 import path from 'path'
 import {
   getWindows,
-  getUpdateStrategy,
+  shouldShowManualUpdateCheck,
   triggerManualUpdateCheck,
 } from 'desktopSrc/lib'
 import { showOrCreateWindow } from 'desktopSrc/utils'
-import { AppUpdateStrategy } from 'uiSrc/electron/constants'
 // eslint-disable-next-line import/no-cycle
 import { setToQuiting } from './trayManager'
 
@@ -87,7 +86,7 @@ export class TrayBuilder {
           )
         },
       },
-      ...(getUpdateStrategy() === AppUpdateStrategy.notify
+      ...(shouldShowManualUpdateCheck()
         ? [
             {
               label: 'Check for Updates…',

--- a/redisinsight/desktop/src/lib/updater/updater.handlers.ts
+++ b/redisinsight/desktop/src/lib/updater/updater.handlers.ts
@@ -31,9 +31,10 @@ export const initAutoUpdaterHandlers = () => {
   })
   autoUpdater.on('update-available', (info) => {
     log.info('Update available.')
+    updateDownloadState.lastAvailableVersion = info.version
     electronStore?.set(ElectronStorageItem.isUpdateAvailable, true)
 
-    if (autoUpdater.autoDownload) {
+    if (autoUpdater.autoDownload || updateDownloadState.isManualCheck) {
       clearPendingAvailable()
       return
     }

--- a/redisinsight/desktop/src/lib/updater/updater.ts
+++ b/redisinsight/desktop/src/lib/updater/updater.ts
@@ -171,7 +171,9 @@ export const triggerManualUpdateCheck = async (
   }
 
   if (!electronStore?.get(ElectronStorageItem.isUpdateAvailable)) {
-    return { status: AppUpdateStatus.NotAvailable }
+    const state: AppUpdateState = { status: AppUpdateStatus.NotAvailable }
+    sendUpdateState(state)
+    return state
   }
 
   electronStore?.delete(ElectronStorageItem.updateSkippedVersion)

--- a/redisinsight/desktop/src/lib/updater/updater.ts
+++ b/redisinsight/desktop/src/lib/updater/updater.ts
@@ -162,7 +162,10 @@ export const triggerManualUpdateCheck = async (
     process.mas ||
     updateDownloadState.isDownloading
   ) {
-    const state: AppUpdateState = { status: AppUpdateStatus.Error }
+    const state: AppUpdateState = {
+      status: AppUpdateStatus.Error,
+      manual: true,
+    }
     sendUpdateState(state)
     return state
   }
@@ -173,8 +176,12 @@ export const triggerManualUpdateCheck = async (
     await checkForUpdate(url)
   } catch (e) {
     log.error(wrapErrorMessageSensitiveData(e as Error))
-    sendUpdateState({ status: AppUpdateStatus.Error })
-    return { status: AppUpdateStatus.Error }
+    const state: AppUpdateState = {
+      status: AppUpdateStatus.Error,
+      manual: true,
+    }
+    sendUpdateState(state)
+    return state
   }
 
   if (!electronStore?.get(ElectronStorageItem.isUpdateAvailable)) {

--- a/redisinsight/desktop/src/lib/updater/updater.ts
+++ b/redisinsight/desktop/src/lib/updater/updater.ts
@@ -17,6 +17,8 @@ export const updateDownloadState = {
   manuallyTriggered: false,
   downloadedInfo: null as UpdateDownloadedEvent | null,
   initiatingStrategy: null as AppUpdateStrategy | null,
+  isManualCheck: false,
+  lastAvailableVersion: null as string | null,
 }
 
 export const getUpdateStrategy = (): AppUpdateStrategy => {
@@ -93,6 +95,7 @@ export const checkForUpdate = async (url: string = '') => {
     }
   } finally {
     updateDownloadState.isDownloading = false
+    updateDownloadState.isManualCheck = false
     // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion with drainQueuedRecheck, both hoisted function declarations
     drainQueuedRecheck()
   }
@@ -141,6 +144,45 @@ export const startUpdateDownload = (version?: string) => {
     sendUpdateState({ status: AppUpdateStatus.Error })
     drainQueuedRecheck()
   })
+}
+
+export const triggerManualUpdateCheck = async (
+  url: string = process.env.RI_MANUAL_UPGRADES_LINK ||
+    process.env.RI_UPGRADES_LINK ||
+    '',
+): Promise<AppUpdateState> => {
+  if (
+    !url ||
+    process.env.RI_DISABLE_AUTO_UPGRADE === 'true' ||
+    process.mas ||
+    updateDownloadState.isDownloading
+  ) {
+    return { status: AppUpdateStatus.Error }
+  }
+
+  updateDownloadState.isManualCheck = true
+
+  try {
+    await checkForUpdate(url)
+  } catch (e) {
+    log.error(wrapErrorMessageSensitiveData(e as Error))
+    sendUpdateState({ status: AppUpdateStatus.Error })
+    return { status: AppUpdateStatus.Error }
+  }
+
+  if (!electronStore?.get(ElectronStorageItem.isUpdateAvailable)) {
+    return { status: AppUpdateStatus.NotAvailable }
+  }
+
+  electronStore?.delete(ElectronStorageItem.updateSkippedVersion)
+
+  const state: AppUpdateState = {
+    status: AppUpdateStatus.Available,
+    version: updateDownloadState.lastAvailableVersion ?? undefined,
+    manual: true,
+  }
+  sendUpdateState(state)
+  return state
 }
 
 export const initAutoUpdateChecks = (url = '', interval = 84 * 3600 * 1000) => {

--- a/redisinsight/desktop/src/lib/updater/updater.ts
+++ b/redisinsight/desktop/src/lib/updater/updater.ts
@@ -28,6 +28,11 @@ export const getUpdateStrategy = (): AppUpdateStrategy => {
     : AppUpdateStrategy.auto
 }
 
+export const shouldShowManualUpdateCheck = (): boolean =>
+  process.env.RI_DISABLE_AUTO_UPGRADE !== 'true' &&
+  !process.mas &&
+  getUpdateStrategy() === AppUpdateStrategy.notify
+
 export const sendToRenderer = (
   channel: IpcOnEvent,
   payload: any,
@@ -157,7 +162,9 @@ export const triggerManualUpdateCheck = async (
     process.mas ||
     updateDownloadState.isDownloading
   ) {
-    return { status: AppUpdateStatus.Error }
+    const state: AppUpdateState = { status: AppUpdateStatus.Error }
+    sendUpdateState(state)
+    return state
   }
 
   updateDownloadState.isManualCheck = true

--- a/redisinsight/ui/src/components/base/forms/buttons/index.ts
+++ b/redisinsight/ui/src/components/base/forms/buttons/index.ts
@@ -10,4 +10,4 @@ export { ToggleButton } from 'uiSrc/components/base/forms/buttons/ToggleButton'
 
 export type { IconType } from 'uiSrc/components/base/forms/buttons/IconButton'
 
-export { TextButton } from '@redis-ui/components'
+export { Button as RedisUIButton, TextButton } from '@redis-ui/components'

--- a/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.spec.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.spec.tsx
@@ -9,6 +9,7 @@ import {
 } from 'uiSrc/utils/test-utils'
 import { AppUpdateStatus, AppUpdateStrategy } from 'uiSrc/electron/constants'
 import { TelemetryEvent } from 'uiSrc/telemetry'
+import i18n from 'uiSrc/i18n'
 import {
   addInfiniteNotification,
   addMessageNotification,
@@ -23,13 +24,15 @@ const findInfiniteNotification = (store: typeof mockedStore) =>
   store
     .getActions()
     .find((action) => action.type === addInfiniteNotification.type) as
-    { payload: InfiniteMessage } | undefined
+    | { payload: InfiniteMessage }
+    | undefined
 
 const findMessageNotification = (store: typeof mockedStore) =>
   store
     .getActions()
     .find((action) => action.type === addMessageNotification.type) as
-    { payload: IMessage } | undefined
+    | { payload: IMessage }
+    | undefined
 
 jest.mock('uiSrc/telemetry', () => ({
   ...jest.requireActual('uiSrc/telemetry'),
@@ -431,6 +434,40 @@ describe('ConfigElectron', () => {
       expect(addAction?.payload.id).toBe(InfiniteMessagesIds.appUpdateFound)
     })
 
+    it('should resurface a dismissed version when the check is manual', () => {
+      render(<ConfigElectron />, { store })
+      const updateStateAction = (window.app.updateState as jest.Mock).mock
+        .calls[0][0]
+
+      updateStateAction(null, {
+        status: AppUpdateStatus.Available,
+        version: '1.2.3',
+      })
+      const foundAction = findInfiniteNotification(store)
+      foundAction?.payload.onClose?.()
+
+      store.clearActions()
+      jest.clearAllMocks()
+
+      // An unattended periodic recheck for the same version stays hidden...
+      updateStateAction(null, {
+        status: AppUpdateStatus.Available,
+        version: '1.2.3',
+      })
+      expect(store.getActions()).toHaveLength(0)
+
+      // ...but a manual check re-surfaces it even though it was dismissed.
+      updateStateAction(null, {
+        status: AppUpdateStatus.Available,
+        version: '1.2.3',
+        manual: true,
+      })
+
+      const addAction = findInfiniteNotification(store)
+      expect(addAction?.payload.id).toBe(InfiniteMessagesIds.appUpdateFound)
+      expect(addAction?.payload.variation).toBe('1.2.3')
+    })
+
     it('should not emit close telemetry after "Update" was clicked', () => {
       triggerUpdateState({
         status: AppUpdateStatus.Available,
@@ -457,6 +494,15 @@ describe('ConfigElectron', () => {
       )
       const messageAction = findMessageNotification(store)
       expect(messageAction?.payload.variant).toBe('danger')
+    })
+
+    it('should show an up-to-date toast when a manual check finds nothing new', () => {
+      triggerUpdateState({ status: AppUpdateStatus.NotAvailable })
+
+      const messageAction = findMessageNotification(store)
+      expect(messageAction?.payload.title).toBe(
+        i18n.t('notification.success.appUpToDate.title'),
+      )
     })
 
     it('should restore a working retry prompt after a download failure', () => {

--- a/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.spec.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.spec.tsx
@@ -466,6 +466,28 @@ describe('ConfigElectron', () => {
       expect(addAction?.payload.variation).toBe('1.2.3')
     })
 
+    it('should not re-show a still-open found toast even for a manual check', () => {
+      render(<ConfigElectron />, { store })
+      const updateStateAction = (window.app.updateState as jest.Mock).mock
+        .calls[0][0]
+
+      updateStateAction(null, {
+        status: AppUpdateStatus.Available,
+        version: '1.2.3',
+      })
+      store.clearActions()
+
+      // The toast for 1.2.3 is still open and unresolved; re-announcing it
+      // manually must not touch it, or its live buttons would be orphaned.
+      updateStateAction(null, {
+        status: AppUpdateStatus.Available,
+        version: '1.2.3',
+        manual: true,
+      })
+
+      expect(store.getActions()).toHaveLength(0)
+    })
+
     it('should not emit close telemetry after "Update" was clicked', () => {
       triggerUpdateState({
         status: AppUpdateStatus.Available,
@@ -490,6 +512,32 @@ describe('ConfigElectron', () => {
       expect(store.getActions()).toContainEqual(
         removeInfiniteNotification(InfiniteMessagesIds.appUpdateFound),
       )
+      const messageAction = findMessageNotification(store)
+      expect(messageAction?.payload.variant).toBe('danger')
+    })
+
+    it('should not touch the found toast when a manual check fails', () => {
+      render(<ConfigElectron />, { store })
+      const updateStateAction = (window.app.updateState as jest.Mock).mock
+        .calls[0][0]
+
+      updateStateAction(null, {
+        status: AppUpdateStatus.Available,
+        version: '1.2.3',
+      })
+      store.clearActions()
+      jest.clearAllMocks()
+
+      updateStateAction(null, { status: AppUpdateStatus.Error, manual: true })
+
+      expect(store.getActions()).not.toContainEqual(
+        removeInfiniteNotification(InfiniteMessagesIds.appUpdateFound),
+      )
+      expect(
+        store
+          .getActions()
+          .filter((action) => action.type === addInfiniteNotification.type),
+      ).toHaveLength(0)
       const messageAction = findMessageNotification(store)
       expect(messageAction?.payload.variant).toBe('danger')
     })

--- a/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.spec.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.spec.tsx
@@ -24,15 +24,13 @@ const findInfiniteNotification = (store: typeof mockedStore) =>
   store
     .getActions()
     .find((action) => action.type === addInfiniteNotification.type) as
-    | { payload: InfiniteMessage }
-    | undefined
+    { payload: InfiniteMessage } | undefined
 
 const findMessageNotification = (store: typeof mockedStore) =>
   store
     .getActions()
     .find((action) => action.type === addMessageNotification.type) as
-    | { payload: IMessage }
-    | undefined
+    { payload: IMessage } | undefined
 
 jest.mock('uiSrc/telemetry', () => ({
   ...jest.requireActual('uiSrc/telemetry'),

--- a/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
@@ -200,10 +200,13 @@ const ConfigElectron = () => {
     )
   }
 
-  const updateStateAction = (_e: any, { status, version }: AppUpdateState) => {
+  const updateStateAction = (
+    _e: any,
+    { status, version, manual }: AppUpdateState,
+  ) => {
     switch (status) {
       case AppUpdateStatus.Available:
-        if (foundGuard.shouldSkip(version)) {
+        if (!manual && foundGuard.shouldSkip(version)) {
           return
         }
         restartGuard.resolveCurrent()

--- a/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
@@ -42,9 +42,9 @@ const createToastGuard = () => {
     get lastVersion() {
       return lastVersion
     },
-    shouldSkip: (version?: string) =>
+    shouldSkip: (version?: string, manual?: boolean) =>
       !!version &&
-      (version === dismissedVersion ||
+      ((version === dismissedVersion && !manual) ||
         (version === lastVersion && !resolvedRef.current)),
     resolveCurrent: () => {
       resolvedRef.current = true
@@ -206,7 +206,7 @@ const ConfigElectron = () => {
   ) => {
     switch (status) {
       case AppUpdateStatus.Available:
-        if (!manual && foundGuard.shouldSkip(version)) {
+        if (foundGuard.shouldSkip(version, manual)) {
           return
         }
         restartGuard.resolveCurrent()
@@ -224,7 +224,6 @@ const ConfigElectron = () => {
         )
         break
       case AppUpdateStatus.Error: {
-        dispatch(removeInfiniteNotification(InfiniteMessagesIds.appUpdateFound))
         dispatch(
           addMessageNotification({
             title: t('notification.error.appUpdateFailed.title'),
@@ -232,9 +231,14 @@ const ConfigElectron = () => {
             variant: 'danger',
           }),
         )
-        const lastFoundVersion = foundGuard.lastVersion
-        if (lastFoundVersion !== null) {
-          showUpdateFoundToast(lastFoundVersion)
+        if (!manual) {
+          dispatch(
+            removeInfiniteNotification(InfiniteMessagesIds.appUpdateFound),
+          )
+          const lastFoundVersion = foundGuard.lastVersion
+          if (lastFoundVersion !== null) {
+            showUpdateFoundToast(lastFoundVersion)
+          }
         }
         break
       }

--- a/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
+++ b/redisinsight/ui/src/electron/components/ConfigElectron/ConfigElectron.tsx
@@ -215,6 +215,14 @@ const ConfigElectron = () => {
         )
         showUpdateFoundToast(version ?? '')
         break
+      case AppUpdateStatus.NotAvailable:
+        dispatch(
+          addMessageNotification({
+            title: t('notification.success.appUpToDate.title'),
+            message: t('notification.success.appUpToDate.message'),
+          }),
+        )
+        break
       case AppUpdateStatus.Error: {
         dispatch(removeInfiniteNotification(InfiniteMessagesIds.appUpdateFound))
         dispatch(

--- a/redisinsight/ui/src/electron/constants/ipcEvent.ts
+++ b/redisinsight/ui/src/electron/constants/ipcEvent.ts
@@ -12,6 +12,7 @@ enum IpcInvokeEvent {
   setUpdateStrategy = 'app:update:strategy:set',
   appUpdateDownload = 'app:update:download',
   skipUpdateVersion = 'app:update:skip',
+  checkForUpdate = 'app:update:check',
 }
 
 enum IpcOnEvent {

--- a/redisinsight/ui/src/electron/constants/updateStrategy.ts
+++ b/redisinsight/ui/src/electron/constants/updateStrategy.ts
@@ -5,10 +5,12 @@ export enum AppUpdateStrategy {
 
 export enum AppUpdateStatus {
   Available = 'available',
+  NotAvailable = 'not-available',
   Error = 'error',
 }
 
 export interface AppUpdateState {
   status: AppUpdateStatus
   version?: string
+  manual?: boolean
 }

--- a/redisinsight/ui/src/electron/utils/ipcAppUpdate.ts
+++ b/redisinsight/ui/src/electron/utils/ipcAppUpdate.ts
@@ -1,4 +1,6 @@
 import {
+  AppUpdateState,
+  AppUpdateStatus,
   AppUpdateStrategy,
   ElectronStorageItem,
   IpcInvokeEvent,
@@ -26,3 +28,8 @@ export const ipcAppUpdateDownload = async (version: string) => {
 export const ipcSkipUpdateVersion = async (version: string) => {
   await window.app?.ipc?.invoke(IpcInvokeEvent.skipUpdateVersion, version)
 }
+
+export const ipcCheckForUpdate = async (): Promise<AppUpdateState> =>
+  (await window.app?.ipc?.invoke(IpcInvokeEvent.checkForUpdate)) ?? {
+    status: AppUpdateStatus.Error,
+  }

--- a/redisinsight/ui/src/i18n/locales/bg.json
+++ b/redisinsight/ui/src/i18n/locales/bg.json
@@ -1772,6 +1772,7 @@
   "settings.general.theme.option.light": "Светла тема",
   "settings.general.theme.option.system": "Същата като системната",
   "settings.general.theme.title": "Цветова тема",
+  "settings.general.updates.button.check": "Провери за актуализации сега",
   "settings.general.updates.label": "Изберете как да получавате нови версии:",
   "settings.general.updates.option.auto": "Изтегляй и инсталирай автоматично",
   "settings.general.updates.option.notify": "Питай ме преди да изтеглиш новата версия",

--- a/redisinsight/ui/src/i18n/locales/bg.json
+++ b/redisinsight/ui/src/i18n/locales/bg.json
@@ -1419,6 +1419,8 @@
   "notification.success.addedKey.title": "Ключът беше добавен",
   "notification.success.addedRdiInstance.message": "<bold>{{name}}</bold> беше добавена към RedisInsight.",
   "notification.success.addedRdiInstance.title": "Инстанцията беше добавена",
+  "notification.success.appUpToDate.message": "Вече използвате последната версия на Redis Insight.",
+  "notification.success.appUpToDate.title": "Всичко е точно!",
   "notification.success.azureAuthSuccess.message": "Влязохте като <bold>{{username}}</bold>",
   "notification.success.azureAuthSuccess.title": "Успешно удостоверяване в Azure",
   "notification.success.createIndex.message": "Отворете списъка с индекси, за да го видите.",

--- a/redisinsight/ui/src/i18n/locales/en.json
+++ b/redisinsight/ui/src/i18n/locales/en.json
@@ -1772,6 +1772,7 @@
   "settings.general.theme.option.light": "Light Theme",
   "settings.general.theme.option.system": "Match System",
   "settings.general.theme.title": "Color Theme",
+  "settings.general.updates.button.check": "Check for updates now",
   "settings.general.updates.label": "Specifies how Redis Insight handles new versions:",
   "settings.general.updates.option.auto": "Download and install automatically",
   "settings.general.updates.option.notify": "Ask me before downloading",

--- a/redisinsight/ui/src/i18n/locales/en.json
+++ b/redisinsight/ui/src/i18n/locales/en.json
@@ -1419,6 +1419,8 @@
   "notification.success.addedKey.title": "Key has been added",
   "notification.success.addedRdiInstance.message": "<bold>{{name}}</bold> has been added to RedisInsight.",
   "notification.success.addedRdiInstance.title": "Instance has been added",
+  "notification.success.appUpToDate.message": "Redis Insight is already running the latest version.",
+  "notification.success.appUpToDate.title": "You're up to date",
   "notification.success.azureAuthSuccess.message": "Signed in as <bold>{{username}}</bold>",
   "notification.success.azureAuthSuccess.title": "Azure authentication successful",
   "notification.success.createIndex.message": "Open the list of indexes to see it.",

--- a/redisinsight/ui/src/pages/settings/components/update-settings/UpdateSettings.spec.tsx
+++ b/redisinsight/ui/src/pages/settings/components/update-settings/UpdateSettings.spec.tsx
@@ -6,7 +6,7 @@ import {
   waitFor,
   waitForRedisUiSelectVisible,
 } from 'uiSrc/utils/test-utils'
-import { AppUpdateStrategy } from 'uiSrc/electron/constants'
+import { AppUpdateStatus, AppUpdateStrategy } from 'uiSrc/electron/constants'
 import { TelemetryEvent } from 'uiSrc/telemetry'
 
 import UpdateSettings from './UpdateSettings'
@@ -20,12 +20,14 @@ jest.mock('uiSrc/electron/utils', () => ({
   ...jest.requireActual('uiSrc/electron/utils'),
   ipcGetUpdateStrategy: jest.fn(),
   ipcSetUpdateStrategy: jest.fn(),
+  ipcCheckForUpdate: jest.fn(),
 }))
 
 const { sendEventTelemetry } = require('uiSrc/telemetry')
 const {
   ipcGetUpdateStrategy,
   ipcSetUpdateStrategy,
+  ipcCheckForUpdate,
 } = require('uiSrc/electron/utils')
 
 describe('UpdateSettings', () => {
@@ -70,6 +72,55 @@ describe('UpdateSettings', () => {
     expect(sendEventTelemetry).toHaveBeenCalledWith({
       event: TelemetryEvent.SETTINGS_UPDATE_STRATEGY_CHANGED,
       eventData: { strategy: AppUpdateStrategy.notify },
+    })
+  })
+
+  it('should not render the check-for-updates button when strategy is auto', async () => {
+    ipcGetUpdateStrategy.mockResolvedValueOnce(AppUpdateStrategy.auto)
+
+    render(<UpdateSettings />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('select-update-strategy')).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByTestId('btn-check-for-updates'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render the check-for-updates button when strategy is notify', async () => {
+    ipcGetUpdateStrategy.mockResolvedValueOnce(AppUpdateStrategy.notify)
+
+    render(<UpdateSettings />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('btn-check-for-updates')).toBeInTheDocument()
+    })
+  })
+
+  it('should trigger a manual check and disable the button while it is in flight', async () => {
+    ipcGetUpdateStrategy.mockResolvedValueOnce(AppUpdateStrategy.notify)
+    let resolveCheck: (value: { status: AppUpdateStatus }) => void
+    ipcCheckForUpdate.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveCheck = resolve
+      }),
+    )
+
+    render(<UpdateSettings />)
+
+    const button = await screen.findByTestId('btn-check-for-updates')
+    await userEvent.click(button)
+
+    expect(ipcCheckForUpdate).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(button).toBeDisabled()
+    })
+
+    resolveCheck!({ status: AppUpdateStatus.NotAvailable })
+
+    await waitFor(() => {
+      expect(button).not.toBeDisabled()
     })
   })
 })

--- a/redisinsight/ui/src/pages/settings/components/update-settings/UpdateSettings.tsx
+++ b/redisinsight/ui/src/pages/settings/components/update-settings/UpdateSettings.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useState } from 'react'
+import { Button, TextButton } from '@redis-ui/components'
+import { Row } from 'uiSrc/components/base/layout/flex'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
+import { RefreshIcon } from 'uiSrc/components/base/icons'
 import { AppUpdateStrategy } from 'uiSrc/electron/constants'
 import {
+  ipcCheckForUpdate,
   ipcGetUpdateStrategy,
   ipcSetUpdateStrategy,
 } from 'uiSrc/electron/utils'
@@ -18,6 +22,7 @@ import { useTranslation } from 'uiSrc/i18n'
 const UpdateSettings = () => {
   const { t } = useTranslation()
   const [strategy, setStrategy] = useState<AppUpdateStrategy | null>(null)
+  const [isChecking, setIsChecking] = useState(false)
 
   useEffect(() => {
     ipcGetUpdateStrategy().then(setStrategy)
@@ -43,6 +48,12 @@ const UpdateSettings = () => {
     })
   }
 
+  const onCheckForUpdates = async () => {
+    setIsChecking(true)
+    await ipcCheckForUpdate()
+    setIsChecking(false)
+  }
+
   if (!strategy) {
     return null
   }
@@ -51,16 +62,29 @@ const UpdateSettings = () => {
     <form>
       <Title size="XS">{t('settings.general.updates.title')}</Title>
       <Spacer size="m" />
-      <FormField label={t('settings.general.updates.label')}>
-        <Spacer size="m" />
-        <RiSelect
-          valueRender={defaultValueRender}
-          options={options}
-          value={strategy}
-          onChange={onChange}
-          data-testid="select-update-strategy"
-        />
-      </FormField>
+      <Row justify="between" align="center">
+        <FormField.Label label={t('settings.general.updates.label')} />
+        {strategy === AppUpdateStrategy.notify && (
+          <TextButton
+            variant="primary-inline"
+            size="small"
+            onClick={onCheckForUpdates}
+            disabled={isChecking}
+            data-testid="btn-check-for-updates"
+          >
+            <Button.Icon icon={RefreshIcon} />
+            {t('settings.general.updates.button.check')}
+          </TextButton>
+        )}
+      </Row>
+      <Spacer size="m" />
+      <RiSelect
+        valueRender={defaultValueRender}
+        options={options}
+        value={strategy}
+        onChange={onChange}
+        data-testid="select-update-strategy"
+      />
       <Spacer size="xl" />
     </form>
   )

--- a/redisinsight/ui/src/pages/settings/components/update-settings/UpdateSettings.tsx
+++ b/redisinsight/ui/src/pages/settings/components/update-settings/UpdateSettings.tsx
@@ -83,6 +83,7 @@ const UpdateSettings = () => {
         options={options}
         value={strategy}
         onChange={onChange}
+        aria-label={t('settings.general.updates.label')}
         data-testid="select-update-strategy"
       />
       <Spacer size="xl" />

--- a/redisinsight/ui/src/pages/settings/components/update-settings/UpdateSettings.tsx
+++ b/redisinsight/ui/src/pages/settings/components/update-settings/UpdateSettings.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import { Button, TextButton } from '@redis-ui/components'
 import { Row } from 'uiSrc/components/base/layout/flex'
 import { Spacer } from 'uiSrc/components/base/layout/spacer'
 import { RefreshIcon } from 'uiSrc/components/base/icons'
@@ -16,6 +15,7 @@ import {
   RiSelectOption,
 } from 'uiSrc/components/base/forms/select/RiSelect'
 import { FormField } from 'uiSrc/components/base/forms/FormField'
+import { RedisUIButton, TextButton } from 'uiSrc/components/base/forms/buttons'
 import { Title } from 'uiSrc/components/base/text'
 import { useTranslation } from 'uiSrc/i18n'
 
@@ -72,7 +72,7 @@ const UpdateSettings = () => {
             disabled={isChecking}
             data-testid="btn-check-for-updates"
           >
-            <Button.Icon icon={RefreshIcon} />
+            <RedisUIButton.Icon icon={RefreshIcon} />
             {t('settings.general.updates.button.check')}
           </TextButton>
         )}


### PR DESCRIPTION
# What

If you have Redis Insight set to "Ask me before downloading" updates, and you postpone or skip an update prompt, there was previously no way to bring it back until a newer version was released. This adds a way to check for updates on demand, in two places:

- **Tray icon / app menu** - right-click the tray icon (or open the app menu on macOS, Help menu on Windows/Linux) and choose "Check for Updates..." to check right away, from anywhere in the app.
- **Settings > Updates** - a "Check for updates" link next to the update-mode setting, for anyone who'd rather do it from the Settings page.

Either one re-checks immediately, including for a version you previously postponed or skipped. If a newer version is found, you'll see the usual update prompt with the option to install or skip it. If you're already on the latest version, you'll see a brief "you're up to date" confirmation instead.

This is only relevant to "Ask me before downloading" mode - in automatic update mode, Redis Insight already checks and installs updates on its own, so no manual action is needed there.

# Demo

https://github.com/user-attachments/assets/e005cdce-0d8a-4b1e-87a9-7740bc5c61d9

# Testing

How to try this locally:

1. Run the desktop app: `npm run dev:desktop`.
2. In `redisinsight/desktop/.env`, point `RI_MANUAL_UPGRADES_LINK` (and `RI_UPGRADES_LINK`) at a URL that serves a real update feed for your platform (e.g. an internal update server, or a temporary local static server serving a manifest such as `latest-mac.yml` that reports a version higher than the one you're running).
3. In Settings > General > Updates, switch the mode to "Ask me before downloading."
4. Trigger a check any of these ways:
   - Tray icon, right-click -> "Check for Updates..."
   - App menu (macOS) or Help menu (Windows/Linux) -> "Check for Updates..."
   - Settings > Updates -> "Check for updates" link
5. Confirm you see the update-found prompt if the feed reports a newer version, or the "up to date" confirmation if it doesn't.
6. To confirm a postponed update reappears: close the update-found prompt without choosing Update or Skip, then trigger the check again - the prompt should come back instead of staying hidden.
7. Switch the mode back to "Download and install automatically" and confirm both the tray/menu item and the Settings button disappear.

---

Refs RI-8394


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop auto-update and notification state handling; behavior is gated to notify mode but still affects when downloads prompt and how skipped versions are cleared.
> 
> **Overview**
> Adds **on-demand update checks** when Redis Insight uses **“Ask me before downloading”** (`notify`), so users can re-open a dismissed or skipped update prompt without waiting for a newer release.
> 
> **Main process:** `triggerManualUpdateCheck` runs the feed check over IPC (`app:update:check`), tracks `manual` / `NotAvailable` outcomes, clears skipped-version storage when a manual check finds an update, and skips the delayed unattended notification path during manual checks. **“Check for Updates…”** appears in the macOS app menu, Help menu (Windows/Linux), and tray context menu only when `shouldShowManualUpdateCheck()` is true; changing update strategy rebuilds those menus.
> 
> **Renderer:** Settings > Updates gets a **Check for updates now** control (notify only). `ConfigElectron` treats manual `Available` as bypassing session dismiss guards, shows an **up to date** toast on `NotAvailable`, and avoids tearing down an open found toast on manual errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80838f9694798dcabe18512b2841d75812cdbe7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->