### PR TITLE
#5179 Honour unchecked Verify TLS Certificate

### DIFF
--- a/redisinsight/api/migration/1785100000000-azure-verify-server-cert.ts
+++ b/redisinsight/api/migration/1785100000000-azure-verify-server-cert.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AzureVerifyServerCert1785100000000 implements MigrationInterface {
+  name = 'AzureVerifyServerCert1785100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            UPDATE database_instance
+            SET "verifyServerCert" = 1
+            WHERE tls = 1
+              AND "verifyServerCert" IS NULL
+              AND provider IN ('AZURE_CACHE', 'AZURE_CACHE_REDIS_ENTERPRISE');
+          `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            UPDATE database_instance
+            SET "verifyServerCert" = NULL
+            WHERE tls = 1
+              AND "verifyServerCert" = 1
+              AND provider IN ('AZURE_CACHE', 'AZURE_CACHE_REDIS_ENTERPRISE');
+          `);
+  }
+}

--- a/redisinsight/api/migration/1785100000000-azure-verify-server-cert.ts
+++ b/redisinsight/api/migration/1785100000000-azure-verify-server-cert.ts
@@ -9,17 +9,12 @@ export class AzureVerifyServerCert1785100000000 implements MigrationInterface {
             SET "verifyServerCert" = 1
             WHERE tls = 1
               AND "verifyServerCert" IS NULL
-              AND provider IN ('AZURE_CACHE', 'AZURE_CACHE_REDIS_ENTERPRISE');
+              AND provider IN ('AZURE_CACHE', 'AZURE_CACHE_REDIS_ENTERPRISE')
+              AND "providerDetails" IS NOT NULL;
           `);
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`
-            UPDATE database_instance
-            SET "verifyServerCert" = NULL
-            WHERE tls = 1
-              AND "verifyServerCert" = 1
-              AND provider IN ('AZURE_CACHE', 'AZURE_CACHE_REDIS_ENTERPRISE');
-          `);
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // Not reversible: cannot distinguish this backfill from a user-checked box.
   }
 }

--- a/redisinsight/api/migration/index.ts
+++ b/redisinsight/api/migration/index.ts
@@ -60,6 +60,7 @@ import { DatabaseIsProduction1778758000000 } from './1778758000000-database-isPr
 import { Environment1779000000000 } from './1779000000000-database-environment';
 import { DropDatabaseIsProduction1779000000001 } from './1779000000001-drop-database-isProduction';
 import { DatabaseConnectionFamily1784000000000 } from './1784000000000-database-connection-family';
+import { AzureVerifyServerCert1785100000000 } from './1785100000000-azure-verify-server-cert';
 
 export default [
   initialMigration1614164490968,
@@ -124,4 +125,5 @@ export default [
   Environment1779000000000,
   DropDatabaseIsProduction1779000000001,
   DatabaseConnectionFamily1784000000000,
+  AzureVerifyServerCert1785100000000,
 ];

--- a/redisinsight/api/src/__mocks__/database-discovery.ts
+++ b/redisinsight/api/src/__mocks__/database-discovery.ts
@@ -168,6 +168,7 @@ export const cleanupTestEnvs = () => {
   delete process.env.RI_REDIS_ALIAS;
   delete process.env.RI_REDIS_USENAME;
   delete process.env.RI_REDIS_PASSWORD;
+  delete process.env.RI_REDIS_TLS;
 
   delete process.env.RI_REDIS_HOST_1;
   delete process.env.RI_REDIS_PORT_1;

--- a/redisinsight/api/src/modules/azure/autodiscovery/azure-autodiscovery.service.spec.ts
+++ b/redisinsight/api/src/modules/azure/autodiscovery/azure-autodiscovery.service.spec.ts
@@ -493,6 +493,7 @@ describe('AzureAutodiscoveryService', () => {
           port: database.sslPort,
           name: database.name,
           tls: true,
+          verifyServerCert: true,
           provider: HostingProvider.AZURE_CACHE,
           providerDetails: expect.objectContaining({
             provider: CloudProvider.Azure,

--- a/redisinsight/api/src/modules/azure/autodiscovery/azure-autodiscovery.service.ts
+++ b/redisinsight/api/src/modules/azure/autodiscovery/azure-autodiscovery.service.ts
@@ -627,6 +627,8 @@ export class AzureAutodiscoveryService {
             username: connectionDetails.username,
             password: connectionDetails.password,
             tls: connectionDetails.tls,
+            // Azure Cache presents a publicly trusted cert; absent now means "do not verify".
+            verifyServerCert: true,
             provider,
             providerDetails,
           });

--- a/redisinsight/api/src/modules/database-discovery/utils/pre-setup.discovery.util.spec.ts
+++ b/redisinsight/api/src/modules/database-discovery/utils/pre-setup.discovery.util.spec.ts
@@ -108,7 +108,7 @@ describe('preSetupDiscoveryUtil', () => {
           host: 'host',
           tls: true,
           verifyServerCert: null,
-        } as Database),
+        } as unknown as Database),
       ).toMatchObject({
         tls: true,
         verifyServerCert: null,

--- a/redisinsight/api/src/modules/database-discovery/utils/pre-setup.discovery.util.spec.ts
+++ b/redisinsight/api/src/modules/database-discovery/utils/pre-setup.discovery.util.spec.ts
@@ -91,6 +91,29 @@ describe('preSetupDiscoveryUtil', () => {
         name: 'host:6379',
       });
     });
+    it('should verify the server cert when tls is set without verifyServerCert', () => {
+      expect(
+        populateDefaultValues({
+          host: 'host',
+          tls: true,
+        } as Database),
+      ).toMatchObject({
+        tls: true,
+        verifyServerCert: true,
+      });
+    });
+    it('should keep an explicit null verifyServerCert on tls file rows', () => {
+      expect(
+        populateDefaultValues({
+          host: 'host',
+          tls: true,
+          verifyServerCert: null,
+        } as Database),
+      ).toMatchObject({
+        tls: true,
+        verifyServerCert: null,
+      });
+    });
     it('should prepare object with default values for not specified fields', () => {
       expect(populateDefaultValues(mockDatabaseToImportFromEnvsInput)).toEqual(
         mockDatabaseToImportFromEnvsPrepared,

--- a/redisinsight/api/src/modules/database-discovery/utils/pre-setup.discovery.util.spec.ts
+++ b/redisinsight/api/src/modules/database-discovery/utils/pre-setup.discovery.util.spec.ts
@@ -181,6 +181,18 @@ describe('preSetupDiscoveryUtil', () => {
         name: `${mockDatabaseToImportFromEnvsPrepared.host}:6379`, // auto generated name
       });
     });
+    it('should verify the server cert when RI_REDIS_TLS is true without client certs', async () => {
+      process.env.RI_REDIS_HOST = mockDatabaseToImportFromEnvsInput.host;
+      process.env.RI_REDIS_TLS = 'true';
+
+      await expect(prepareDatabaseFromEnvs('RI_REDIS_HOST')).resolves.toEqual({
+        ...mockDatabaseToImportFromEnvsPrepared,
+        port: 6379,
+        name: `${mockDatabaseToImportFromEnvsPrepared.host}:6379`,
+        tls: true,
+        verifyServerCert: true,
+      });
+    });
     it('should discover database with certs in base64 format', async () => {
       process.env.RI_REDIS_HOST_1 =
         mockDatabaseToImportWithCertsFromEnvsInput.host;

--- a/redisinsight/api/src/modules/database-discovery/utils/pre-setup.discovery.util.ts
+++ b/redisinsight/api/src/modules/database-discovery/utils/pre-setup.discovery.util.ts
@@ -42,10 +42,11 @@ export const populateDefaultValues = (
     db = null,
     provider = null,
     modules = [],
-    verifyServerCert = null,
     ssh = null,
     sshOptions = null,
     tls = false,
+    // Absent now means "do not verify". Keep explicit null/false as-is.
+    verifyServerCert = tls ? true : null,
     tlsServername = null,
     caCert = null,
     clientCert = null,

--- a/redisinsight/api/src/modules/database-discovery/utils/pre-setup.discovery.util.ts
+++ b/redisinsight/api/src/modules/database-discovery/utils/pre-setup.discovery.util.ts
@@ -153,6 +153,10 @@ export const prepareDatabaseFromEnvs = async (
         certificate: tlsCertificate,
         key: tlsKey,
       } as ClientCertificate;
+    }
+
+    // populateDefaultValues leaves verifyServerCert null, which now means "do not verify".
+    if (databaseToAdd.tls) {
       databaseToAdd.verifyServerCert = true;
     }
 

--- a/redisinsight/api/src/modules/database-import/database-import.service.spec.ts
+++ b/redisinsight/api/src/modules/database-import/database-import.service.spec.ts
@@ -332,6 +332,37 @@ describe('DatabaseImportService', () => {
         false,
       );
     });
+    it('should keep an exported null verifyServerCert as unchecked', async () => {
+      await service['createDatabase'](
+        mockSessionMetadata,
+        {
+          ...mockDatabase,
+          tls: true,
+          verifyServerCert: null,
+        },
+        0,
+      );
+
+      expect(databaseRepository.create).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        {
+          ...pick(mockDatabase, [
+            'host',
+            'port',
+            'name',
+            'connectionType',
+            'compressor',
+            'modules',
+            'environment',
+            'connectionFamily',
+          ]),
+          tls: true,
+          verifyServerCert: false,
+          new: true,
+        },
+        false,
+      );
+    });
     it('should keep an explicit false verifyServerCert on tls import', async () => {
       await service['createDatabase'](
         mockSessionMetadata,

--- a/redisinsight/api/src/modules/database-import/database-import.service.spec.ts
+++ b/redisinsight/api/src/modules/database-import/database-import.service.spec.ts
@@ -302,6 +302,98 @@ describe('DatabaseImportService', () => {
         false,
       );
     });
+    it('should default verifyServerCert to true when importing tls without the flag', async () => {
+      await service['createDatabase'](
+        mockSessionMetadata,
+        {
+          ...mockDatabase,
+          tls: true,
+        },
+        0,
+      );
+
+      expect(databaseRepository.create).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        {
+          ...pick(mockDatabase, [
+            'host',
+            'port',
+            'name',
+            'connectionType',
+            'compressor',
+            'modules',
+            'environment',
+            'connectionFamily',
+          ]),
+          tls: true,
+          verifyServerCert: true,
+          new: true,
+        },
+        false,
+      );
+    });
+    it('should keep an explicit false verifyServerCert on tls import', async () => {
+      await service['createDatabase'](
+        mockSessionMetadata,
+        {
+          ...mockDatabase,
+          tls: true,
+          verifyServerCert: false,
+        },
+        0,
+      );
+
+      expect(databaseRepository.create).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        {
+          ...pick(mockDatabase, [
+            'host',
+            'port',
+            'name',
+            'connectionType',
+            'compressor',
+            'modules',
+            'environment',
+            'connectionFamily',
+          ]),
+          tls: true,
+          verifyServerCert: false,
+          new: true,
+        },
+        false,
+      );
+    });
+    it('should map sslOptions.rejectUnauthorized onto verifyServerCert', async () => {
+      await service['createDatabase'](
+        mockSessionMetadata,
+        {
+          ...mockDatabase,
+          ssl: true,
+          sslOptions: { rejectUnauthorized: false },
+        },
+        0,
+      );
+
+      expect(databaseRepository.create).toHaveBeenCalledWith(
+        mockSessionMetadata,
+        {
+          ...pick(mockDatabase, [
+            'host',
+            'port',
+            'name',
+            'connectionType',
+            'compressor',
+            'modules',
+            'environment',
+            'connectionFamily',
+          ]),
+          tls: true,
+          verifyServerCert: false,
+          new: true,
+        },
+        false,
+      );
+    });
     it('should create cluster database', async () => {
       await service['createDatabase'](
         mockSessionMetadata,

--- a/redisinsight/api/src/modules/database-import/database-import.service.spec.ts
+++ b/redisinsight/api/src/modules/database-import/database-import.service.spec.ts
@@ -17,6 +17,7 @@ import {
   ConnectionType,
   Compressor,
 } from 'src/modules/database/entities/database.entity';
+import { DatabaseImportStatus } from 'src/modules/database-import/dto/database-import.response';
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { ValidationError } from 'class-validator';
 import {
@@ -393,6 +394,20 @@ describe('DatabaseImportService', () => {
         },
         false,
       );
+    });
+    it('should reject a non-boolean verifyServerCert on tls import', async () => {
+      const result = await service['createDatabase'](
+        mockSessionMetadata,
+        {
+          ...mockDatabase,
+          ssl: true,
+          sslOptions: { rejectUnauthorized: 'true' },
+        },
+        0,
+      );
+
+      expect(databaseRepository.create).not.toHaveBeenCalled();
+      expect(result.status).toBe(DatabaseImportStatus.Fail);
     });
     it('should map sslOptions.rejectUnauthorized onto verifyServerCert', async () => {
       await service['createDatabase'](

--- a/redisinsight/api/src/modules/database-import/database-import.service.ts
+++ b/redisinsight/api/src/modules/database-import/database-import.service.ts
@@ -299,9 +299,13 @@ export class DatabaseImportService {
         }
       }
 
-      // Import files rarely carry verifyServerCert; absent now means "do not verify".
+      // Absent verifyServerCert now means "do not verify". Default only when
+      // the field is missing; exported null/false must stay unchecked.
       if (data?.tls) {
-        data.verifyServerCert = data.verifyServerCert ?? true;
+        data.verifyServerCert =
+          data.verifyServerCert === undefined
+            ? true
+            : data.verifyServerCert === true;
       }
 
       if (data?.compressor && !(data.compressor in Compressor)) {

--- a/redisinsight/api/src/modules/database-import/database-import.service.ts
+++ b/redisinsight/api/src/modules/database-import/database-import.service.ts
@@ -57,6 +57,7 @@ export class DatabaseImportService {
     ['type', ['type']],
     ['connectionType', ['connectionType']],
     ['tls', ['tls', 'ssl']],
+    ['verifyServerCert', ['verifyServerCert', 'sslOptions.rejectUnauthorized']],
     ['tlsServername', ['tlsServername']],
     ['tlsCaName', ['caCert.name']],
     [
@@ -296,6 +297,11 @@ export class DatabaseImportService {
           status = DatabaseImportStatus.Partial;
           errors.push(e);
         }
+      }
+
+      // Import files rarely carry verifyServerCert; absent now means "do not verify".
+      if (data?.tls) {
+        data.verifyServerCert = data.verifyServerCert ?? true;
       }
 
       if (data?.compressor && !(data.compressor in Compressor)) {

--- a/redisinsight/api/src/modules/database-import/database-import.service.ts
+++ b/redisinsight/api/src/modules/database-import/database-import.service.ts
@@ -299,13 +299,15 @@ export class DatabaseImportService {
         }
       }
 
-      // Absent verifyServerCert now means "do not verify". Default only when
-      // the field is missing; exported null/false must stay unchecked.
+      // Absent now means "do not verify". Default only when the field is
+      // missing; exported null stays unchecked. Leave other values alone so
+      // @IsBoolean can reject junk (e.g. rejectUnauthorized: "true").
       if (data?.tls) {
-        data.verifyServerCert =
-          data.verifyServerCert === undefined
-            ? true
-            : data.verifyServerCert === true;
+        if (data.verifyServerCert === undefined) {
+          data.verifyServerCert = true;
+        } else if (data.verifyServerCert === null) {
+          data.verifyServerCert = false;
+        }
       }
 
       if (data?.compressor && !(data.compressor in Compressor)) {

--- a/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.spec.ts
+++ b/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.spec.ts
@@ -22,6 +22,7 @@ import {
 import { InternalServerErrorException } from '@nestjs/common';
 import ERROR_MESSAGES from 'src/constants/error-messages';
 import { ReplyError } from 'src/models';
+import { Database } from 'src/modules/database/models/database';
 
 const REDIS_CLIENTS_CONFIG = apiConfig.get(
   'redis_clients',
@@ -399,7 +400,7 @@ describe('IoredisRedisConnectionStrategy', () => {
         const config = await service['getTLSConfig']({
           ...mockDatabaseWithTlsAuth,
           verifyServerCert,
-        });
+        } as Database);
 
         expect(config.rejectUnauthorized).toEqual(false);
       },

--- a/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.spec.ts
+++ b/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.spec.ts
@@ -382,4 +382,27 @@ describe('IoredisRedisConnectionStrategy', () => {
         .catch(checkError(done));
     });
   });
+
+  describe('getTLSConfig', () => {
+    it('should reject unauthorized when verifyServerCert is true', async () => {
+      const config = await service['getTLSConfig']({
+        ...mockDatabaseWithTlsAuth,
+        verifyServerCert: true,
+      });
+
+      expect(config.rejectUnauthorized).toEqual(true);
+    });
+
+    it.each([false, undefined, null])(
+      'should not reject unauthorized when verifyServerCert is %s',
+      async (verifyServerCert) => {
+        const config = await service['getTLSConfig']({
+          ...mockDatabaseWithTlsAuth,
+          verifyServerCert,
+        });
+
+        expect(config.rejectUnauthorized).toEqual(false);
+      },
+    );
+  });
 });

--- a/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.ts
+++ b/redisinsight/api/src/modules/redis/connection/ioredis.redis.connection.strategy.ts
@@ -156,7 +156,10 @@ export class IoredisRedisConnectionStrategy extends RedisConnectionStrategy {
   private async getTLSConfig(database: Database): Promise<ConnectionOptions> {
     let config: ConnectionOptions;
     config = {
-      rejectUnauthorized: database.verifyServerCert,
+      // Node treats a missing rejectUnauthorized as true. verifyServerCert is
+      // optional and defaults to false (unchecked "Verify TLS Certificate");
+      // older rows and test-connection payloads leave it null/undefined.
+      rejectUnauthorized: database.verifyServerCert === true,
       checkServerIdentity: this.dummyFn,
       servername: database.tlsServername || undefined,
     };

--- a/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.spec.ts
+++ b/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.spec.ts
@@ -10,6 +10,7 @@ import { SshTunnelProvider } from 'src/modules/ssh/ssh-tunnel.provider';
 import { NodeRedisConnectionStrategy } from 'src/modules/redis/connection/node.redis.connection.strategy';
 import { StandaloneNodeRedisClient } from 'src/modules/redis/client/node-redis/standalone.node-redis.client';
 import { RedisConnectionFamily } from 'src/modules/database/entities/database.entity';
+import { Database } from 'src/modules/database/models/database';
 
 jest.mock('redis', () => ({
   ...jest.requireActual('redis'),
@@ -117,7 +118,7 @@ describe('NodeRedisConnectionStrategy', () => {
         const config = await service['getTLSConfig']({
           ...mockDatabaseWithTlsAuth,
           verifyServerCert,
-        });
+        } as Database);
 
         expect(config.rejectUnauthorized).toEqual(false);
       },

--- a/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.spec.ts
+++ b/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.spec.ts
@@ -3,6 +3,7 @@ import * as redis from 'redis';
 import {
   mockClientMetadata,
   mockDatabase,
+  mockDatabaseWithTlsAuth,
   mockSshTunnelProvider,
 } from 'src/__mocks__';
 import { SshTunnelProvider } from 'src/modules/ssh/ssh-tunnel.provider';
@@ -98,5 +99,28 @@ describe('NodeRedisConnectionStrategy', () => {
         }),
       );
     });
+  });
+
+  describe('getTLSConfig', () => {
+    it('should reject unauthorized when verifyServerCert is true', async () => {
+      const config = await service['getTLSConfig']({
+        ...mockDatabaseWithTlsAuth,
+        verifyServerCert: true,
+      });
+
+      expect(config.rejectUnauthorized).toEqual(true);
+    });
+
+    it.each([false, undefined, null])(
+      'should not reject unauthorized when verifyServerCert is %s',
+      async (verifyServerCert) => {
+        const config = await service['getTLSConfig']({
+          ...mockDatabaseWithTlsAuth,
+          verifyServerCert,
+        });
+
+        expect(config.rejectUnauthorized).toEqual(false);
+      },
+    );
   });
 });

--- a/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.ts
+++ b/redisinsight/api/src/modules/redis/connection/node.redis.connection.strategy.ts
@@ -156,7 +156,10 @@ export class NodeRedisConnectionStrategy extends RedisConnectionStrategy {
   private async getTLSConfig(database: Database): Promise<ConnectionOptions> {
     let config: ConnectionOptions;
     config = {
-      rejectUnauthorized: database.verifyServerCert,
+      // Node treats a missing rejectUnauthorized as true. verifyServerCert is
+      // optional and defaults to false (unchecked "Verify TLS Certificate");
+      // older rows and test-connection payloads leave it null/undefined.
+      rejectUnauthorized: database.verifyServerCert === true,
       checkServerIdentity: this.dummyFn.bind(this),
       servername: database.tlsServername || undefined,
     };


### PR DESCRIPTION
# What

Unchecked **Verify TLS Certificate** still verified the server cert. `getTLSConfig` passed `verifyServerCert` through to Node as `rejectUnauthorized`, and Node treats `null`/`undefined` as **verify on**. Both connection strategies now set `rejectUnauthorized` only when `verifyServerCert === true`.

That flip also meant first-party `tls: true` creates that never set the flag would stop verifying. This PR now:

- sets `verifyServerCert: true` on Azure autodiscovery (public CA)
- maps the flag on import; missing → verify on, exported `null`/`false` → off; non-booleans fail `@IsBoolean`
- defaults missing TLS verify on env and file pre-setup the same way
- backfills existing Azure **autodiscovery** rows (`providerDetails IS NOT NULL`) that still have `tls + NULL`; hand-added Azure hostnames are left alone

`null` on import/export stays verify-off. That matches the checkbox fix; a blanket `?? true` would re-check boxes the user unchecked.

# Testing

- Unit tests on both strategies: `true` → reject; `false` / `undefined` / `null` → do not reject
- Azure / import / pre-setup specs for the producer-path defaults and the non-boolean import reject
- `npm test` on the touched API suites (Node 24.16.0)
- Manually connected RedisInsight 3.8.0 (local package) to a Redis Cluster that presents a self-signed leaf, TLS on, Verify off, no CA — connection succeeds

---

Refs #5179