### PR TITLE
Add dev-rdiUi feature flag

### DIFF
--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 11,
+  "version": 12,
   "features": {
     "dev-rdiUi": {
       "flag": true,

--- a/redisinsight/api/config/features-config.json
+++ b/redisinsight/api/config/features-config.json
@@ -1,6 +1,11 @@
 {
   "version": 11,
   "features": {
+    "dev-rdiUi": {
+      "flag": true,
+      "perc": [[0, 0]],
+      "filters": []
+    },
     "appUpdateStrategySettings": {
       "flag": true,
       "perc": [[0, 100]],

--- a/redisinsight/api/src/modules/feature/constants/index.ts
+++ b/redisinsight/api/src/modules/feature/constants/index.ts
@@ -37,6 +37,7 @@ export enum KnownFeatures {
   DevBrowser = 'dev-browser',
   Array = 'array',
   DevLanguage = 'dev-language',
+  DevRdiUi = 'dev-rdiUi',
   VectorSearchEnhancements = 'vectorSearchEnhancements',
   ValueDecoder = 'valueDecoder',
   AppUpdateStrategySettings = 'appUpdateStrategySettings',

--- a/redisinsight/api/src/modules/feature/constants/known-features.ts
+++ b/redisinsight/api/src/modules/feature/constants/known-features.ts
@@ -86,6 +86,10 @@ export const knownFeatures: Record<KnownFeatures, IFeatureFlag> = {
     name: KnownFeatures.DevLanguage,
     storage: FeatureStorage.Database,
   },
+  [KnownFeatures.DevRdiUi]: {
+    name: KnownFeatures.DevRdiUi,
+    storage: FeatureStorage.Database,
+  },
   [KnownFeatures.VectorSearchEnhancements]: {
     name: KnownFeatures.VectorSearchEnhancements,
     storage: FeatureStorage.Database,

--- a/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
+++ b/redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.ts
@@ -107,6 +107,13 @@ export class FeatureFlagProvider {
       ),
     );
     this.strategies.set(
+      KnownFeatures.DevRdiUi,
+      new SwitchableFlagStrategy(
+        this.featuresConfigService,
+        this.settingsService,
+      ),
+    );
+    this.strategies.set(
       KnownFeatures.ValueDecoder,
       new CommonFlagStrategy(this.featuresConfigService, this.settingsService),
     );

--- a/redisinsight/ui/src/constants/featureFlags.ts
+++ b/redisinsight/ui/src/constants/featureFlags.ts
@@ -15,6 +15,7 @@ export enum FeatureFlags {
   azureEntraId = 'azureEntraId',
   devBrowser = 'dev-browser',
   devLanguage = 'dev-language',
+  devRdiUi = 'dev-rdiUi',
   vectorSearchEnhancements = 'vectorSearchEnhancements',
   valueDecoder = 'valueDecoder',
   appUpdateStrategySettings = 'appUpdateStrategySettings',

--- a/redisinsight/ui/src/slices/app/features.ts
+++ b/redisinsight/ui/src/slices/app/features.ts
@@ -74,6 +74,9 @@ export const initialState: StateAppFeatures = {
       [FeatureFlags.devLanguage]: {
         flag: false,
       },
+      [FeatureFlags.devRdiUi]: {
+        flag: false,
+      },
       [FeatureFlags.vectorSearchEnhancements]: {
         flag: false,
       },
@@ -251,6 +254,15 @@ export const isDevLanguageEnabledSelector = (state: RootState): boolean => {
 
   const features = state.app.features.featureFlags.features
   return features[FeatureFlags.devLanguage]?.flag ?? false
+}
+
+export const isDevRdiUiEnabledSelector = (state: RootState): boolean => {
+  if (isDevelopment) {
+    return true
+  }
+
+  const features = state.app.features.featureFlags.features
+  return features[FeatureFlags.devRdiUi]?.flag ?? false
 }
 
 export const isVectorSearchEnhancementsEnabledSelector = (


### PR DESCRIPTION
# What

Adds a `dev-rdiUi` feature flag (off by default, `SwitchableFlagStrategy`) as the first step of the rdi-ui integration. This flag will gate the upcoming new rdi-ui-powered pipeline management flow, rendered for RDI instances above a supported version, while the current management flow stays default for everyone else.

No behavior changes yet — this PR only wires up the flag across backend and frontend:
- `features-config.json`: `dev-rdiUi` entry (`flag: true`, `perc: [[0, 0]]`, `filters: []`) — off for all real users, but locally overridable.
- Backend: `KnownFeatures` enum, `known-features.ts`, and `feature-flag.provider.ts` (registered with `SwitchableFlagStrategy`).
- Frontend: `FeatureFlags` enum, `features.ts` default state, and an `isDevRdiUiEnabledSelector` (auto-enabled when running `npm run dev:ui` locally, mirroring the `dev-language` pattern).

# Testing

- `npm run lint` and `npm run type-check` pass.
- Relevant Jest suites pass: `redisinsight/ui/src/slices/tests/app/features.spec.ts`, `redisinsight/api/src/modules/feature/providers/feature-flag/feature-flag.provider.spec.ts`, `redisinsight/api/src/modules/feature/local.feature.service.spec.ts`.
- Manually verified via `/api/features` that the flag defaults to `false` with no local override, and that adding `{"features": {"dev-rdiUi": true}}` to a local `config.json` override forces it on.

---

No ticket yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Plumbing-only feature flag registration with defaults off; no production behavior or security-sensitive logic changes.
> 
> **Overview**
> Introduces a **`dev-rdiUi`** feature flag as groundwork for a future rdi-ui pipeline management flow, with **no user-facing behavior yet**.
> 
> **Config:** bumps `features-config.json` to version **12** and adds `dev-rdiUi` with `perc: [[0, 0]]` so it stays off for production users but can be toggled locally (same pattern as `dev-language`).
> 
> **Backend:** registers `DevRdiUi` in `KnownFeatures`, `known-features.ts`, and **`SwitchableFlagStrategy`** in the feature-flag provider.
> 
> **Frontend:** adds `FeatureFlags.devRdiUi`, default **`flag: false`** in Redux, and **`isDevRdiUiEnabledSelector`** (auto-enabled in development UI builds, mirroring `isDevLanguageEnabledSelector`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d9094e0b9fb5bfdd465b384ad4e355d15eb9a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->