### PR TITLE
Add pipeline-management-v2 route and entry-point redirect

### DIFF
--- a/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/components/instances-list/InstancesList.spec.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/components/instances-list/InstancesList.spec.tsx
@@ -1,5 +1,6 @@
 import { cloneDeep } from 'lodash'
 import React from 'react'
+import reactRouterDom from 'react-router-dom'
 import { instance, mock } from 'ts-mockito'
 import { act } from 'react-dom/test-utils'
 import {
@@ -12,6 +13,7 @@ import {
 import { sendEventTelemetry, TelemetryEvent } from 'uiSrc/telemetry'
 import { Environment } from 'apiClient'
 import { Instance, RdiInstance } from 'uiSrc/slices/interfaces'
+import { Pages } from 'uiSrc/constants'
 import InstancesList, { InstancesListProps } from './InstancesList'
 import { InstancesTabs } from '../../InstancesNavigationPopover'
 
@@ -71,6 +73,9 @@ jest.mock('uiSrc/slices/rdi/instances', () => ({
       name: 'RdiDB_1',
     },
   }),
+  checkConnectToRdiInstanceAction:
+    (id: string, onSuccessAction?: (id: string) => void) => () =>
+      onSuccessAction?.(id),
 }))
 
 jest.mock('uiSrc/slices/instances/instances', () => ({
@@ -138,5 +143,25 @@ describe('InstancesList', () => {
       event: TelemetryEvent.CONFIG_DATABASES_OPEN_DATABASE,
       eventData: expect.any(Object),
     })
+  })
+
+  it('should navigate to the bare rdi instance url on switching rdi instances, not straight to the legacy config page', async () => {
+    const pushMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: pushMock,
+    })
+
+    const { getByTestId } = render(
+      <InstancesList
+        {...instance(mockedProps)}
+        selectedTab={InstancesTabs.RDI}
+        filteredRdiInstances={mockRdis}
+      />,
+    )
+
+    const listItem = getByTestId(`instance-item-${mockRdis[1].id}`)
+    await act(() => fireEvent.click(listItem))
+
+    expect(pushMock).toHaveBeenCalledWith(Pages.rdiPipeline(mockRdis[1].id))
   })
 })

--- a/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/components/instances-list/InstancesList.tsx
+++ b/redisinsight/ui/src/components/instance-header/components/instances-navigation-popover/components/instances-list/InstancesList.tsx
@@ -99,7 +99,10 @@ const InstancesList = ({
         (id: string) => {
           setLoading(false)
           onItemClick?.()
-          history.push(Pages.rdiPipelineConfig(id))
+          // the bare instance URL is where the v1/v2 pipeline management
+          // decision is made - jumping straight to the legacy config page
+          // would skip it
+          history.push(Pages.rdiPipeline(id))
         },
         () => setLoading(false),
       ),

--- a/redisinsight/ui/src/components/main-router/constants/defaultRoutes.ts
+++ b/redisinsight/ui/src/components/main-router/constants/defaultRoutes.ts
@@ -22,6 +22,7 @@ import RdiPage from 'uiSrc/pages/rdi/home'
 import RdiInstancePage from 'uiSrc/pages/rdi/instance'
 import RdiStatisticsPage from 'uiSrc/pages/rdi/statistics'
 import PipelineManagementPage from 'uiSrc/pages/rdi/pipeline-management'
+import PipelineManagementV2Page from 'uiSrc/pages/rdi/pipeline-management-v2'
 import { ANALYTICS_ROUTES, RDI_PIPELINE_MANAGEMENT_ROUTES } from './sub-routes'
 import COMMON_ROUTES from './commonRoutes'
 import { getRouteIncludedByEnv, LAZY_LOAD } from '../config'
@@ -67,6 +68,9 @@ const LazyRdiStatisticsPage = lazy(() => import('uiSrc/pages/rdi/statistics'))
 const LazyPipelineManagementPage = lazy(
   () => import('uiSrc/pages/rdi/pipeline-management'),
 )
+const LazyPipelineManagementV2Page = lazy(
+  () => import('uiSrc/pages/rdi/pipeline-management-v2'),
+)
 
 const INSTANCE_ROUTES: IRoute[] = [
   {
@@ -109,6 +113,12 @@ const RDI_INSTANCE_ROUTES: IRoute[] = getRouteIncludedByEnv([
     path: Pages.rdiPipelineManagement(':rdiInstanceId'),
     component: LAZY_LOAD ? LazyPipelineManagementPage : PipelineManagementPage,
     routes: RDI_PIPELINE_MANAGEMENT_ROUTES,
+  },
+  {
+    path: Pages.rdiPipelineManagementV2(':rdiInstanceId'),
+    component: LAZY_LOAD
+      ? LazyPipelineManagementV2Page
+      : PipelineManagementV2Page,
   },
 ])
 

--- a/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
+++ b/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
@@ -8,10 +8,12 @@ import { Props as HighlightedFeatureProps } from 'uiSrc/components/hightlighted-
 import { ANALYTICS_ROUTES } from 'uiSrc/components/main-router/constants/sub-routes'
 import {
   appFeaturePagesHighlightingSelector,
+  isDevRdiUiEnabledSelector,
   removeFeatureFromHighlighting,
 } from 'uiSrc/slices/app/features'
 import { connectedInstanceSelector } from 'uiSrc/slices/instances/instances'
 import { connectedInstanceSelector as connectedRdiInstanceSelector } from 'uiSrc/slices/rdi/instances'
+import { shouldUseRdiUiPipeline } from 'uiSrc/utils/rdi'
 
 import { ONBOARDING_FEATURES } from 'uiSrc/components/onboarding-features'
 import { BUILD_FEATURES } from 'uiSrc/constants/featuresHighlighting'
@@ -45,9 +47,9 @@ export function useNavigation() {
   const { id: connectedInstanceId = '' } = useAppSelector(
     connectedInstanceSelector,
   )
-  const { id: connectedRdiInstanceId = '' } = useAppSelector(
-    connectedRdiInstanceSelector,
-  )
+  const { id: connectedRdiInstanceId = '', version: connectedRdiVersion = '' } =
+    useAppSelector(connectedRdiInstanceSelector)
+  const isDevRdiUiEnabled = useAppSelector(isDevRdiUiEnabledSelector)
   const highlightedPages = useAppSelector(appFeaturePagesHighlightingSelector)
 
   const isRdiWorkspace = workspace === AppWorkspace.RDI
@@ -144,13 +146,19 @@ export function useNavigation() {
     },
   ].filter((tab) => !!tab) as INavigations[]
 
+  const pipelineManagementPage = shouldUseRdiUiPipeline(
+    connectedRdiVersion,
+    isDevRdiUiEnabled,
+  )
+    ? Pages.rdiPipelineManagementV2(connectedRdiInstanceId)
+    : Pages.rdiPipelineManagement(connectedRdiInstanceId)
+
   const privateRdiRoutes: INavigations[] = [
     {
       tooltipText: t('navigation.page.pipeline.tooltip'),
       pageName: PageNames.rdiPipelineManagement,
       ariaLabel: t('navigation.page.pipeline.ariaLabel'),
-      onClick: () =>
-        handleGoPage(Pages.rdiPipelineManagement(connectedRdiInstanceId)),
+      onClick: () => handleGoPage(pipelineManagementPage),
       dataTestId: 'pipeline-management-page-btn',
       isActivePage: isPipelineManagementPath(),
       iconType: PipelineManagementIcon,

--- a/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
+++ b/redisinsight/ui/src/components/navigation-menu/hooks/useNavigation.ts
@@ -158,7 +158,8 @@ export function useNavigation() {
       tooltipText: t('navigation.page.pipeline.tooltip'),
       pageName: PageNames.rdiPipelineManagement,
       ariaLabel: t('navigation.page.pipeline.ariaLabel'),
-      onClick: () => handleGoPage(pipelineManagementPage),
+      onClick: () =>
+        connectedRdiInstanceId && handleGoPage(pipelineManagementPage),
       dataTestId: 'pipeline-management-page-btn',
       isActivePage: isPipelineManagementPath(),
       iconType: PipelineManagementIcon,

--- a/redisinsight/ui/src/config/default.ts
+++ b/redisinsight/ui/src/config/default.ts
@@ -109,6 +109,10 @@ export const defaultConfig = {
     cloudAds: {
       defaultFlag: booleanEnv('RI_FEATURES_CLOUD_ADS_DEFAULT_FLAG', true),
     },
+    rdiUi: {
+      minSupportedVersion:
+        process.env.RI_FEATURES_RDI_UI_MIN_SUPPORTED_VERSION ?? '1.16.0',
+    },
   },
   sentry: {
     dsn: process.env.RI_SENTRY_DSN ?? '',

--- a/redisinsight/ui/src/constants/pages.ts
+++ b/redisinsight/ui/src/constants/pages.ts
@@ -28,6 +28,7 @@ export enum PageNames {
   settings = 'settings',
   // rdi pages
   rdiPipelineManagement = 'pipeline-management',
+  rdiPipelineManagementV2 = 'pipeline-management-v2',
   rdiPipelineConfig = 'config',
   rdiPipelineJobs = 'jobs',
   rdiStatistics = 'statistics',
@@ -84,6 +85,8 @@ export const Pages = {
   rdiPipeline: (rdiInstance: string) => `${rdi}/${rdiInstance}`,
   rdiPipelineManagement: (rdiInstance: string) =>
     `${rdi}/${rdiInstance}/${PageNames.rdiPipelineManagement}`,
+  rdiPipelineManagementV2: (rdiInstance: string) =>
+    `${rdi}/${rdiInstance}/${PageNames.rdiPipelineManagementV2}`,
   rdiPipelineConfig: (rdiInstance: string) =>
     `${rdi}/${rdiInstance}/${PageNames.rdiPipelineManagement}/${PageNames.rdiPipelineConfig}`,
   rdiPipelineJobs: (rdiInstance: string, jobName: string) =>

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
@@ -195,9 +195,16 @@ describe('InstancePage', () => {
     reactRouterDom.useLocation = jest
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
-    // the v1/v2 decision only fires once the connected instance has loaded
+    // the v1/v2 decision only fires once the store has processed this
+    // instance's own reset+fetch cycle (contextRdiInstanceId) and it has
+    // finished loading
+    ;(appContextSelector as jest.Mock).mockReturnValue({
+      contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
+    })
     store.getState().rdi.instances.connectedInstance.id = RDI_INSTANCE_ID_MOCK
     store.getState().rdi.instances.connectedInstance.version = ''
+    store.getState().rdi.instances.connectedInstance.loading = false
+    store.getState().rdi.instances.connectedInstance.error = ''
 
     await act(() =>
       render(
@@ -222,8 +229,46 @@ describe('InstancePage', () => {
     reactRouterDom.useLocation = jest
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
+    ;(appContextSelector as jest.Mock).mockReturnValue({
+      contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
+    })
     store.getState().rdi.instances.connectedInstance.id = RDI_INSTANCE_ID_MOCK
     store.getState().rdi.instances.connectedInstance.version = '1.17.0'
+    store.getState().rdi.instances.connectedInstance.loading = false
+    store.getState().rdi.instances.connectedInstance.error = ''
+    store.getState().app.features.featureFlags.features[FeatureFlags.devRdiUi] =
+      { flag: true }
+
+    await act(() =>
+      render(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+      ),
+    )
+
+    expect(pushMock).toHaveBeenCalledWith(
+      Pages.rdiPipelineManagementV2(RDI_INSTANCE_ID_MOCK),
+    )
+  })
+
+  it('should redirect to rdi pipeline management page even at exactly the minimum supported version', async () => {
+    const pushMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: pushMock,
+      block: jest.fn(() => jest.fn()),
+    })
+
+    reactRouterDom.useLocation = jest
+      .fn()
+      .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
+    ;(appContextSelector as jest.Mock).mockReturnValue({
+      contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
+    })
+    store.getState().rdi.instances.connectedInstance.id = RDI_INSTANCE_ID_MOCK
+    store.getState().rdi.instances.connectedInstance.version = '1.16.0'
+    store.getState().rdi.instances.connectedInstance.loading = false
+    store.getState().rdi.instances.connectedInstance.error = ''
     store.getState().app.features.featureFlags.features[FeatureFlags.devRdiUi] =
       { flag: true }
 
@@ -250,8 +295,48 @@ describe('InstancePage', () => {
     reactRouterDom.useLocation = jest
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
+    ;(appContextSelector as jest.Mock).mockReturnValue({
+      contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
+    })
     store.getState().rdi.instances.connectedInstance.id = ''
+    store.getState().rdi.instances.connectedInstance.loading = true
     store.getState().rdi.instances.connectedInstance.error = ''
+
+    await act(() =>
+      render(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+      ),
+    )
+
+    expect(pushMock).not.toHaveBeenCalledWith(
+      Pages.rdiPipelineManagement(RDI_INSTANCE_ID_MOCK),
+    )
+    expect(pushMock).not.toHaveBeenCalledWith(
+      Pages.rdiPipelineManagementV2(RDI_INSTANCE_ID_MOCK),
+    )
+  })
+
+  it('should ignore a stale error left over from a previously viewed instance', async () => {
+    const pushMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: pushMock,
+      block: jest.fn(() => jest.fn()),
+    })
+
+    reactRouterDom.useLocation = jest
+      .fn()
+      .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
+    // contextRdiInstanceId hasn't caught up to this instance yet, even
+    // though a stale error from a different instance is still in the store
+    ;(appContextSelector as jest.Mock).mockReturnValue({
+      contextRdiInstanceId: 'previousInstanceId',
+    })
+    store.getState().rdi.instances.connectedInstance.id = ''
+    store.getState().rdi.instances.connectedInstance.loading = false
+    store.getState().rdi.instances.connectedInstance.error =
+      'stale error from a previous instance'
 
     await act(() =>
       render(
@@ -279,7 +364,11 @@ describe('InstancePage', () => {
     reactRouterDom.useLocation = jest
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
+    ;(appContextSelector as jest.Mock).mockReturnValue({
+      contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
+    })
     store.getState().rdi.instances.connectedInstance.id = ''
+    store.getState().rdi.instances.connectedInstance.loading = false
     store.getState().rdi.instances.connectedInstance.error = 'Some error'
 
     await act(() =>
@@ -378,6 +467,35 @@ describe('InstancePage', () => {
 
     expect(pushMock).not.toHaveBeenCalledWith(
       Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK),
+    )
+  })
+
+  it('should navigate to the v2 pipeline management page when clicking the Pipeline tab and the instance is eligible', async () => {
+    const pushMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: pushMock,
+      block: jest.fn(() => jest.fn()),
+    })
+
+    reactRouterDom.useLocation = jest.fn().mockReturnValue({
+      pathname: Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK),
+    })
+    store.getState().rdi.instances.connectedInstance.id = RDI_INSTANCE_ID_MOCK
+    store.getState().rdi.instances.connectedInstance.version = '1.17.0'
+    store.getState().app.features.featureFlags.features[FeatureFlags.devRdiUi] =
+      { flag: true }
+
+    const { getByRole } = render(
+      <BrowserRouter>
+        <InstancePage {...instance(mockedProps)} />
+      </BrowserRouter>,
+    )
+    const pipelineTab = getByRole('tab', { name: 'Pipeline' })
+
+    await userEvent.click(pipelineTab)
+
+    expect(pushMock).toHaveBeenCalledWith(
+      Pages.rdiPipelineManagementV2(RDI_INSTANCE_ID_MOCK),
     )
   })
 })

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
@@ -41,7 +41,7 @@ import {
   loadInstances as loadRdiInstances,
   setConnectedInstance,
 } from 'uiSrc/slices/rdi/instances'
-import { PageNames, Pages } from 'uiSrc/constants'
+import { FeatureFlags, PageNames, Pages } from 'uiSrc/constants'
 import {
   getPipelineStatus,
   setConfigValidationErrors,
@@ -195,6 +195,92 @@ describe('InstancePage', () => {
     reactRouterDom.useLocation = jest
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
+    // the v1/v2 decision only fires once the connected instance has loaded
+    store.getState().rdi.instances.connectedInstance.id = RDI_INSTANCE_ID_MOCK
+    store.getState().rdi.instances.connectedInstance.version = ''
+
+    await act(() =>
+      render(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+      ),
+    )
+
+    expect(pushMock).toHaveBeenCalledWith(
+      Pages.rdiPipelineManagement(RDI_INSTANCE_ID_MOCK),
+    )
+  })
+
+  it('should redirect to rdi pipeline management v2 page when the flag is enabled and the version is high enough', async () => {
+    const pushMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: pushMock,
+      block: jest.fn(() => jest.fn()),
+    })
+
+    reactRouterDom.useLocation = jest
+      .fn()
+      .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
+    store.getState().rdi.instances.connectedInstance.id = RDI_INSTANCE_ID_MOCK
+    store.getState().rdi.instances.connectedInstance.version = '1.17.0'
+    store.getState().app.features.featureFlags.features[FeatureFlags.devRdiUi] =
+      { flag: true }
+
+    await act(() =>
+      render(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+      ),
+    )
+
+    expect(pushMock).toHaveBeenCalledWith(
+      Pages.rdiPipelineManagementV2(RDI_INSTANCE_ID_MOCK),
+    )
+  })
+
+  it('should not redirect to rdi pipeline management page until the connected instance has loaded', async () => {
+    const pushMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: pushMock,
+      block: jest.fn(() => jest.fn()),
+    })
+
+    reactRouterDom.useLocation = jest
+      .fn()
+      .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
+    store.getState().rdi.instances.connectedInstance.id = ''
+    store.getState().rdi.instances.connectedInstance.error = ''
+
+    await act(() =>
+      render(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+      ),
+    )
+
+    expect(pushMock).not.toHaveBeenCalledWith(
+      Pages.rdiPipelineManagement(RDI_INSTANCE_ID_MOCK),
+    )
+    expect(pushMock).not.toHaveBeenCalledWith(
+      Pages.rdiPipelineManagementV2(RDI_INSTANCE_ID_MOCK),
+    )
+  })
+
+  it('should default to rdi pipeline management page when the connected instance fails to load', async () => {
+    const pushMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: pushMock,
+      block: jest.fn(() => jest.fn()),
+    })
+
+    reactRouterDom.useLocation = jest
+      .fn()
+      .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
+    store.getState().rdi.instances.connectedInstance.id = ''
+    store.getState().rdi.instances.connectedInstance.error = 'Some error'
 
     await act(() =>
       render(

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
@@ -461,6 +461,92 @@ describe('InstancePage', () => {
     )
   })
 
+  it('should redirect to rdi pipeline management (not restore statistics) when the navigation explicitly opts out via skipLastPageRestore', async () => {
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
+      contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
+      lastPage: PageNames.rdiStatistics,
+    })
+
+    const replaceMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: jest.fn(),
+      replace: replaceMock,
+      block: jest.fn(() => jest.fn()),
+    })
+
+    reactRouterDom.useLocation = jest.fn().mockReturnValue({
+      pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK),
+      state: { skipLastPageRestore: true },
+    })
+    store.getState().rdi.instances.connectedInstance.id = RDI_INSTANCE_ID_MOCK
+    store.getState().rdi.instances.connectedInstance.version = ''
+    store.getState().rdi.instances.connectedInstance.loading = false
+    store.getState().rdi.instances.connectedInstance.error = ''
+
+    await act(() =>
+      render(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+      ),
+    )
+
+    expect(replaceMock).toHaveBeenCalledWith(
+      Pages.rdiPipelineManagement(RDI_INSTANCE_ID_MOCK),
+    )
+    expect(replaceMock).not.toHaveBeenCalledWith(
+      Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK),
+    )
+  })
+
+  it('should redirect to rdi pipeline management when navigating to the bare url from within the same already-loaded instance (e.g. the statistics empty-state CTA)', async () => {
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
+      contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
+      lastPage: PageNames.rdiStatistics,
+    })
+
+    const replaceMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: jest.fn(),
+      replace: replaceMock,
+      block: jest.fn(() => jest.fn()),
+    })
+
+    store.getState().rdi.instances.connectedInstance.id = RDI_INSTANCE_ID_MOCK
+    store.getState().rdi.instances.connectedInstance.version = ''
+    store.getState().rdi.instances.connectedInstance.loading = false
+    store.getState().rdi.instances.connectedInstance.error = ''
+
+    reactRouterDom.useLocation = jest.fn().mockReturnValue({
+      pathname: Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK),
+    })
+
+    const { rerender } = render(
+      <BrowserRouter>
+        <InstancePage {...instance(mockedProps)} />
+      </BrowserRouter>,
+    )
+
+    reactRouterDom.useLocation = jest.fn().mockReturnValue({
+      pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK),
+      state: { skipLastPageRestore: true },
+    })
+
+    await act(() =>
+      rerender(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+      ),
+    )
+
+    expect(replaceMock).toHaveBeenCalledWith(
+      Pages.rdiPipelineManagement(RDI_INSTANCE_ID_MOCK),
+    )
+  })
+
   it('should navigate to rdi pipeline analytics page via clicking on navigation', async () => {
     const pushMock = jest.fn()
     reactRouterDom.useHistory = jest.fn().mockReturnValue({

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
@@ -19,6 +19,7 @@ import {
   resetPipelineManagement,
   setAppContextConnectedRdiInstanceId,
   setAppContextInitialState,
+  setLastPageContext,
 } from 'uiSrc/slices/app/context'
 import {
   resetCliHelperSettings,
@@ -136,6 +137,7 @@ describe('InstancePage', () => {
       setPipelineConfig(''),
       setPipelineJobs([]),
       resetPipelineManagement(),
+      setLastPageContext(''),
       setConnectedInstance(),
       setAppContextConnectedRdiInstanceId('rdiInstanceId'),
       resetConnectedDatabaseInstance(),
@@ -177,6 +179,7 @@ describe('InstancePage', () => {
       setPipelineConfig(''),
       setPipelineJobs([]),
       resetPipelineManagement(),
+      setLastPageContext(''),
       setConnectedInstance(),
     ]
 
@@ -468,6 +471,60 @@ describe('InstancePage', () => {
     expect(pushMock).not.toHaveBeenCalledWith(
       Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK),
     )
+  })
+
+  it('should not restore a lastPage left over from a previously viewed instance', async () => {
+    ;(appContextSelector as jest.Mock).mockReturnValue({
+      contextRdiInstanceId: 'previousInstanceId',
+      lastPage: PageNames.rdiStatistics,
+    })
+
+    const pushMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: pushMock,
+      block: jest.fn(() => jest.fn()),
+    })
+
+    reactRouterDom.useLocation = jest
+      .fn()
+      .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
+
+    await act(() =>
+      render(
+        <BrowserRouter>
+          <InstancePage {...instance(mockedProps)} />
+        </BrowserRouter>,
+      ),
+    )
+
+    expect(store.getActions()).toContainEqual(setLastPageContext(''))
+    expect(pushMock).not.toHaveBeenCalledWith(
+      Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK),
+    )
+  })
+
+  it('should not navigate when clicking the Pipeline tab while the connected instance id is not yet available', async () => {
+    const pushMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: pushMock,
+      block: jest.fn(() => jest.fn()),
+    })
+
+    reactRouterDom.useLocation = jest.fn().mockReturnValue({
+      pathname: Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK),
+    })
+    store.getState().rdi.instances.connectedInstance.id = ''
+
+    const { getByRole } = render(
+      <BrowserRouter>
+        <InstancePage {...instance(mockedProps)} />
+      </BrowserRouter>,
+    )
+    const pipelineTab = getByRole('tab', { name: 'Pipeline' })
+
+    await userEvent.click(pipelineTab)
+
+    expect(pushMock).not.toHaveBeenCalled()
   })
 
   it('should navigate to the v2 pipeline management page when clicking the Pipeline tab and the instance is eligible', async () => {

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
@@ -74,6 +74,7 @@ beforeEach(() => {
 
   reactRouterDom.useHistory = jest.fn().mockReturnValue({
     push: jest.fn(),
+    replace: jest.fn(),
     block: jest.fn(() => jest.fn()),
   })
 })
@@ -191,9 +192,10 @@ describe('InstancePage', () => {
   })
 
   it('should redirect to rdi pipeline management page', async () => {
-    const pushMock = jest.fn()
+    const replaceMock = jest.fn()
     reactRouterDom.useHistory = jest.fn().mockReturnValue({
-      push: pushMock,
+      push: jest.fn(),
+      replace: replaceMock,
       block: jest.fn(() => jest.fn()),
     })
 
@@ -220,15 +222,16 @@ describe('InstancePage', () => {
       ),
     )
 
-    expect(pushMock).toHaveBeenCalledWith(
+    expect(replaceMock).toHaveBeenCalledWith(
       Pages.rdiPipelineManagement(RDI_INSTANCE_ID_MOCK),
     )
   })
 
   it('should redirect to rdi pipeline management v2 page when the flag is enabled and the version is high enough', async () => {
-    const pushMock = jest.fn()
+    const replaceMock = jest.fn()
     reactRouterDom.useHistory = jest.fn().mockReturnValue({
-      push: pushMock,
+      push: jest.fn(),
+      replace: replaceMock,
       block: jest.fn(() => jest.fn()),
     })
 
@@ -254,15 +257,16 @@ describe('InstancePage', () => {
       ),
     )
 
-    expect(pushMock).toHaveBeenCalledWith(
+    expect(replaceMock).toHaveBeenCalledWith(
       Pages.rdiPipelineManagementV2(RDI_INSTANCE_ID_MOCK),
     )
   })
 
   it('should redirect to rdi pipeline management page even at exactly the minimum supported version', async () => {
-    const pushMock = jest.fn()
+    const replaceMock = jest.fn()
     reactRouterDom.useHistory = jest.fn().mockReturnValue({
-      push: pushMock,
+      push: jest.fn(),
+      replace: replaceMock,
       block: jest.fn(() => jest.fn()),
     })
 
@@ -288,15 +292,16 @@ describe('InstancePage', () => {
       ),
     )
 
-    expect(pushMock).toHaveBeenCalledWith(
+    expect(replaceMock).toHaveBeenCalledWith(
       Pages.rdiPipelineManagementV2(RDI_INSTANCE_ID_MOCK),
     )
   })
 
   it('should not redirect to rdi pipeline management page until the connected instance has loaded', async () => {
-    const pushMock = jest.fn()
+    const replaceMock = jest.fn()
     reactRouterDom.useHistory = jest.fn().mockReturnValue({
-      push: pushMock,
+      push: jest.fn(),
+      replace: replaceMock,
       block: jest.fn(() => jest.fn()),
     })
 
@@ -319,18 +324,19 @@ describe('InstancePage', () => {
       ),
     )
 
-    expect(pushMock).not.toHaveBeenCalledWith(
+    expect(replaceMock).not.toHaveBeenCalledWith(
       Pages.rdiPipelineManagement(RDI_INSTANCE_ID_MOCK),
     )
-    expect(pushMock).not.toHaveBeenCalledWith(
+    expect(replaceMock).not.toHaveBeenCalledWith(
       Pages.rdiPipelineManagementV2(RDI_INSTANCE_ID_MOCK),
     )
   })
 
   it('should ignore a stale error left over from a previously viewed instance', async () => {
-    const pushMock = jest.fn()
+    const replaceMock = jest.fn()
     reactRouterDom.useHistory = jest.fn().mockReturnValue({
-      push: pushMock,
+      push: jest.fn(),
+      replace: replaceMock,
       block: jest.fn(() => jest.fn()),
     })
 
@@ -356,18 +362,19 @@ describe('InstancePage', () => {
       ),
     )
 
-    expect(pushMock).not.toHaveBeenCalledWith(
+    expect(replaceMock).not.toHaveBeenCalledWith(
       Pages.rdiPipelineManagement(RDI_INSTANCE_ID_MOCK),
     )
-    expect(pushMock).not.toHaveBeenCalledWith(
+    expect(replaceMock).not.toHaveBeenCalledWith(
       Pages.rdiPipelineManagementV2(RDI_INSTANCE_ID_MOCK),
     )
   })
 
   it('should default to rdi pipeline management page when the connected instance fails to load', async () => {
-    const pushMock = jest.fn()
+    const replaceMock = jest.fn()
     reactRouterDom.useHistory = jest.fn().mockReturnValue({
-      push: pushMock,
+      push: jest.fn(),
+      replace: replaceMock,
       block: jest.fn(() => jest.fn()),
     })
 
@@ -390,7 +397,7 @@ describe('InstancePage', () => {
       ),
     )
 
-    expect(pushMock).toHaveBeenCalledWith(
+    expect(replaceMock).toHaveBeenCalledWith(
       Pages.rdiPipelineManagement(RDI_INSTANCE_ID_MOCK),
     )
   })
@@ -431,9 +438,10 @@ describe('InstancePage', () => {
       lastPage: PageNames.rdiStatistics,
     })
 
-    const pushMock = jest.fn()
+    const replaceMock = jest.fn()
     reactRouterDom.useHistory = jest.fn().mockReturnValue({
-      push: pushMock,
+      push: jest.fn(),
+      replace: replaceMock,
       block: jest.fn(() => jest.fn()),
     })
 
@@ -448,7 +456,7 @@ describe('InstancePage', () => {
       ),
     )
 
-    expect(pushMock).toHaveBeenCalledWith(
+    expect(replaceMock).toHaveBeenCalledWith(
       Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK),
     )
   })
@@ -489,9 +497,10 @@ describe('InstancePage', () => {
       lastPage: PageNames.rdiStatistics,
     })
 
-    const pushMock = jest.fn()
+    const replaceMock = jest.fn()
     reactRouterDom.useHistory = jest.fn().mockReturnValue({
-      push: pushMock,
+      push: jest.fn(),
+      replace: replaceMock,
       block: jest.fn(() => jest.fn()),
     })
 
@@ -508,7 +517,7 @@ describe('InstancePage', () => {
     )
 
     expect(store.getActions()).toContainEqual(setLastPageContext(''))
-    expect(pushMock).not.toHaveBeenCalledWith(
+    expect(replaceMock).not.toHaveBeenCalledWith(
       Pages.rdiStatistics(RDI_INSTANCE_ID_MOCK),
     )
   })

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.spec.tsx
@@ -95,7 +95,8 @@ describe('InstancePage', () => {
   })
 
   it('should call proper actions with resetting context', async () => {
-    ;(appContextSelector as jest.Mock).mockReturnValue({
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
       contextRdiInstanceId: '',
     })
 
@@ -154,7 +155,8 @@ describe('InstancePage', () => {
   })
 
   it('should fetch rdi instance info', async () => {
-    ;(appContextSelector as jest.Mock).mockReturnValue({
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
       contextRdiInstanceId: 'prevId',
     })
 
@@ -201,7 +203,8 @@ describe('InstancePage', () => {
     // the v1/v2 decision only fires once the store has processed this
     // instance's own reset+fetch cycle (contextRdiInstanceId) and it has
     // finished loading
-    ;(appContextSelector as jest.Mock).mockReturnValue({
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
       contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
     })
     store.getState().rdi.instances.connectedInstance.id = RDI_INSTANCE_ID_MOCK
@@ -232,7 +235,8 @@ describe('InstancePage', () => {
     reactRouterDom.useLocation = jest
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
-    ;(appContextSelector as jest.Mock).mockReturnValue({
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
       contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
     })
     store.getState().rdi.instances.connectedInstance.id = RDI_INSTANCE_ID_MOCK
@@ -265,7 +269,8 @@ describe('InstancePage', () => {
     reactRouterDom.useLocation = jest
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
-    ;(appContextSelector as jest.Mock).mockReturnValue({
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
       contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
     })
     store.getState().rdi.instances.connectedInstance.id = RDI_INSTANCE_ID_MOCK
@@ -298,7 +303,8 @@ describe('InstancePage', () => {
     reactRouterDom.useLocation = jest
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
-    ;(appContextSelector as jest.Mock).mockReturnValue({
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
       contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
     })
     store.getState().rdi.instances.connectedInstance.id = ''
@@ -333,7 +339,8 @@ describe('InstancePage', () => {
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
     // contextRdiInstanceId hasn't caught up to this instance yet, even
     // though a stale error from a different instance is still in the store
-    ;(appContextSelector as jest.Mock).mockReturnValue({
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
       contextRdiInstanceId: 'previousInstanceId',
     })
     store.getState().rdi.instances.connectedInstance.id = ''
@@ -367,7 +374,8 @@ describe('InstancePage', () => {
     reactRouterDom.useLocation = jest
       .fn()
       .mockReturnValue({ pathname: Pages.rdiPipeline(RDI_INSTANCE_ID_MOCK) })
-    ;(appContextSelector as jest.Mock).mockReturnValue({
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
       contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
     })
     store.getState().rdi.instances.connectedInstance.id = ''
@@ -417,7 +425,8 @@ describe('InstancePage', () => {
   })
 
   it('should redirect to rdi pipeline statistics page', async () => {
-    ;(appContextSelector as jest.Mock).mockReturnValue({
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
       contextRdiInstanceId: RDI_INSTANCE_ID_MOCK,
       lastPage: PageNames.rdiStatistics,
     })
@@ -474,7 +483,8 @@ describe('InstancePage', () => {
   })
 
   it('should not restore a lastPage left over from a previously viewed instance', async () => {
-    ;(appContextSelector as jest.Mock).mockReturnValue({
+    const mockedAppContextSelector = appContextSelector as jest.Mock
+    mockedAppContextSelector.mockReturnValue({
       contextRdiInstanceId: 'previousInstanceId',
       lastPage: PageNames.rdiStatistics,
     })

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
@@ -20,8 +20,8 @@ import {
   resetConnectedInstance as resetConnectedDatabaseInstance,
 } from 'uiSrc/slices/instances/instances'
 import { isDevRdiUiEnabledSelector } from 'uiSrc/slices/app/features'
-import { getConfig } from 'uiSrc/config'
-import { isVersionHigher, Nullable } from 'uiSrc/utils'
+import { Nullable } from 'uiSrc/utils'
+import { shouldUseRdiUiPipeline } from 'uiSrc/utils/rdi'
 
 import { RdiInstancePageTemplate } from 'uiSrc/templates'
 import { AppNavigation, RdiInstanceHeader } from 'uiSrc/components'
@@ -30,8 +30,6 @@ import { useNavigation } from 'uiSrc/components/navigation-menu/hooks/useNavigat
 import InstancePageRouter from './InstancePageRouter'
 import { RdiPipelineHeader } from './components'
 import styles from './styles.module.scss'
-
-const riConfig = getConfig()
 
 export interface Props {
   routes: IRoute[]
@@ -85,19 +83,31 @@ const RdiInstancePage = ({ routes = [] }: Props) => {
       }
 
       // The connected instance (incl. version) loads asynchronously above.
-      // `id` only matches `rdiInstanceId` once that fetch actually succeeds,
-      // so wait for it rather than deciding v1 vs v2 off stale/empty data.
-      const isConnectedInstanceReady = connectedInstance.id === rdiInstanceId
-      if (!isConnectedInstanceReady && !connectedInstance.error) {
+      // `id` only matches `rdiInstanceId` once that fetch actually succeeds.
+      // `contextRdiInstanceId === rdiInstanceId` confirms the store has
+      // already processed *this* instance's reset+fetch cycle (it's set in
+      // the same effect, synchronously) - without it, a stale `error` left
+      // over from a previously viewed instance would look like "this
+      // instance failed to load" on the very first render and push to
+      // legacy before the real fetch ever gets a chance to resolve.
+      const isSameInstanceContext = contextRdiInstanceId === rdiInstanceId
+      const isConnectedInstanceReady =
+        isSameInstanceContext && connectedInstance.id === rdiInstanceId
+      const hasFailedToLoad =
+        isSameInstanceContext &&
+        !connectedInstance.loading &&
+        !!connectedInstance.error &&
+        !isConnectedInstanceReady
+
+      if (!isConnectedInstanceReady && !hasFailedToLoad) {
         return
       }
 
       const shouldUseRdiUi =
         isConnectedInstanceReady &&
-        isDevRdiUiEnabled &&
-        isVersionHigher(
-          connectedInstance.version,
-          riConfig.features.rdiUi.minSupportedVersion,
+        shouldUseRdiUiPipeline(
+          connectedInstance.version ?? '',
+          isDevRdiUiEnabled,
         )
 
       history.push(
@@ -106,7 +116,12 @@ const RdiInstancePage = ({ routes = [] }: Props) => {
           : Pages.rdiPipelineManagement(rdiInstanceId),
       )
     }
-  }, [connectedInstance.id, connectedInstance.error])
+  }, [
+    contextRdiInstanceId,
+    connectedInstance.id,
+    connectedInstance.error,
+    connectedInstance.loading,
+  ])
 
   return (
     <Col className={styles.page} gap="none" responsive={false}>

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
@@ -9,6 +9,7 @@ import {
 } from 'uiSrc/slices/app/context'
 import { IRoute, PageNames, Pages } from 'uiSrc/constants'
 import {
+  connectedInstanceSelector,
   fetchConnectedInstanceAction,
   fetchInstancesAction as fetchRdiInstancesAction,
   instancesSelector as rdiInstancesSelector,
@@ -18,15 +19,19 @@ import {
   instancesSelector as dbInstancesSelector,
   resetConnectedInstance as resetConnectedDatabaseInstance,
 } from 'uiSrc/slices/instances/instances'
+import { isDevRdiUiEnabledSelector } from 'uiSrc/slices/app/features'
+import { getConfig } from 'uiSrc/config'
+import { isVersionHigher, Nullable } from 'uiSrc/utils'
 
 import { RdiInstancePageTemplate } from 'uiSrc/templates'
 import { AppNavigation, RdiInstanceHeader } from 'uiSrc/components'
 import { Col, FlexItem } from 'uiSrc/components/base/layout/flex'
+import { useNavigation } from 'uiSrc/components/navigation-menu/hooks/useNavigation'
 import InstancePageRouter from './InstancePageRouter'
 import { RdiPipelineHeader } from './components'
 import styles from './styles.module.scss'
-import { Nullable } from 'uiSrc/utils'
-import { useNavigation } from 'uiSrc/components/navigation-menu/hooks/useNavigation'
+
+const riConfig = getConfig()
 
 export interface Props {
   routes: IRoute[]
@@ -42,6 +47,8 @@ const RdiInstancePage = ({ routes = [] }: Props) => {
   const { lastPage, contextRdiInstanceId } = useAppSelector(appContextSelector)
   const { data: rdiInstances } = useAppSelector(rdiInstancesSelector)
   const { data: dbInstances } = useAppSelector(dbInstancesSelector)
+  const connectedInstance = useAppSelector(connectedInstanceSelector)
+  const isDevRdiUiEnabled = useAppSelector(isDevRdiUiEnabledSelector)
 
   const [actions, setActions] = useState<Nullable<React.ReactNode>>(null)
 
@@ -76,9 +83,30 @@ const RdiInstancePage = ({ routes = [] }: Props) => {
         history.push(Pages.rdiStatistics(rdiInstanceId))
         return
       }
-      history.push(Pages.rdiPipelineManagement(rdiInstanceId))
+
+      // The connected instance (incl. version) loads asynchronously above.
+      // `id` only matches `rdiInstanceId` once that fetch actually succeeds,
+      // so wait for it rather than deciding v1 vs v2 off stale/empty data.
+      const isConnectedInstanceReady = connectedInstance.id === rdiInstanceId
+      if (!isConnectedInstanceReady && !connectedInstance.error) {
+        return
+      }
+
+      const shouldUseRdiUi =
+        isConnectedInstanceReady &&
+        isDevRdiUiEnabled &&
+        isVersionHigher(
+          connectedInstance.version,
+          riConfig.features.rdiUi.minSupportedVersion,
+        )
+
+      history.push(
+        shouldUseRdiUi
+          ? Pages.rdiPipelineManagementV2(rdiInstanceId)
+          : Pages.rdiPipelineManagement(rdiInstanceId),
+      )
     }
-  }, [])
+  }, [connectedInstance.id, connectedInstance.error])
 
   return (
     <Col className={styles.page} gap="none" responsive={false}>

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
@@ -39,7 +39,8 @@ export interface Props {
 const RdiInstancePage = ({ routes = [] }: Props) => {
   const dispatch = useAppDispatch()
   const history = useHistory()
-  const { pathname } = useLocation()
+  const location = useLocation<{ skipLastPageRestore?: boolean }>()
+  const { pathname } = location
   const { privateRdiRoutes } = useNavigation()
 
   const { rdiInstanceId } = useParams<{ rdiInstanceId: string }>()
@@ -77,6 +78,7 @@ const RdiInstancePage = ({ routes = [] }: Props) => {
     // redirect only if there is no exact path
     if (pathname === Pages.rdiPipeline(rdiInstanceId)) {
       if (
+        !location.state?.skipLastPageRestore &&
         lastPage === PageNames.rdiStatistics &&
         contextRdiInstanceId === rdiInstanceId
       ) {
@@ -121,6 +123,8 @@ const RdiInstancePage = ({ routes = [] }: Props) => {
       )
     }
   }, [
+    pathname,
+    location.state,
     contextRdiInstanceId,
     connectedInstance.id,
     connectedInstance.error,

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
@@ -6,6 +6,7 @@ import {
   resetDatabaseContext,
   resetRdiContext,
   setAppContextConnectedRdiInstanceId,
+  setLastPageContext,
 } from 'uiSrc/slices/app/context'
 import { IRoute, PageNames, Pages } from 'uiSrc/constants'
 import {
@@ -62,6 +63,7 @@ const RdiInstancePage = ({ routes = [] }: Props) => {
   useEffect(() => {
     if (!contextRdiInstanceId || contextRdiInstanceId !== rdiInstanceId) {
       dispatch(resetRdiContext())
+      dispatch(setLastPageContext(''))
       dispatch(fetchConnectedInstanceAction(rdiInstanceId))
     }
     dispatch(setAppContextConnectedRdiInstanceId(rdiInstanceId))

--- a/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
+++ b/redisinsight/ui/src/pages/rdi/instance/InstancePage.tsx
@@ -80,7 +80,9 @@ const RdiInstancePage = ({ routes = [] }: Props) => {
         lastPage === PageNames.rdiStatistics &&
         contextRdiInstanceId === rdiInstanceId
       ) {
-        history.push(Pages.rdiStatistics(rdiInstanceId))
+        // replace, not push - the bare URL isn't a real page, so it
+        // shouldn't become a dead history entry that Back can land on
+        history.replace(Pages.rdiStatistics(rdiInstanceId))
         return
       }
 
@@ -112,7 +114,7 @@ const RdiInstancePage = ({ routes = [] }: Props) => {
           isDevRdiUiEnabled,
         )
 
-      history.push(
+      history.replace(
         shouldUseRdiUi
           ? Pages.rdiPipelineManagementV2(rdiInstanceId)
           : Pages.rdiPipelineManagement(rdiInstanceId),

--- a/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.spec.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { BrowserRouter } from 'react-router-dom'
+
+import { render, screen, cleanup, mockedStore } from 'uiSrc/utils/test-utils'
+import PipelineManagementV2Page from './PipelineManagementV2Page'
+
+let store: typeof mockedStore
+beforeEach(() => {
+  cleanup()
+  store = mockedStore
+})
+
+const renderPage = () =>
+  render(
+    <BrowserRouter>
+      <PipelineManagementV2Page />
+    </BrowserRouter>,
+    { store },
+  )
+
+describe('PipelineManagementV2Page', () => {
+  it('should render the placeholder', () => {
+    renderPage()
+
+    expect(
+      screen.getByTestId('pipeline-management-v2-page'),
+    ).toBeInTheDocument()
+  })
+})

--- a/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.spec.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 
 import { render, screen, cleanup, mockedStore } from 'uiSrc/utils/test-utils'
+import { PageNames } from 'uiSrc/constants'
+import { setLastPageContext } from 'uiSrc/slices/app/context'
 import PipelineManagementV2Page from './PipelineManagementV2Page'
 
 let store: typeof mockedStore
@@ -25,5 +27,15 @@ describe('PipelineManagementV2Page', () => {
     expect(
       screen.getByTestId('pipeline-management-v2-page'),
     ).toBeInTheDocument()
+  })
+
+  it('should record itself as the last visited rdi section on unmount', () => {
+    const { unmount } = renderPage()
+
+    unmount()
+
+    expect(store.getActions()).toContainEqual(
+      setLastPageContext(PageNames.rdiPipelineManagement),
+    )
   })
 })

--- a/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.styles.ts
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.styles.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+import { FlexItem } from 'uiSrc/components/base/layout/flex'
+import { Theme } from 'uiSrc/components/base/theme/types'
+
+export const PlaceholderContainer = styled(FlexItem)`
+  padding: ${({ theme }: { theme: Theme }) => theme.core.space.space300};
+`

--- a/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+import { connectedInstanceSelector } from 'uiSrc/slices/rdi/instances'
+import { useAppSelector } from 'uiSrc/slices/hooks'
+import { formatLongName, setTitle } from 'uiSrc/utils'
+import { useTranslation } from 'uiSrc/i18n'
+import { Text } from 'uiSrc/components/base/text'
+import { Row } from 'uiSrc/components/base/layout/flex'
+import * as S from './PipelineManagementV2Page.styles'
+
+const PipelineManagementV2Page = () => {
+  const { t } = useTranslation()
+  const { name: connectedRdiInstanceName } = useAppSelector(
+    connectedInstanceSelector,
+  )
+
+  const rdiInstanceName = formatLongName(connectedRdiInstanceName, 33, 0, '...')
+  setTitle(t('rdi.pipeline.pageTitle', { name: rdiInstanceName }))
+
+  return (
+    <Row
+      justify="center"
+      align="center"
+      data-testid="pipeline-management-v2-page"
+    >
+      <S.PlaceholderContainer>
+        <Text>The new pipeline management experience is coming soon.</Text>
+      </S.PlaceholderContainer>
+    </Row>
+  )
+}
+
+export default PipelineManagementV2Page

--- a/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.tsx
@@ -1,21 +1,34 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import { connectedInstanceSelector } from 'uiSrc/slices/rdi/instances'
-import { useAppSelector } from 'uiSrc/slices/hooks'
+import { useAppSelector, useAppDispatch } from 'uiSrc/slices/hooks'
 import { formatLongName, setTitle } from 'uiSrc/utils'
 import { useTranslation } from 'uiSrc/i18n'
 import { Text } from 'uiSrc/components/base/text'
 import { Row } from 'uiSrc/components/base/layout/flex'
+import { PageNames } from 'uiSrc/constants'
+import { setLastPageContext } from 'uiSrc/slices/app/context'
 import * as S from './PipelineManagementV2Page.styles'
 
 const PipelineManagementV2Page = () => {
   const { t } = useTranslation()
+  const dispatch = useAppDispatch()
   const { name: connectedRdiInstanceName } = useAppSelector(
     connectedInstanceSelector,
   )
 
   const rdiInstanceName = formatLongName(connectedRdiInstanceName, 33, 0, '...')
   setTitle(t('rdi.pipeline.pageTitle', { name: rdiInstanceName }))
+
+  useEffect(
+    () => () => {
+      // unmount - record this as the last visited RDI section, same as the
+      // legacy pipeline management page, so re-entering the instance's bare
+      // URL restores here instead of wherever lastPage was last set to
+      dispatch(setLastPageContext(PageNames.rdiPipelineManagement))
+    },
+    [],
+  )
 
   return (
     <Row

--- a/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.tsx
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management-v2/PipelineManagementV2Page.tsx
@@ -22,9 +22,6 @@ const PipelineManagementV2Page = () => {
 
   useEffect(
     () => () => {
-      // unmount - record this as the last visited RDI section, same as the
-      // legacy pipeline management page, so re-entering the instance's bare
-      // URL restores here instead of wherever lastPage was last set to
       dispatch(setLastPageContext(PageNames.rdiPipelineManagement))
     },
     [],

--- a/redisinsight/ui/src/pages/rdi/pipeline-management-v2/index.ts
+++ b/redisinsight/ui/src/pages/rdi/pipeline-management-v2/index.ts
@@ -1,0 +1,3 @@
+import PipelineManagementV2Page from './PipelineManagementV2Page'
+
+export default PipelineManagementV2Page

--- a/redisinsight/ui/src/pages/rdi/statistics/empty/Empty.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/statistics/empty/Empty.spec.tsx
@@ -25,6 +25,8 @@ describe('Empty', () => {
     const addPipelineButton = screen.getByTestId('add-pipeline-btn')
     await userEvent.click(addPipelineButton)
 
-    expect(pushMock).toHaveBeenCalledWith(Pages.rdiPipeline('123'))
+    expect(pushMock).toHaveBeenCalledWith(Pages.rdiPipeline('123'), {
+      skipLastPageRestore: true,
+    })
   })
 })

--- a/redisinsight/ui/src/pages/rdi/statistics/empty/Empty.spec.tsx
+++ b/redisinsight/ui/src/pages/rdi/statistics/empty/Empty.spec.tsx
@@ -1,8 +1,8 @@
-import { createMemoryHistory } from 'history'
 import React from 'react'
-import { Router } from 'react-router-dom'
+import reactRouterDom from 'react-router-dom'
 
-import { fireEvent, render, screen, waitFor } from 'uiSrc/utils/test-utils'
+import { render, screen, userEvent } from 'uiSrc/utils/test-utils'
+import { Pages } from 'uiSrc/constants'
 import Empty from './Empty'
 
 describe('Empty', () => {
@@ -14,19 +14,17 @@ describe('Empty', () => {
     ).toBeInTheDocument()
   })
 
-  test('navigates to pipeline config page when "Add Pipeline" button is clicked', () => {
-    const history = createMemoryHistory()
-    render(
-      <Router history={history}>
-        <Empty rdiInstanceId="123" />
-      </Router>,
-    )
+  test('navigates to the bare rdi instance url when "Add Pipeline" button is clicked, not straight to the legacy config page', async () => {
+    const pushMock = jest.fn()
+    reactRouterDom.useHistory = jest.fn().mockReturnValue({
+      push: pushMock,
+    })
+
+    render(<Empty rdiInstanceId="123" />)
 
     const addPipelineButton = screen.getByTestId('add-pipeline-btn')
-    fireEvent.click(addPipelineButton)
+    await userEvent.click(addPipelineButton)
 
-    waitFor(() => {
-      expect(history.location.pathname).toBe('/rdi/pipeline-config/123')
-    })
+    expect(pushMock).toHaveBeenCalledWith(Pages.rdiPipeline('123'))
   })
 })

--- a/redisinsight/ui/src/pages/rdi/statistics/empty/Empty.tsx
+++ b/redisinsight/ui/src/pages/rdi/statistics/empty/Empty.tsx
@@ -37,7 +37,10 @@ const Empty = ({ rdiInstanceId }: Props) => {
           data-testid="add-pipeline-btn"
           size="s"
           onClick={() => {
-            history.push(Pages.rdiPipelineConfig(rdiInstanceId))
+            // the bare instance URL is where the v1/v2 pipeline management
+            // decision is made - jumping straight to the legacy config page
+            // would skip it
+            history.push(Pages.rdiPipeline(rdiInstanceId))
           }}
         >
           {t('rdi.statistics.empty.addButton')}

--- a/redisinsight/ui/src/pages/rdi/statistics/empty/Empty.tsx
+++ b/redisinsight/ui/src/pages/rdi/statistics/empty/Empty.tsx
@@ -37,10 +37,9 @@ const Empty = ({ rdiInstanceId }: Props) => {
           data-testid="add-pipeline-btn"
           size="s"
           onClick={() => {
-            // the bare instance URL is where the v1/v2 pipeline management
-            // decision is made - jumping straight to the legacy config page
-            // would skip it
-            history.push(Pages.rdiPipeline(rdiInstanceId))
+            history.push(Pages.rdiPipeline(rdiInstanceId), {
+              skipLastPageRestore: true,
+            })
           }}
         >
           {t('rdi.statistics.empty.addButton')}

--- a/redisinsight/ui/src/utils/rdi/index.ts
+++ b/redisinsight/ui/src/utils/rdi/index.ts
@@ -1,4 +1,5 @@
 import getRdiUrl from './getUrlRdiInstance'
 import isEqualPipelineFile from './pipeline'
+import { shouldUseRdiUiPipeline } from './shouldUseRdiUiPipeline'
 
-export { getRdiUrl, isEqualPipelineFile }
+export { getRdiUrl, isEqualPipelineFile, shouldUseRdiUiPipeline }

--- a/redisinsight/ui/src/utils/rdi/shouldUseRdiUiPipeline.ts
+++ b/redisinsight/ui/src/utils/rdi/shouldUseRdiUiPipeline.ts
@@ -1,0 +1,11 @@
+import { getConfig } from 'uiSrc/config'
+import { isVersionHigherOrEquals } from 'uiSrc/utils'
+
+const riConfig = getConfig()
+
+export const shouldUseRdiUiPipeline = (
+  version: string,
+  isDevRdiUiEnabled: boolean,
+): boolean =>
+  isDevRdiUiEnabled &&
+  isVersionHigherOrEquals(version, riConfig.features.rdiUi.minSupportedVersion)


### PR DESCRIPTION
# What

Second PR in the rdi-ui integration chain (stacked on #6464).

Registers a new `pipeline-management-v2` placeholder page/route, to be wired up with the real `rdi-ui` component in a follow-up PR. The choice between the legacy pipeline management page and this new one is made once, when entering an RDI instance (`RdiInstancePage`), based on the `dev-rdiUi` flag and whether the instance version is above `1.16` — not inside the destination pages themselves, so a future manual v1/v2 switcher won't fight an automatic redirect on every render.

Key points:
- `redisinsight/ui/src/config/default.ts`: `features.rdiUi.minSupportedVersion` (env-overridable via `RI_FEATURES_RDI_UI_MIN_SUPPORTED_VERSION`, default `1.16.0`), following the same pattern as `features.envDependent`/`features.cloudAds`.
- `RdiInstancePage`: extended its existing bare-URL default-route effect to also decide legacy vs. v2, waiting for the connected instance to actually finish loading (checked via `connectedInstance.id === rdiInstanceId`, not `loading`, to avoid a stale-closure race) and falling back to legacy if the connect fetch fails.
- New `pipeline-management-v2` page: an unconditional placeholder for now — no redirect/version logic lives in the page itself.
- No new dependency added yet (no `rdi-ui` library) — that's a separate follow-up PR.

# Testing

- `npm run lint:ui` and relevant Jest suites pass (`InstancePage.spec.tsx`, `PipelineManagementV2Page.spec.tsx`, `PipelineManagementPage.spec.tsx` — the latter is untouched/reverted to its original state).
- Added tests for: redirect to v2 when flag+version qualify, waiting for the instance to load before deciding, and falling back to legacy on a failed connect.

---

No ticket yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core RDI routing and redirect timing; wrong gating could send users to the wrong pipeline UI or flash redirects, but behavior is heavily tested and defaults to legacy on failure.
> 
> **Overview**
> Adds a **`pipeline-management-v2`** route and placeholder page, plus config **`features.rdiUi.minSupportedVersion`** (default `1.16.0`, overridable via env). **`shouldUseRdiUiPipeline`** picks legacy vs v2 when the **`dev-rdiUi`** flag is on and the connected RDI instance version meets that minimum.
> 
> **`RdiInstancePage`** is the single decision point on the bare instance URL (`Pages.rdiPipeline`): it waits until the connected instance fetch finishes (and ignores stale errors from other instances), uses **`history.replace`** instead of push, supports **`skipLastPageRestore`** so CTAs don’t bounce back to statistics, clears **`lastPage`** on instance switch, and falls back to legacy pipeline management if connect fails. Instance switching and the statistics empty state now navigate to that bare URL instead of jumping straight to legacy config.
> 
> **Navigation** sends the Pipeline tab to v1 or v2 using the same helper. Tests cover redirects, loading races, and navigation entry points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b81e0d8e37449cc201f93be5a32c628d1eede2c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->